### PR TITLE
[le12] Addon updates for docker and podman

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="df7d44387166d90954e290dfbe0a278649bf71d0e89933615bdc0757580b68e4"
+PKG_SHA256="abd16e3911bc7bbd00596ebe4f58baf3d577160d99eefd749a908507ddfc587b"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="ce1223035ac3ab8922717092e63a184cf67b493d"
+export PKG_GIT_COMMIT="9f9e4058019a37304dc6572ffcbb409d529b59d8"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="27.3.1"
-PKG_SHA256="d18208d9e0b6421307342cdef266193984c97c87177b9262b1113e6e9e7e020e"
+PKG_VERSION="27.5.1"
+PKG_SHA256="0d071c1773c855778d85590e01b924c1857000fd786485f4b674a3be2d3b893c"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="41ca978a0a5400cc24b274137efa9f25517fcc0b"
+export PKG_GIT_COMMIT="4c9b3b011ae4c30145a7b344c870bdda01b454e2"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.23.2"
-PKG_SHA256="fc3448a68fca887ceb0e0d4357d0ecd05d54a78e052f8667b283e745c87e7f2e"
+PKG_VERSION="1.23.6"
+PKG_SHA256="06ca9da2305302a7ca1593afadf012494debf658a11e4e41119ee1ee160f77c7"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/libseccomp/package.mk
+++ b/packages/addons/addon-depends/libseccomp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libseccomp"
-PKG_VERSION="2.5.5"
-PKG_SHA256="248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375"
+PKG_VERSION="2.6.0"
+PKG_SHA256="83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="https://github.com/seccomp/libseccomp"
 PKG_URL="https://github.com/seccomp/libseccomp/releases/download/v${PKG_VERSION}/libseccomp-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/gpgme/package.mk
+++ b/packages/addons/addon-depends/podman/gpgme/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpgme"
-PKG_VERSION="1.23.2"
-PKG_SHA256="9499e8b1f33cccb6815527a1bc16049d35a6198a6c5fae0185f2bd561bce5224"
+PKG_VERSION="1.24.2"
+PKG_SHA256="e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581"
 PKG_LICENSE="gpgme"
 PKG_SITE="https://gnupg.org/software/gpgme/index.html"
 PKG_URL="https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/podman/netavark/package.mk
+++ b/packages/addons/addon-depends/podman/netavark/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netavark"
-PKG_VERSION="1.12.2"
-PKG_SHA256="d1e5a7e65b825724fd084b0162084d9b61db8cda1dad26de8a07be1bd6891dbc"
+PKG_VERSION="1.14.0"
+PKG_SHA256="d2ded5412e5037e84f79a28c774378c864aa6f6e43023dd88891c70cfaf963ef"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/netavark"
 PKG_URL="https://github.com/containers/netavark/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.2.2"
-PKG_SHA256="571658f175d61724269c1a20626c1e39424af59b7bcf7ff94135d03b790bbecb"
+PKG_VERSION="5.4.0"
+PKG_SHA256="e5efb825558624d0539dac94847c39aafec68e6d4dd712435ff4ec1b17044b69"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="fcee48106a12dd531702d729d17f40f6e152027f"
+export PKG_GIT_COMMIT="f9f7d48b24b1ca4403f189caaeab1cb8ff4a9aa2"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/addon-depends/podman/podman-bin/patches/podman-0002-path-changes.patch
+++ b/packages/addons/addon-depends/podman/podman-bin/patches/podman-0002-path-changes.patch
@@ -1,6 +1,6 @@
 diff -Nur a/pkg/api/handlers/libpod/swagger_spec.go b/pkg/api/handlers/libpod/swagger_spec.go
---- a/pkg/api/handlers/libpod/swagger_spec.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/api/handlers/libpod/swagger_spec.go	2024-09-14 06:41:57.836922873 +0000
+--- a/pkg/api/handlers/libpod/swagger_spec.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/api/handlers/libpod/swagger_spec.go	2024-11-22 09:32:20.604644984 +0000
 @@ -13,7 +13,7 @@
  )
  
@@ -11,20 +11,20 @@ diff -Nur a/pkg/api/handlers/libpod/swagger_spec.go b/pkg/api/handlers/libpod/sw
  func ServeSwagger(w http.ResponseWriter, r *http.Request) {
  	path := DefaultPodmanSwaggerSpec
 diff -Nur a/pkg/machine/define/config.go b/pkg/machine/define/config.go
---- a/pkg/machine/define/config.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/machine/define/config.go	2024-09-14 06:41:57.863589758 +0000
-@@ -2,7 +2,7 @@
- 
+--- a/pkg/machine/define/config.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/machine/define/config.go	2024-11-22 09:32:20.631311705 +0000
+@@ -3,7 +3,7 @@
  import "os"
  
--const UserCertsTargetPath = "/etc/containers/certs.d"
-+const UserCertsTargetPath = "/storage/.kodi/addons/service.system.podman/etc/containers/certs.d"
- const DefaultIdentityName = "machine"
- 
- // MountTag is an identifier to mount a VirtioFS file system tag on a mount point in the VM.
+ const (
+-	UserCertsTargetPath = "/etc/containers/certs.d"
++	UserCertsTargetPath = "/storage/.kodi/addons/service.system.podman/etc/containers/certs.d"
+ 	DefaultIdentityName = "machine"
+ 	DefaultMachineName  = "podman-machine-default"
+ )
 diff -Nur a/pkg/machine/ignition/ignition.go b/pkg/machine/ignition/ignition.go
---- a/pkg/machine/ignition/ignition.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/machine/ignition/ignition.go	2024-09-14 06:41:57.870256479 +0000
+--- a/pkg/machine/ignition/ignition.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/machine/ignition/ignition.go	2024-11-22 09:32:20.637978385 +0000
 @@ -381,7 +381,7 @@
  	files = append(files, File{
  		Node: Node{
@@ -35,8 +35,8 @@ diff -Nur a/pkg/machine/ignition/ignition.go b/pkg/machine/ignition/ignition.go
  		},
  		FileEmbedded1: FileEmbedded1{
 diff -Nur a/pkg/machine/wsl/machine.go b/pkg/machine/wsl/machine.go
---- a/pkg/machine/wsl/machine.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/machine/wsl/machine.go	2024-09-14 06:41:57.870256479 +0000
+--- a/pkg/machine/wsl/machine.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/machine/wsl/machine.go	2024-11-22 09:32:20.637978385 +0000
 @@ -180,7 +180,7 @@
  		return fmt.Errorf("could not configure systemd settings for guest OS: %w", err)
  	}
@@ -65,8 +65,8 @@ diff -Nur a/pkg/machine/wsl/machine.go b/pkg/machine/wsl/machine.go
  		return fmt.Errorf("could not configure registries on guest OS: %w", err)
  	}
 diff -Nur a/pkg/systemd/generate/containers_test.go b/pkg/systemd/generate/containers_test.go
---- a/pkg/systemd/generate/containers_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/systemd/generate/containers_test.go	2024-09-14 06:41:57.843589594 +0000
+--- a/pkg/systemd/generate/containers_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/systemd/generate/containers_test.go	2024-11-22 09:32:20.611311664 +0000
 @@ -1045,7 +1045,7 @@
  				StopTimeout:       22,
  				PodmanVersion:     "CI",
@@ -383,8 +383,8 @@ diff -Nur a/pkg/systemd/generate/containers_test.go b/pkg/systemd/generate/conta
  				RestartSec:        15,
  			},
 diff -Nur a/pkg/systemd/generate/pods_test.go b/pkg/systemd/generate/pods_test.go
---- a/pkg/systemd/generate/pods_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/systemd/generate/pods_test.go	2024-09-14 06:41:57.843589594 +0000
+--- a/pkg/systemd/generate/pods_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/systemd/generate/pods_test.go	2024-11-22 09:32:20.611311664 +0000
 @@ -485,7 +485,7 @@
  				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
  				StopTimeout:      42,
@@ -521,11 +521,11 @@ diff -Nur a/pkg/systemd/generate/pods_test.go b/pkg/systemd/generate/pods_test.g
  				RequiredServices: []string{"container-1", "container-2"},
  				CreateCommand:    []string{"podman", "pod", "create", "--name", "foo", "bar=arg with space"},
 diff -Nur a/pkg/systemd/quadlet/quadlet.go b/pkg/systemd/quadlet/quadlet.go
---- a/pkg/systemd/quadlet/quadlet.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/systemd/quadlet/quadlet.go	2024-09-14 06:41:57.843589594 +0000
-@@ -21,9 +21,9 @@
- 	// but it is causing bloat
- 	autoUpdateLabel = "io.containers.autoupdate"
+--- a/pkg/systemd/quadlet/quadlet.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/systemd/quadlet/quadlet.go	2024-11-22 09:32:20.611311664 +0000
+@@ -23,9 +23,9 @@
+ 	// Directory for temporary Quadlet files (sysadmin owned)
+ 	UnitDirTemp = "/run/containers/systemd"
  	// Directory for global Quadlet files (sysadmin owned)
 -	UnitDirAdmin = "/etc/containers/systemd"
 +	UnitDirAdmin = "/storage/.kodi/addons/service.system.podman/etc/containers/systemd"
@@ -536,8 +536,8 @@ diff -Nur a/pkg/systemd/quadlet/quadlet.go b/pkg/systemd/quadlet/quadlet.go
  	// Names of commonly used systemd/quadlet group names
  	ContainerGroup  = "Container"
 diff -Nur a/pkg/trust/registries.go b/pkg/trust/registries.go
---- a/pkg/trust/registries.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/pkg/trust/registries.go	2024-09-14 06:41:57.860256397 +0000
+--- a/pkg/trust/registries.go	2024-11-21 13:40:20.000000000 +0000
++++ b/pkg/trust/registries.go	2024-11-22 09:32:20.627978364 +0000
 @@ -29,7 +29,7 @@
  }
  
@@ -548,9 +548,9 @@ diff -Nur a/pkg/trust/registries.go b/pkg/trust/registries.go
  // userRegistriesDir is the path to the per user registries.d.
  var userRegistriesDir = filepath.FromSlash(".config/containers/registries.d")
 diff -Nur a/test/e2e/common_test.go b/test/e2e/common_test.go
---- a/test/e2e/common_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/common_test.go	2024-09-14 06:41:58.060258033 +0000
-@@ -284,7 +284,7 @@
+--- a/test/e2e/common_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/common_test.go	2024-11-22 09:32:20.821312090 +0000
+@@ -314,7 +314,7 @@
  	}
  
  	networkBackend := Netavark
@@ -560,8 +560,8 @@ diff -Nur a/test/e2e/common_test.go b/test/e2e/common_test.go
  		networkConfigDir = filepath.Join(root, "etc", "networks")
  	}
 diff -Nur a/test/e2e/create_test.go b/test/e2e/create_test.go
---- a/test/e2e/create_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/create_test.go	2024-09-14 06:41:58.063591394 +0000
+--- a/test/e2e/create_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/create_test.go	2024-11-22 09:32:20.824645430 +0000
 @@ -355,7 +355,7 @@
  			Expect(session).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
  		}
@@ -572,8 +572,8 @@ diff -Nur a/test/e2e/create_test.go b/test/e2e/create_test.go
  		Expect(session).Should(ExitCleanly())
  	})
 diff -Nur a/test/e2e/import_test.go b/test/e2e/import_test.go
---- a/test/e2e/import_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/import_test.go	2024-09-14 06:41:58.053591313 +0000
+--- a/test/e2e/import_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/import_test.go	2024-11-22 09:32:20.814645410 +0000
 @@ -175,7 +175,7 @@
  		importImage.WaitWithDefaultTimeout()
  		Expect(importImage).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
@@ -584,8 +584,8 @@ diff -Nur a/test/e2e/import_test.go b/test/e2e/import_test.go
  		Expect(result).Should(ExitCleanly())
  	})
 diff -Nur a/test/e2e/load_test.go b/test/e2e/load_test.go
---- a/test/e2e/load_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/load_test.go	2024-09-14 06:41:58.053591313 +0000
+--- a/test/e2e/load_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/load_test.go	2024-11-22 09:32:20.814645410 +0000
 @@ -85,7 +85,7 @@
  		rmi.WaitWithDefaultTimeout()
  		Expect(rmi).Should(ExitCleanly())
@@ -596,9 +596,9 @@ diff -Nur a/test/e2e/load_test.go b/test/e2e/load_test.go
  		if IsRemote() {
  			Expect(result).To(ExitWithError(125, "unknown flag: --signature-policy"))
 diff -Nur a/test/e2e/push_test.go b/test/e2e/push_test.go
---- a/test/e2e/push_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/push_test.go	2024-09-14 06:41:58.056924672 +0000
-@@ -197,11 +197,11 @@
+--- a/test/e2e/push_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/push_test.go	2024-11-22 09:32:20.814645410 +0000
+@@ -198,11 +198,11 @@
  			// Ideally, this should set SystemContext.RegistriesDirPath, but Podman currently doesn’t
  			// expose that as an option. So, for now, modify /etc/directly, and skip testing sigstore if
  			// we don’t have permission to do so.
@@ -612,7 +612,7 @@ diff -Nur a/test/e2e/push_test.go b/test/e2e/push_test.go
  			} else {
  				defer func() {
  					err := os.Remove(systemRegistriesDAddition)
-@@ -267,16 +267,16 @@
+@@ -268,16 +268,16 @@
  	})
  
  	It("podman push to local registry with authorization", func() {
@@ -632,7 +632,7 @@ diff -Nur a/test/e2e/push_test.go b/test/e2e/push_test.go
  
  		cwd, _ := os.Getwd()
  		certPath := filepath.Join(cwd, "../", "certs")
-@@ -315,7 +315,7 @@
+@@ -316,7 +316,7 @@
  		Expect(push).Should(Exit(0))
  		Expect(push.ErrorToString()).To(ContainSubstring("Writing manifest to image destination"))
  
@@ -642,9 +642,9 @@ diff -Nur a/test/e2e/push_test.go b/test/e2e/push_test.go
  
  		push = podmanTest.Podman([]string{"push", "--creds=podmantest:wrongpasswd", ALPINE, "localhost:5004/credstest"})
 diff -Nur a/test/e2e/run_test.go b/test/e2e/run_test.go
---- a/test/e2e/run_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/run_test.go	2024-09-14 06:41:58.053591313 +0000
-@@ -124,7 +124,7 @@
+--- a/test/e2e/run_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/run_test.go	2024-11-22 09:32:20.811312070 +0000
+@@ -125,7 +125,7 @@
  		}
  		Expect(session).To(ExitWithError(125, "open /no/such/file: no such file or directory"))
  
@@ -654,8 +654,8 @@ diff -Nur a/test/e2e/run_test.go b/test/e2e/run_test.go
  		Expect(session).Should(Exit(0))
  		Expect(session.ErrorToString()).To(ContainSubstring("Getting image source signatures"))
 diff -Nur a/test/e2e/save_test.go b/test/e2e/save_test.go
---- a/test/e2e/save_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/save_test.go	2024-09-14 06:41:58.050257951 +0000
+--- a/test/e2e/save_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/save_test.go	2024-11-22 09:32:20.807978730 +0000
 @@ -29,7 +29,7 @@
  		SkipIfRemote("--signature-policy N/A for remote")
  		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
@@ -695,8 +695,8 @@ diff -Nur a/test/e2e/save_test.go b/test/e2e/save_test.go
  		pushedImage := fmt.Sprintf("localhost:%d/alpine", port)
  		session = podmanTest.Podman([]string{"tag", ALPINE, pushedImage})
 diff -Nur a/test/e2e/system_reset_test.go b/test/e2e/system_reset_test.go
---- a/test/e2e/system_reset_test.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/test/e2e/system_reset_test.go	2024-09-14 06:41:58.050257951 +0000
+--- a/test/e2e/system_reset_test.go	2024-11-21 13:40:20.000000000 +0000
++++ b/test/e2e/system_reset_test.go	2024-11-22 09:32:20.807978730 +0000
 @@ -45,7 +45,7 @@
  		Expect(session).Should(ExitCleanly())
  
@@ -707,8 +707,8 @@ diff -Nur a/test/e2e/system_reset_test.go b/test/e2e/system_reset_test.go
  		session = podmanTest.Podman([]string{"images", "-n"})
  		session.WaitWithDefaultTimeout()
 diff -Nur a/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go b/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go
---- a/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go	2024-09-14 06:41:58.693596546 +0000
+--- a/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/libnetwork/network/interface_freebsd.go	2024-11-22 09:32:21.437980016 +0000
 @@ -4,7 +4,7 @@
  	// cniConfigDir is the directory where cni configuration is found
  	cniConfigDir = "/usr/local/etc/cni/net.d/"
@@ -719,8 +719,8 @@ diff -Nur a/vendor/github.com/containers/common/libnetwork/network/interface_fre
  	netavarkRunDir = "/var/run/containers/networks"
  )
 diff -Nur a/vendor/github.com/containers/common/libnetwork/network/interface_linux.go b/vendor/github.com/containers/common/libnetwork/network/interface_linux.go
---- a/vendor/github.com/containers/common/libnetwork/network/interface_linux.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/libnetwork/network/interface_linux.go	2024-09-14 06:41:58.693596546 +0000
+--- a/vendor/github.com/containers/common/libnetwork/network/interface_linux.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/libnetwork/network/interface_linux.go	2024-11-22 09:32:21.437980016 +0000
 @@ -4,7 +4,7 @@
  	// cniConfigDir is the directory where cni configuration is found
  	cniConfigDir = "/etc/cni/net.d/"
@@ -731,8 +731,8 @@ diff -Nur a/vendor/github.com/containers/common/libnetwork/network/interface_lin
  	netavarkRunDir = "/run/containers/networks"
  )
 diff -Nur a/vendor/github.com/containers/common/pkg/config/config_bsd.go b/vendor/github.com/containers/common/pkg/config/config_bsd.go
---- a/vendor/github.com/containers/common/pkg/config/config_bsd.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/config/config_bsd.go	2024-09-14 06:41:58.690263186 +0000
+--- a/vendor/github.com/containers/common/pkg/config/config_bsd.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/config/config_bsd.go	2024-11-22 09:32:21.434646676 +0000
 @@ -11,7 +11,7 @@
  
  	// DefaultSignaturePolicyPath is the default value for the
@@ -743,8 +743,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/config/config_bsd.go b/vendo
  
  var defaultHelperBinariesDir = []string{
 diff -Nur a/vendor/github.com/containers/common/pkg/config/config_darwin.go b/vendor/github.com/containers/common/pkg/config/config_darwin.go
---- a/vendor/github.com/containers/common/pkg/config/config_darwin.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/config/config_darwin.go	2024-09-14 06:41:58.690263186 +0000
+--- a/vendor/github.com/containers/common/pkg/config/config_darwin.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/config/config_darwin.go	2024-11-22 09:32:21.434646676 +0000
 @@ -9,7 +9,7 @@
  
  	// DefaultSignaturePolicyPath is the default value for the
@@ -755,8 +755,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/config/config_darwin.go b/ve
  
  var defaultHelperBinariesDir = []string{
 diff -Nur a/vendor/github.com/containers/common/pkg/config/config_linux.go b/vendor/github.com/containers/common/pkg/config/config_linux.go
---- a/vendor/github.com/containers/common/pkg/config/config_linux.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/config/config_linux.go	2024-09-14 06:41:58.693596546 +0000
+--- a/vendor/github.com/containers/common/pkg/config/config_linux.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/config/config_linux.go	2024-11-22 09:32:21.434646676 +0000
 @@ -13,7 +13,7 @@
  
  	// DefaultSignaturePolicyPath is the default value for the
@@ -767,8 +767,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/config/config_linux.go b/ven
  
  func selinuxEnabled() bool {
 diff -Nur a/vendor/github.com/containers/common/pkg/config/config_windows.go b/vendor/github.com/containers/common/pkg/config/config_windows.go
---- a/vendor/github.com/containers/common/pkg/config/config_windows.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/config/config_windows.go	2024-09-14 06:41:58.690263186 +0000
+--- a/vendor/github.com/containers/common/pkg/config/config_windows.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/config/config_windows.go	2024-11-22 09:32:21.434646676 +0000
 @@ -12,7 +12,7 @@
  
  	// DefaultSignaturePolicyPath is the default value for the
@@ -779,8 +779,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/config/config_windows.go b/v
  	// Mount type for mounting host dir
  	_typeBind = "bind"
 diff -Nur a/vendor/github.com/containers/common/pkg/config/default.go b/vendor/github.com/containers/common/pkg/config/default.go
---- a/vendor/github.com/containers/common/pkg/config/default.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/config/default.go	2024-09-14 06:41:58.690263186 +0000
+--- a/vendor/github.com/containers/common/pkg/config/default.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/config/default.go	2024-11-22 09:32:21.434646676 +0000
 @@ -23,7 +23,7 @@
  
  const (
@@ -800,8 +800,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/config/default.go b/vendor/g
  	DefaultCdiSpecDirs = []string{"/etc/cdi"}
  	// DefaultCapabilities is the default for the default_capabilities option in the containers.conf file.
 diff -Nur a/vendor/github.com/containers/common/pkg/hooks/hooks.go b/vendor/github.com/containers/common/pkg/hooks/hooks.go
---- a/vendor/github.com/containers/common/pkg/hooks/hooks.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/hooks/hooks.go	2024-09-14 06:41:58.686929825 +0000
+--- a/vendor/github.com/containers/common/pkg/hooks/hooks.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/hooks/hooks.go	2024-11-22 09:32:21.431313336 +0000
 @@ -20,10 +20,10 @@
  
  const (
@@ -816,8 +816,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/hooks/hooks.go b/vendor/gith
  
  // Manager provides an opaque interface for managing CRI-O hooks.
 diff -Nur a/vendor/github.com/containers/common/pkg/machine/machine.go b/vendor/github.com/containers/common/pkg/machine/machine.go
---- a/vendor/github.com/containers/common/pkg/machine/machine.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/machine/machine.go	2024-09-14 06:41:58.693596546 +0000
+--- a/vendor/github.com/containers/common/pkg/machine/machine.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/machine/machine.go	2024-11-22 09:32:21.437980016 +0000
 @@ -12,7 +12,7 @@
  }
  
@@ -828,9 +828,9 @@ diff -Nur a/vendor/github.com/containers/common/pkg/machine/machine.go b/vendor/
  	Qemu       = "qemu"
  	AppleHV    = "applehv"
 diff -Nur a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
---- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go	2024-09-14 06:41:58.690263186 +0000
-@@ -19,10 +19,10 @@
+--- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go	2024-11-22 09:32:21.431313336 +0000
+@@ -20,10 +20,10 @@
  var (
  	// DefaultMountsFile holds the default mount paths in the form
  	// "host_path:container_path"
@@ -844,8 +844,8 @@ diff -Nur a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.
  	// "host_path:container_path" overridden by the rootless user
  	UserOverrideMountsFile = filepath.Join(os.Getenv("HOME"), ".config/containers/mounts.conf")
 diff -Nur a/vendor/github.com/containers/image/v5/docker/registries_d.go b/vendor/github.com/containers/image/v5/docker/registries_d.go
---- a/vendor/github.com/containers/image/v5/docker/registries_d.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/docker/registries_d.go	2024-09-14 06:41:58.673596383 +0000
+--- a/vendor/github.com/containers/image/v5/docker/registries_d.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/docker/registries_d.go	2024-11-22 09:32:21.417979975 +0000
 @@ -35,7 +35,7 @@
  var defaultUserDockerDir = filepath.FromSlash(".local/share/containers/sigstore")
  
@@ -856,8 +856,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/docker/registries_d.go b/vendo
  // registryConfiguration is one of the files in registriesDirPath configuring lookaside locations, or the result of merging them all.
  // NOTE: Keep this in sync with docs/registries.d.md!
 diff -Nur a/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go b/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go
---- a/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go	2024-09-14 06:41:58.666929661 +0000
+--- a/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go	2024-11-22 09:32:21.411313295 +0000
 @@ -17,7 +17,7 @@
  	// If the format changes in an incompatible way, increase the version number.
  	blobInfoCacheFilename = "blob-info-cache-v1.sqlite"
@@ -868,8 +868,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/pkg/blobinfocache/default.go b
  
  // blobInfoCacheDir returns a path to a blob info cache appropriate for sys and euid.
 diff -Nur a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go
---- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go	2024-09-14 06:41:58.663596301 +0000
+--- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_common.go	2024-11-22 09:32:21.407979955 +0000
 @@ -5,8 +5,8 @@
  
  // builtinRegistriesConfPath is the path to the registry configuration file.
@@ -882,8 +882,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_comm
 -const builtinRegistriesConfDirPath = "/etc/containers/registries.conf.d"
 +const builtinRegistriesConfDirPath = "/storage/.kodi/addons/service.system.podman/etc/containers/registries.conf.d"
 diff -Nur a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go
---- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go	2024-09-14 06:41:58.663596301 +0000
+--- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_freebsd.go	2024-11-22 09:32:21.407979955 +0000
 @@ -5,8 +5,8 @@
  
  // builtinRegistriesConfPath is the path to the registry configuration file.
@@ -896,8 +896,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/paths_free
 -const builtinRegistriesConfDirPath = "/usr/local/etc/containers/registries.conf.d"
 +const builtinRegistriesConfDirPath = "/usr/local/storage/.kodi/addons/service.system.podman/etc/containers/registries.conf.d"
 diff -Nur a/vendor/github.com/containers/image/v5/signature/policy_paths_common.go b/vendor/github.com/containers/image/v5/signature/policy_paths_common.go
---- a/vendor/github.com/containers/image/v5/signature/policy_paths_common.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/signature/policy_paths_common.go	2024-09-14 06:41:58.666929661 +0000
+--- a/vendor/github.com/containers/image/v5/signature/policy_paths_common.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/signature/policy_paths_common.go	2024-11-22 09:32:21.411313295 +0000
 @@ -5,4 +5,4 @@
  
  // builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
@@ -905,8 +905,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/signature/policy_paths_common.
 -const builtinDefaultPolicyPath = "/etc/containers/policy.json"
 +const builtinDefaultPolicyPath = "/storage/.kodi/addons/service.system.podman/etc/containers/policy.json"
 diff -Nur a/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go b/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go
---- a/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go	2024-09-14 06:41:58.666929661 +0000
+--- a/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd.go	2024-11-22 09:32:21.411313295 +0000
 @@ -5,4 +5,4 @@
  
  // builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
@@ -914,8 +914,8 @@ diff -Nur a/vendor/github.com/containers/image/v5/signature/policy_paths_freebsd
 -const builtinDefaultPolicyPath = "/usr/local/etc/containers/policy.json"
 +const builtinDefaultPolicyPath = "/usr/local/storage/.kodi/addons/service.system.podman/etc/containers/policy.json"
 diff -Nur a/vendor/github.com/containers/storage/types/options_bsd.go b/vendor/github.com/containers/storage/types/options_bsd.go
---- a/vendor/github.com/containers/storage/types/options_bsd.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/storage/types/options_bsd.go	2024-09-14 06:41:58.643596138 +0000
+--- a/vendor/github.com/containers/storage/types/options_bsd.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/storage/types/options_bsd.go	2024-11-22 09:32:21.387979914 +0000
 @@ -12,7 +12,7 @@
  
  // defaultConfigFile path to the system wide storage.conf file
@@ -926,8 +926,8 @@ diff -Nur a/vendor/github.com/containers/storage/types/options_bsd.go b/vendor/g
  
  // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 diff -Nur a/vendor/github.com/containers/storage/types/options_darwin.go b/vendor/github.com/containers/storage/types/options_darwin.go
---- a/vendor/github.com/containers/storage/types/options_darwin.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/storage/types/options_darwin.go	2024-09-14 06:41:58.643596138 +0000
+--- a/vendor/github.com/containers/storage/types/options_darwin.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/storage/types/options_darwin.go	2024-11-22 09:32:21.387979914 +0000
 @@ -4,11 +4,11 @@
  	// these are default path for run and graph root for rootful users
  	// for rootless path is constructed via getRootlessStorageOpts
@@ -944,8 +944,8 @@ diff -Nur a/vendor/github.com/containers/storage/types/options_darwin.go b/vendo
  // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
  func canUseRootlessOverlay() bool {
 diff -Nur a/vendor/github.com/containers/storage/types/options_linux.go b/vendor/github.com/containers/storage/types/options_linux.go
---- a/vendor/github.com/containers/storage/types/options_linux.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/storage/types/options_linux.go	2024-09-14 06:41:58.643596138 +0000
+--- a/vendor/github.com/containers/storage/types/options_linux.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/storage/types/options_linux.go	2024-11-22 09:32:21.387979914 +0000
 @@ -12,13 +12,13 @@
  	// these are default path for run and graph root for rootful users
  	// for rootless path is constructed via getRootlessStorageOpts
@@ -964,8 +964,8 @@ diff -Nur a/vendor/github.com/containers/storage/types/options_linux.go b/vendor
  
  // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 diff -Nur a/vendor/github.com/containers/storage/types/options_windows.go b/vendor/github.com/containers/storage/types/options_windows.go
---- a/vendor/github.com/containers/storage/types/options_windows.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/containers/storage/types/options_windows.go	2024-09-14 06:41:58.643596138 +0000
+--- a/vendor/github.com/containers/storage/types/options_windows.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/containers/storage/types/options_windows.go	2024-11-22 09:32:21.387979914 +0000
 @@ -4,13 +4,13 @@
  	// these are default path for run and graph root for rootful users
  	// for rootless path is constructed via getRootlessStorageOpts
@@ -984,8 +984,8 @@ diff -Nur a/vendor/github.com/containers/storage/types/options_windows.go b/vend
  
  // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 diff -Nur a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
---- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go	2024-08-21 17:43:11.000000000 +0000
-+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go	2024-09-14 06:41:58.540261960 +0000
+--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go	2024-11-21 13:40:20.000000000 +0000
++++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go	2024-11-22 09:32:21.287979709 +0000
 @@ -23,7 +23,7 @@
  
  const (

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"

--- a/tools/docker/bookworm/Dockerfile
+++ b/tools/docker/bookworm/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y \
     wget bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++ xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go/bookworm-backports git openssh-client \
+      golang-1.21-go/bookworm-backports git openssh-client rsync \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.21 /usr/lib/go \
     && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \

--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget bash bc gcc-10 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-10 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
-      golang-1.18-go git openssh-client \
+      golang-1.18-go git openssh-client rsync \
     --no-install-recommends \
  && ln -s /usr/lib/go-1.18 /usr/lib/go \
  && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/focal/Dockerfile
+++ b/tools/docker/focal/Dockerfile
@@ -20,10 +20,12 @@ RUN adduser --disabled-password --gecos '' docker \
 RUN apt-get update && apt-get install -y \
     wget bash bc gcc-10 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-10 xfonts-utils xsltproc default-jre-headless python3 \
-      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl \
-      golang-1.18-go git openssh-client rsync \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
+      golang-1.20-go git openssh-client rsync \
     --no-install-recommends \
- && ln -s /usr/lib/go-1.18 /usr/lib/go \
+ && ln -s /usr/lib/go-1.20 /usr/lib/go \
+ && ln -s /usr/lib/go-1.20/bin/go /usr/bin/go \
+ && ln -s /usr/lib/go-1.20/bin/gofmt /usr/bin/gofmt \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go git openssh-client \
+      golang-1.21-go git openssh-client rsync \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.21 /usr/lib/go \
     && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,11 +22,11 @@ RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.21-go git openssh-client rsync \
+      golang-1.22-go git openssh-client rsync \
     --no-install-recommends \
-    && ln -s /usr/lib/go-1.21 /usr/lib/go \
-    && ln -s /usr/lib/go-1.21/bin/go /usr/bin/go \
-    && ln -s /usr/lib/go-1.21/bin/gofmt /usr/bin/gofmt
+    && ln -s /usr/lib/go-1.22 /usr/lib/go \
+    && ln -s /usr/lib/go-1.22/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.22/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
   echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -21,8 +21,11 @@ RUN apt-get install -y \
     wget bash bc gcc-13 cpp-13 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-13 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-go git openssh-client rsync \
-    --no-install-recommends
+      golang-1.23-go git openssh-client rsync \
+    --no-install-recommends \
+    && ln -s /usr/lib/go-1.23 /usr/lib/go \
+    && ln -s /usr/lib/go-1.23/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.23/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
   echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y \
     wget bash bc gcc-13 cpp-13 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-13 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-go git openssh-client \
+      golang-go git openssh-client rsync \
     --no-install-recommends
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \


### PR DESCRIPTION
- Backport #9784
- docker: update to 27.5.1 and addon (8)
- podman: update to 5.4.0 and addon (2)
- go: update to 1.23.6
- tools/docker/jammy: update to building with go-1.22
- tools/docker/noble: update to building with go-1.23
- tools/docker/focal: update Dockerfile to use golang-1.20
- dockerfiles: add rsync to docker build environments
- podman-bin: update to 5.4.0
- libseccomp: update to 2.6.0
- cli: update to 27.5.1
- moby: update to 27.5.1
- gpgme: update to 1.24.2
- netavark: update to 1.14.0