### PR TITLE
rpi-eeprom: update to 50d7bfc

### DIFF
--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="a1bffdeb5d19fba475c85de499ec85907bbe21ce"
-PKG_SHA256="d36e11031128bbedfe4a175234e9b042af742910024c1bcea452bb30eda014c6"
+PKG_VERSION="50d7bfcf8273816262ac85711bc579bfa5f90df0"
+PKG_SHA256="5c53c658c6b2ea4ac8752713c549b1c32f7ae23dad73f71772096487e5a60c78"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
The "latest" version now got promoted to "default"

Runtime tested on RPi5