### PR TITLE
[le12] linux (RPi): update to 6.6.78

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="d664f45f77423b03e5a435e480822075c03331bd" # 6.6.75
-    PKG_SHA256="9be96baaca80908df1e52dce55f369b1b3161f009e0b8302b0366d0b85331ef4"
+    PKG_VERSION="009bacab99e1baf79a37563b2f15c394d2e3db8a" # 6.6.77
+    PKG_SHA256="ec495c3ecf34e3742ed1048530553e94149c677fdeadfb734510071db06897c6"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="009bacab99e1baf79a37563b2f15c394d2e3db8a" # 6.6.77
-    PKG_SHA256="ec495c3ecf34e3742ed1048530553e94149c677fdeadfb734510071db06897c6"
+    PKG_VERSION="9afba138031d6ee69824935b507cc9339427ddaf" # 6.6.78
+    PKG_SHA256="61928e06851b9955e9b63523a4847ce1f942fb506d9cf2a2d2601a0cc6cf7b51"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="6d16e47ca139ba64c5daedf06e72f2774adbdc48" # 6.6.74
-    PKG_SHA256="2625c01652ed76de6a69062c286bda0c256b0106bf29352766e8232c1690033f"
+    PKG_VERSION="d664f45f77423b03e5a435e480822075c03331bd" # 6.6.75
+    PKG_SHA256="9be96baaca80908df1e52dce55f369b1b3161f009e0b8302b0366d0b85331ef4"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="b543406ce066d3fcaa03078511bc47e62ad0bbec"
-PKG_SHA256="0e696f4b8a78ca8826c5fea3ffafd9189d32308d964bc45f890371db526f094e"
+PKG_VERSION="9995946dce284505d3dd46c7563d74a691f38a70"
+PKG_SHA256="b85fd1c08308f8d6d66c82e6c8deb533291028b9c3f7d85092a6ed208db4920c"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="0190dbc122fe0adeed591375fb4e80fbfe6aae15"
-PKG_SHA256="09e6043d72c3dc388376f7bb5e2bc9c29d529e68c48b9018c0c3a36262002db5"
+PKG_VERSION="a1bffdeb5d19fba475c85de499ec85907bbe21ce"
+PKG_SHA256="d36e11031128bbedfe4a175234e9b042af742910024c1bcea452bb30eda014c6"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="a1bffdeb5d19fba475c85de499ec85907bbe21ce"
-PKG_SHA256="d36e11031128bbedfe4a175234e9b042af742910024c1bcea452bb30eda014c6"
+PKG_VERSION="50d7bfcf8273816262ac85711bc579bfa5f90df0"
+PKG_SHA256="5c53c658c6b2ea4ac8752713c549b1c32f7ae23dad73f71772096487e5a60c78"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b67b21ddda8b6468090fcdc5034bb075344a8903"
-PKG_SHA256="8105d2d90fde2d109bf5c2fc45276e6570cb37aedd23b3fd36ba2f3e4249daf5"
+PKG_VERSION="0190dbc122fe0adeed591375fb4e80fbfe6aae15"
+PKG_SHA256="09e6043d72c3dc388376f7bb5e2bc9c29d529e68c48b9018c0c3a36262002db5"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi4 and RPi5