### PR TITLE
openssh: update to 9.9p2

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.9p1"
-PKG_SHA256="b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02"
+PKG_VERSION="9.9p2"
+PKG_SHA256="91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Change log:
- https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ChangeLog

Release notes:
- https://www.openssh.com/releasenotes.html#9.9p2

Release notes:
- https://www.openssh.com/txt/release-9.9p2