### PR TITLE
Package updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.3.82"
-PKG_SHA256="51576cd492a6997d3ae2fbe91fb5943d407f1e0c081fc3699679e25f77757acb"
+PKG_VERSION="1.3.83"
+PKG_SHA256="fb9ffee4c8cece297dd44cb83bc070d9fdf0d264a08858b21b401e17683ca790"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="zstd"
-PKG_VERSION="1.5.6"
-PKG_SHA256="4aa8dd1c1115c0fd6b6b66c35c7f6ce7bd58cc1dfd3e4f175b45b39e84b14352"
+PKG_VERSION="1.5.7"
+PKG_SHA256="5b331d961d6989dc21bb03397fc7a2a4d86bc65a14adc5ffbbce050354e30fd2"
 PKG_LICENSE="BSD/GPLv2"
 PKG_SITE="http://www.zstd.net"
 PKG_URL="https://github.com/facebook/zstd/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.zst"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.83.3"
-PKG_SHA256="d0c65318bb2e3fa594277cf98a71cffaf5f666c078db39dcec121757b2ba328d"
+PKG_VERSION="2.83.4"
+PKG_SHA256="4edc4dc184f46d1220694b7775c5d7c62265c83b0e9632d844da127c181fc391"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="10.2.0"
-PKG_SHA256="620e3468faec2ea8685d32c46a58469b850ef63040b3565cde05959825b48227"
+PKG_VERSION="10.3.0"
+PKG_SHA256="cd63fc3cbae32622588e46e0670fabf78ee6cff44a6348ca7f037dae9a32f9ea"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/flit/package.mk
+++ b/packages/python/devel/flit/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flit"
-PKG_VERSION="3.10.1"
-PKG_SHA256="66e5b87874a0d6e39691f0e22f09306736b633548670ad3c09ec9db03c5662f7"
+PKG_VERSION="3.11.0"
+PKG_SHA256="6ceeee3219e9d2ea282041f3e027c441597b450b33007cb81168e887b6113a8f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/flit-core/"
 PKG_URL="https://files.pythonhosted.org/packages/source/f/flit_core/flit_core-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pyelftools/package.mk
+++ b/packages/python/devel/pyelftools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pyelftools"
-PKG_VERSION="0.31"
-PKG_SHA256="24815cbfff9c5f68f5268983f55d969540a087bfdaa73c93f1a88e2a771f80f1"
+PKG_VERSION="0.32"
+PKG_SHA256="82d0399bce74d162fba75b3568ad47bf48ed2c5e028b72026bdc2f678903de7d"
 PKG_LICENSE="Unlicense"
 PKG_SITE="https://github.com/eliben/pyelftools"
 PKG_URL="https://github.com/eliben/pyelftools/archive/refs/tags/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- harfbuzz: update to 10.3.0
- pipewire: update to 1.3.83
- glib: update to 2.83.4
- zstd: update to 1.5.7
- pyelftools: update to 0.32
- flit: update to 3.11.0