### PR TITLE
[le12] json-c: update download link and sha256

### DIFF
--- a/packages/devel/json-c/package.mk
+++ b/packages/devel/json-c/package.mk
@@ -5,9 +5,9 @@
 
 PKG_NAME="json-c"
 PKG_VERSION="0.17"
-PKG_SHA256="fc1b9ed57f4cda51c52ec9b3b012f6973bd8d80fb70f363c5ca2754342389eb1"
+PKG_SHA256="7550914d58fb63b2c3546f3ccfbe11f1c094147bd31a69dcd23714d7956159e6"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/json-c/json-c"
-PKG_URL="https://github.com/json-c/json-c/archive/json-c-${PKG_VERSION%-*}.tar.gz"
+PKG_URL="https://s3.amazonaws.com/json-c_releases/releases/json-c-${PKG_VERSION%-*}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Implements a reference counting object model that allows you to easily construct JSON objects in C."


### PR DESCRIPTION
ref:
- https://github.com/json-c/json-c/wiki
- https://github.com/json-c/json-c/wiki/Old-Releases
- https://s3.amazonaws.com/json-c_releases/releases/index.html