### PR TITLE
kmod: add upstream fix for link errors with glibc 2.31

### DIFF
--- a/packages/sysutils/kmod/patches/kmod-01-fix-build-with-glibc-2.31.patch
+++ b/packages/sysutils/kmod/patches/kmod-01-fix-build-with-glibc-2.31.patch
@@ -1,0 +1,55 @@
+From 5bc0ef11b684393bd3727ea01495a61b791857cd Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.de.marchi@gmail.com>
+Date: Tue, 25 Feb 2025 08:49:50 -0600
+Subject: [PATCH] meson: Fix build with glibc 2.31
+
+In order to use dlopen it may be required to link with libdl depending
+on the libc. Add the proper dependency to fix the build in Debian
+Bullseye.
+
+Closes: https://github.com/kmod-project/kmod/issues/298
+Signed-off-by: Lucas De Marchi <lucas.de.marchi@gmail.com>
+---
+ meson.build | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 800b6e4c..f8f26aee 100644
+--- a/meson.build
++++ b/meson.build
+@@ -394,6 +394,11 @@ libkmod_files = files(
+ )
+ 
+ libkmod_deps = []
++cdeps = []
++
++if not cc.has_function('dlopen')
++  cdeps += cc.find_library('dl', required : true)
++endif
+ 
+ if dep_map.get('zstd').found()
+   libkmod_files += files('libkmod/libkmod-file-zstd.c')
+@@ -419,7 +424,7 @@ install_headers('libkmod/libkmod.h')
+ libkmod = shared_library(
+   'kmod',
+   libkmod_files,
+-  dependencies : libkmod_deps,
++  dependencies : libkmod_deps + cdeps,
+   link_with : libshared,
+   link_args : ['-Wl,--version-script', meson.current_source_dir() /
+                                                   'libkmod/libkmod.sym'],
+@@ -434,12 +439,13 @@ pkg.generate(
+   description : 'Library to deal with kernel modules',
+   libraries : libkmod,
+   requires_private : libkmod_deps,
++  libraries_private : cdeps,
+ )
+ 
+ libkmod_internal = static_library(
+   'kmod-internal',
+   objects : libkmod.extract_all_objects(recursive : true),
+-  dependencies : libkmod_deps,
++  dependencies : libkmod_deps + cdeps,
+   install : false,
+ )
+ 


### PR DESCRIPTION
This patch fixes the kmod:host link error when building LE master on Debian Bullseye.

See https://github.com/kmod-project/kmod/pull/299