### PR TITLE
alsa-utils: fix build with gettext-0.24

### DIFF
--- a/packages/audio/alsa-utils/patches/alsa-utils-0001-gettext-fix.patch
+++ b/packages/audio/alsa-utils/patches/alsa-utils-0001-gettext-fix.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2024-11-12 09:47:31.000000000 +0000
++++ b/configure.ac	2025-02-28 21:46:40.319313458 +0000
+@@ -8,7 +8,7 @@
+ AM_MAINTAINER_MODE([enable])
+ 
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION([0.19.8])
++AM_GNU_GETTEXT_VERSION([0.24])
+ 
+ dnl Checks for programs.
+ 


### PR DESCRIPTION
Intermittent build issue in GHA, fixed by updating GETTEXT AC to matching gettext version.
- https://github.com/alsa-project/alsa-utils/issues/294