### PR TITLE
Package updates

### DIFF
--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.83.4"
-PKG_SHA256="4edc4dc184f46d1220694b7775c5d7c62265c83b0e9632d844da127c181fc391"
+PKG_VERSION="2.83.5"
+PKG_SHA256="f8342c4f2b713c926db1b34b8bd93dd4cb2515a1102d8419686fe93942c6071c"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="groovy"
-PKG_VERSION="4.0.25"
-PKG_SHA256="822cad8e03388f23bf613d37f990b813bb4165fe389fd3fcc24f8b96476c30ef"
+PKG_VERSION="4.0.26"
+PKG_SHA256="3be6880c6de70eada2f3f5c69e1e94953e0b0c4e33c4604c1040d05dddeaed92"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://groovy.apache.org"
 PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"

--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap"
-PKG_VERSION="2.73"
-PKG_SHA256="6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
+PKG_VERSION="2.74"
+PKG_SHA256="eb85271f2893188644b6451cec8ce99f4541498f16ff9f84877c2fc872717714"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libcap/libcap.git/log/"
 PKG_URL="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="10.3.0"
-PKG_SHA256="cd63fc3cbae32622588e46e0670fabf78ee6cff44a6348ca7f037dae9a32f9ea"
+PKG_VERSION="10.4.0"
+PKG_SHA256="480b6d25014169300669aa1fc39fb356c142d5028324ea52b3a27648b9beaad8"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="19.1.4"
-PKG_SHA256="8f15eb0c998ca29ac59dab25be093d41f36d77c215f54ad9402a405495bea183"
+PKG_VERSION="19.1.5"
+PKG_SHA256="6c0e5784a0f639be80755bc7c7e2fedabf0e8511c49e50208b91c4a05a6a19bc"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="25.1.2"
-PKG_SHA256="6c11cfe1b9012011d0354b010d191a527fa3a4086152726ba642ca51808029bb"
+PKG_VERSION="25.1.3"
+PKG_SHA256="35f645b3da152a703f52071b125ea3e0b193fe3b1d6a20aad313b3c33a593128"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.108"
-PKG_SHA256="12db2163548e3be4b572821280b579e8b68d6f7c6a91c32b231cab43fcaea564"
+PKG_VERSION="3.109"
+PKG_SHA256="25be414ff9c207dd67355f19e9e71001db45957b6bb74adf5b094c92e05116b4"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/sysutils/dbus/package.mk
+++ b/packages/sysutils/dbus/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dbus"
-PKG_VERSION="1.16.0"
-PKG_SHA256="9f8ca5eb51cbe09951aec8624b86c292990ae2428b41b856e2bed17ec65c8849"
+PKG_VERSION="1.16.2"
+PKG_SHA256="0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://dbus.freedesktop.org"
 PKG_URL="https://dbus.freedesktop.org/releases/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/web/nghttp2/package.mk
+++ b/packages/web/nghttp2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nghttp2"
-PKG_VERSION="1.64.0"
-PKG_SHA256="88bb94c9e4fd1c499967f83dece36a78122af7d5fb40da2019c56b9ccc6eb9dd"
+PKG_VERSION="1.65.0"
+PKG_SHA256="f1b9df5f02e9942b31247e3d415483553bc4ac501c87aa39340b6d19c92a9331"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.linuxfromscratch.org/blfs/view/cvs/basicnet/nghttp2.html"
 PKG_URL="https://github.com/nghttp2/nghttp2/releases/download/v${PKG_VERSION}/nghttp2-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- groovy: update to 4.0.26
- glib: update to 2.83.5
- dbus: update to 1.16.2
- harfbuzz: update to 10.4.0
- spirv-llvm-translator: update to 19.1.5
- media-driver: update to 25.1.3
- libcap: update to 2.74
- nghttp2: update to 1.65.0
- nss: update to 3.109