### PR TITLE
fix usage of multiple toolchains

### DIFF
--- a/packages/devel/binutils-aarch64/package.mk
+++ b/packages/devel/binutils-aarch64/package.mk
@@ -12,8 +12,7 @@ PKG_DEPENDS_UNPACK+=" binutils"
 PKG_PATCH_DIRS+=" $(get_pkg_directory binutils)/patches"
 
 PKG_CONFIGURE_OPTS_HOST="--target=aarch64-none-elf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
-                         --with-lib-path=${SYSROOT_PREFIX}/lib:${SYSROOT_PREFIX}/usr/lib \
+                         --with-sysroot=${TOOLCHAIN}/aarch64-none-elf/sysroot \
                          --without-ppl \
                          --enable-static \
                          --without-cloog \
@@ -47,9 +46,5 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
-  make -C libsframe install # bfd is reliant on libsframe
-  make -C bfd install # fix parallel build with libctf requiring bfd
-  # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils-arm-none-eabi/package.mk
+++ b/packages/devel/binutils-arm-none-eabi/package.mk
@@ -12,8 +12,7 @@ PKG_DEPENDS_UNPACK+=" binutils"
 PKG_PATCH_DIRS+=" $(get_pkg_directory binutils)/patches"
 
 PKG_CONFIGURE_OPTS_HOST="--target=arm-none-eabi \
-                         --with-sysroot=${SYSROOT_PREFIX} \
-                         --with-lib-path=${SYSROOT_PREFIX}/lib:${SYSROOT_PREFIX}/usr/lib \
+                         --with-sysroot=${TOOLCHAIN}/arm-none-eabi/sysroot \
                          --without-ppl \
                          --enable-static \
                          --without-cloog \
@@ -47,9 +46,6 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
-  make -C libsframe install # bfd is reliant on libsframe
-  make -C bfd install # fix parallel build with libctf requiring bfd
   # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils-bpf/package.mk
+++ b/packages/devel/binutils-bpf/package.mk
@@ -12,8 +12,7 @@ PKG_DEPENDS_UNPACK+=" binutils"
 PKG_PATCH_DIRS+=" $(get_pkg_directory binutils)/patches"
 
 PKG_CONFIGURE_OPTS_HOST="--target=bpf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
-                         --with-lib-path=${SYSROOT_PREFIX}/lib:${SYSROOT_PREFIX}/usr/lib \
+                         --with-sysroot=${TOOLCHAIN}/bpf/sysroot \
                          --without-ppl \
                          --enable-static \
                          --without-cloog \
@@ -47,9 +46,6 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
-  make -C libsframe install # bfd is reliant on libsframe
-  make -C bfd install # fix parallel build with libctf requiring bfd
   # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/devel/binutils-or1k/package.mk
+++ b/packages/devel/binutils-or1k/package.mk
@@ -12,8 +12,7 @@ PKG_DEPENDS_UNPACK+=" binutils"
 PKG_PATCH_DIRS+=" $(get_pkg_directory binutils)/patches"
 
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
-                         --with-lib-path=${SYSROOT_PREFIX}/lib:${SYSROOT_PREFIX}/usr/lib \
+                         --with-sysroot=${TOOLCHAIN}/or1k-none-elf/sysroot \
                          --without-ppl \
                          --enable-static \
                          --without-cloog \
@@ -47,8 +46,6 @@ make_host() {
 }
 
 makeinstall_host() {
-  cp -v ../include/libiberty.h ${SYSROOT_PREFIX}/usr/include
-  make -C bfd install # fix parallel build with libctf requiring bfd
   # override the makeinfo binary with true - this does not build the documentation
   make MAKEINFO=true install
 }

--- a/packages/lang/gcc-aarch64/package.mk
+++ b/packages/lang/gcc-aarch64/package.mk
@@ -16,7 +16,7 @@ if [ "${MOLD_SUPPORT}" = "yes" ]; then
 fi
 
 PKG_CONFIGURE_OPTS_HOST="--target=aarch64-none-elf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
+                         --with-sysroot=${TOOLCHAIN}/aarch64-none-elf/sysroot \
                          --with-gmp=${TOOLCHAIN} \
                          --with-mpfr=${TOOLCHAIN} \
                          --with-mpc=${TOOLCHAIN} \
@@ -55,6 +55,13 @@ PKG_CONFIGURE_OPTS_HOST="--target=aarch64-none-elf \
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/gcc/gcc-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+pre_configure_host() {
+  unset CPPFLAGS
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
 }
 
 post_makeinstall_host() {

--- a/packages/lang/gcc-arm-none-eabi/package.mk
+++ b/packages/lang/gcc-arm-none-eabi/package.mk
@@ -16,7 +16,7 @@ if [ "${MOLD_SUPPORT}" = "yes" ]; then
 fi
 
 PKG_CONFIGURE_OPTS_HOST="--target=arm-none-eabi \
-                         --with-sysroot=${SYSROOT_PREFIX} \
+                         --with-sysroot=${TOOLCHAIN}/arm-none-eabi/sysroot \
                          --with-gmp=${TOOLCHAIN} \
                          --with-mpfr=${TOOLCHAIN} \
                          --with-mpc=${TOOLCHAIN} \
@@ -54,6 +54,13 @@ PKG_CONFIGURE_OPTS_HOST="--target=arm-none-eabi \
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/gcc/gcc-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+pre_configure_host() {
+  unset CPPFLAGS
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
 }
 
 post_makeinstall_host() {

--- a/packages/lang/gcc-bpf/package.mk
+++ b/packages/lang/gcc-bpf/package.mk
@@ -16,7 +16,7 @@ if [ "${MOLD_SUPPORT}" = "yes" ]; then
 fi
 
 PKG_CONFIGURE_OPTS_HOST="--target=bpf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
+                         --with-sysroot=${TOOLCHAIN}/bpf/sysroot \
                          --with-gmp=${TOOLCHAIN} \
                          --with-mpfr=${TOOLCHAIN} \
                          --with-mpc=${TOOLCHAIN} \
@@ -55,4 +55,11 @@ PKG_CONFIGURE_OPTS_HOST="--target=bpf \
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/gcc/gcc-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+pre_configure_host() {
+  unset CPPFLAGS
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
 }

--- a/packages/lang/gcc-or1k/package.mk
+++ b/packages/lang/gcc-or1k/package.mk
@@ -16,7 +16,7 @@ if [ "${MOLD_SUPPORT}" = "yes" ]; then
 fi
 
 PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \
-                         --with-sysroot=${SYSROOT_PREFIX} \
+                         --with-sysroot=${TOOLCHAIN}/or1k-none-elf/sysroot \
                          --with-gmp=${TOOLCHAIN} \
                          --with-mpfr=${TOOLCHAIN} \
                          --with-mpc=${TOOLCHAIN} \
@@ -55,6 +55,13 @@ PKG_CONFIGURE_OPTS_HOST="--target=or1k-none-elf \
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/gcc/gcc-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+pre_configure_host() {
+  unset CPPFLAGS
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
 }
 
 post_makeinstall_host() {

--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -21,12 +21,13 @@ fi
 
 make_target() {
   # As of atf 2.11.0 - the supported compile for .S is gcc (not as.)
-  unset AS
+  unset AR AS CC CPP CXX LD NM OBJCOPY OBJDUMP STRIP RANLIB
+  unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
   if [ "${ATF_PLATFORM}" = "imx8mq" ]; then
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="" make PLAT=${ATF_PLATFORM} LOG_LEVEL=0 bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" make PLAT=${ATF_PLATFORM} LOG_LEVEL=0 bl31
   else
     # as of atf 2.12.0 - sun50i_a64 builds use LTO, include -ffat-lto-objects to support this
-    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" LDFLAGS="" CFLAGS="-ffat-lto-objects" make PLAT=${ATF_PLATFORM} bl31
+    CROSS_COMPILE="${TARGET_KERNEL_PREFIX}" CFLAGS="-ffat-lto-objects" make PLAT=${ATF_PLATFORM} bl31
   fi
 }
 


### PR DESCRIPTION
Here's a funky one.

- I build ~once a month and it failed 100% for me for at least 6 months
- Looking at the patches this is in "how did this ever work for anyone?" territory 
- My build uses aarch64, armv8 and or1k, and while I fixed arm-none-eabi and bpf too, those changes are untested