### PR TITLE
jre.zulu: bump jdk packages to 8.84.0.15-8.0.442 and addon (1)

### DIFF
--- a/packages/addons/addon-depends/jre-depends/jdk-aarch64-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-aarch64-zulu/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
 
 PKG_NAME="jdk-aarch64-zulu"
-PKG_VERSION="8.38.0.162-1.8.0_212"
-PKG_SHA256="2afa6b9a86fea6f9275856506b5cc1efd8420f674c5e2dc3e1b04e140d6ad852"
+PKG_VERSION="8.84.0.15-8.0.442"
+PKG_SHA256="3ae6b27727a308c0c262a99e20af29c87aad7910de423db2607c44551b598e57"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.azul.com/products/zulu-embedded/"
-PKG_URL="http://cdn.azul.com/zulu-embedded/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_aarch64.tar.gz"
+PKG_URL="http://cdn.azul.com/zulu/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_aarch64.tar.gz"
 PKG_LONGDESC="Zulu, the open Java(TM) platform from Azul Systems."
 PKG_TOOLCHAIN="manual"
 

--- a/packages/addons/addon-depends/jre-depends/jdk-arm-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-arm-zulu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
 
 PKG_NAME="jdk-arm-zulu"
-PKG_VERSION="8.38.0.163-1.8.0_212"
-PKG_SHA256="bc45f41eab6e55c4e740e980001831c5e35db85745ec61a2b110e816e1074715"
+PKG_VERSION="8.84.0.15-8.0.442"
+PKG_SHA256="3a164013eae14af23256b7fbaedc6ac3abc295f3bfafd794e5f5a44266ddecab"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.azul.com/products/zulu-embedded/"
 PKG_URL="https://cdn.azul.com/zulu-embedded/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_aarch32hf.tar.gz"

--- a/packages/addons/addon-depends/jre-depends/jdk-x86_64-zulu/package.mk
+++ b/packages/addons/addon-depends/jre-depends/jdk-x86_64-zulu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Peter Vicman (peter.vicman@gmail.com)
 
 PKG_NAME="jdk-x86_64-zulu"
-PKG_VERSION="8.38.0.13-8.0.212"
-PKG_SHA256="568e7578f1b20b1e62a8ed2c374bad4eb0e75d221323ccfa6ba8d7bc56cf33cf"
+PKG_VERSION="8.84.0.15-8.0.442"
+PKG_SHA256="6e3bd4d911e6eb2d14e0b48e622b6909c76add0b51c51d11f5c2c3d2a045bcf3"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.azul.com/products/zulu-enterprise/"
 PKG_URL="https://cdn.azul.com/zulu/bin/zulu${PKG_VERSION%%-*}-ca-jdk${PKG_VERSION##*-}-linux_x64.tar.gz"

--- a/packages/addons/tools/jre.zulu/package.mk
+++ b/packages/addons/tools/jre.zulu/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="jre.zulu"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_LICENSE="GPL2"
 PKG_DEPENDS_TARGET="jre-libbluray libXext libXi libXrender chrome-libXtst jre-libXinerama"
 PKG_DEPENDS_UNPACK="jdk-${TARGET_ARCH}-zulu"

--- a/packages/addons/tools/jre.zulu/profile.d/jre.profile
+++ b/packages/addons/tools/jre.zulu/profile.d/jre.profile
@@ -6,3 +6,9 @@ export LIBBLURAY_CP="/storage/.kodi/addons/tools.jre.zulu/"
 
 # or set file directly
 # export LIBBLURAY_CP="/storage/.kodi/addons/tools.jre.zulu/libbluray-j2se-1.0.2.jar"
+
+# additional java options
+#export _JAVA_OPTIONS="-Djava.io.tmpdir=/storage/libbluray-bdj-cache"
+
+# remove old libbluray bdj cache
+rm -fr "/storage/.kodi/userdata/addon_data/tools.jre.zulu/libbluray-bdj-cache"

--- a/packages/multimedia/libbluray/patches/libbluray-03-set-headless-false.patch
+++ b/packages/multimedia/libbluray/patches/libbluray-03-set-headless-false.patch
@@ -6,16 +6,20 @@ Subject: [PATCH] disable X11 check because it will not run in headless mode
 https://github.com/fandangos/libbluray/commit/47726b99922899bb9c4ea688356199f2068d156a
 https://github.com/PojavLauncherTeam/PojavLauncher/issues/713#issuecomment-769816262
 
+temporary folder is set to /storage/.kodi/userdata/addon_data/tools.jre.zulu/libbluray-bdj-cache
+
 ---
  src/libbluray/bdj/bdj.c | 2 ++
  1 file changed, 2 insertions(+)
 
 --- a/src/libbluray/bdj/bdj.c
 +++ b/src/libbluray/bdj/bdj.c
-@@ -903,6 +903,8 @@ static int _create_jvm(void *jvm_lib, co
+@@ -903,6 +903,10 @@ static int _create_jvm(void *jvm_lib, co
      option[n++].optionString = str_dup   ("-Xms256M");
      option[n++].optionString = str_dup   ("-Xmx256M");
      option[n++].optionString = str_dup   ("-Xss2048k");
++    option[n++].optionString = str_dup   ("-Djava.io.tmpdir=/storage/.kodi/userdata/addon_data/tools.jre.zulu");
++    BD_DEBUG(DBG_BDJ | DBG_CRIT, "Use /storage/.kodi/userdata/addon_data/tools.jre.zulu as cache dir.\n");
 +    option[n++].optionString = str_dup   ("-Djava.awt.headless=false");
 +    BD_DEBUG(DBG_CRIT | DBG_BDJ, "Disable X11 check\n");
  #ifdef HAVE_BDJ_J2ME


### PR DESCRIPTION
temporary folder for libbluray-bdj-cache is set to /storage/libbluray-bdj-cache