### PR TITLE
kodi: update to githash 24fb7e8

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="8260af82ffa21e99c84e258a4e7b231a08bcf37b"
-PKG_SHA256="41ac56e0554cf929e30b9fbf78a99d1bc5f6447ff73b1f0de9d82cc5d35a38b2"
+PKG_VERSION="24fb7e8829ec2939ccde113a709548c057b6d386"
+PKG_SHA256="25cadd57e93921fb0560808758ad178be4d9951b05fe7de38ed511018a024a31"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/8260af82ffa21e99c84e258a4e7b231a08bcf37b...24fb7e8829ec2939ccde113a709548c057b6d386

```
=== tested on ===
Generic.x86_64-devel-20250307091526-2090d87
Linux nuc12 6.14.0-rc5 #1 SMP Thu Mar  6 21:57:26 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:24fb7e8829ec2939ccde113a709548c057b6d386). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-03-07 by GCC 15.0.1 for Linux x86 64-bit version 6.14.0 (396800)
Running on LibreELEC (heitbaum): devel-20250307091526-2090d87 13.0, kernel: Linux x86 64-bit version 6.14.0-rc5
FFmpeg version/source: 7.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.1
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.1.3 (4e0a024624)
```