### PR TITLE
linux (RPi): update to 6.12.17

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"
     ;;
   raspberrypi)
-    PKG_VERSION="031a3826707c5a9c5761bb9c354756b6730051cf" # 6.12.15
-    PKG_SHA256="247184d2f8e5de5606988ba8820dc663460492147d138076bb69fafde53ac820"
+    PKG_VERSION="d76ddb7372f26a545e8df41bcfac36d0210dd859" # 6.12.16
+    PKG_SHA256="e424e48b9d78fea7984a5fe8532c707dd51d94f84333b04e318898d755e74d3d"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"
     ;;
   raspberrypi)
-    PKG_VERSION="a6322f0a1e9c2450db4fcb042db608b8a598bd1a" # 6.12.16
-    PKG_SHA256="edc6d2118a94b3cbb12c6435c00c54751290a8dd549fc970768a368f1e860a45"
+    PKG_VERSION="5985ce32e511f4e8279a841a1b06a8c7d972b386" # 6.12.17
+    PKG_SHA256="99a4ddc4632c0127e5b6142392b8146fce5d1234e1224780f4f920a7f3e919e5"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"
     ;;
   raspberrypi)
-    PKG_VERSION="d76ddb7372f26a545e8df41bcfac36d0210dd859" # 6.12.16
-    PKG_SHA256="e424e48b9d78fea7984a5fe8532c707dd51d94f84333b04e318898d755e74d3d"
+    PKG_VERSION="a6322f0a1e9c2450db4fcb042db608b8a598bd1a" # 6.12.16
+    PKG_SHA256="edc6d2118a94b3cbb12c6435c00c54751290a8dd549fc970768a368f1e860a45"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"
     ;;
   raspberrypi)
-    PKG_VERSION="5985ce32e511f4e8279a841a1b06a8c7d972b386" # 6.12.17
-    PKG_SHA256="99a4ddc4632c0127e5b6142392b8146fce5d1234e1224780f4f920a7f3e919e5"
+    PKG_VERSION="9b8abc11c8be5fccf756eb1cee86b86e7ca90bdf" # 6.12.17
+    PKG_SHA256="358acae4d706d1f3fb9ca81afa67d80ae1faff7b25fd1ed5ed3a81f5b77c4843"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="50d7bfcf8273816262ac85711bc579bfa5f90df0"
-PKG_SHA256="5c53c658c6b2ea4ac8752713c549b1c32f7ae23dad73f71772096487e5a60c78"
+PKG_VERSION="3a16bd016f533877079c3bfad188539abd31fb8a"
+PKG_SHA256="c833aeeaa7fcae516c2971b5084b479a62b8c1e348a380cf76e3b8d1dfe82a78"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -3238,6 +3238,7 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
+# CONFIG_VIDEO_RPI_HEVC_DEC is not set
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #
@@ -5115,7 +5116,6 @@ CONFIG_R8712U=m
 CONFIG_VT6656=m
 CONFIG_STAGING_MEDIA=y
 # CONFIG_VIDEO_MAX96712 is not set
-# CONFIG_VIDEO_RPIVID is not set
 
 #
 # StarFive media platform drivers

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.14 Kernel Configuration
+# Linux/arm 6.12.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4210,6 +4210,7 @@ CONFIG_SND_DACBERRY400=m
 # CONFIG_SND_I2S_HI6210_I2S is not set
 # CONFIG_SND_SOC_IMG is not set
 # CONFIG_SND_SOC_MTK_BTCVSD is not set
+# CONFIG_SND_RP1_AUDIO_OUT is not set
 # CONFIG_SND_SOC_SOF_TOPLEVEL is not set
 
 #

--- a/projects/RPi/devices/RPi/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.16 Kernel Configuration
+# Linux/arm 6.12.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -1336,7 +1336,6 @@ CONFIG_RASPBERRYPI_FIRMWARE=y
 # CONFIG_FW_CFG_SYSFS is not set
 CONFIG_FW_CS_DSP=m
 # CONFIG_GOOGLE_FIRMWARE is not set
-# CONFIG_IMX_SCMI_MISC_DRV is not set
 
 #
 # Qualcomm firmware drivers
@@ -5137,7 +5136,6 @@ CONFIG_BCM2835_VCHIQ_MMAL=y
 # CONFIG_FIELDBUS_DEV is not set
 # CONFIG_GOLDFISH is not set
 # CONFIG_CHROME_PLATFORMS is not set
-# CONFIG_CZNIC_PLATFORMS is not set
 # CONFIG_MELLANOX_PLATFORM is not set
 CONFIG_HAVE_CLK=y
 CONFIG_HAVE_CLK_PREPARE=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.16 Kernel Configuration
+# Linux/arm 6.12.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -1531,7 +1531,6 @@ CONFIG_RASPBERRYPI_FIRMWARE=y
 # CONFIG_TRUSTED_FOUNDATIONS is not set
 CONFIG_FW_CS_DSP=m
 # CONFIG_GOOGLE_FIRMWARE is not set
-# CONFIG_IMX_SCMI_MISC_DRV is not set
 
 #
 # Qualcomm firmware drivers
@@ -5378,7 +5377,6 @@ CONFIG_BCM2835_VCHIQ_MMAL=y
 # CONFIG_FIELDBUS_DEV is not set
 # CONFIG_GOLDFISH is not set
 # CONFIG_CHROME_PLATFORMS is not set
-# CONFIG_CZNIC_PLATFORMS is not set
 # CONFIG_MELLANOX_PLATFORM is not set
 CONFIG_HAVE_CLK=y
 CONFIG_HAVE_CLK_PREPARE=y

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -3477,6 +3477,7 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
+# CONFIG_VIDEO_RPI_HEVC_DEC is not set
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #
@@ -5356,7 +5357,6 @@ CONFIG_R8712U=m
 CONFIG_VT6656=m
 CONFIG_STAGING_MEDIA=y
 # CONFIG_VIDEO_MAX96712 is not set
-# CONFIG_VIDEO_RPIVID is not set
 
 #
 # StarFive media platform drivers

--- a/projects/RPi/devices/RPi2/linux/linux.arm.conf
+++ b/projects/RPi/devices/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.12.14 Kernel Configuration
+# Linux/arm 6.12.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -4450,6 +4450,7 @@ CONFIG_SND_DACBERRY400=m
 # CONFIG_SND_I2S_HI6210_I2S is not set
 # CONFIG_SND_SOC_IMG is not set
 # CONFIG_SND_SOC_MTK_BTCVSD is not set
+# CONFIG_SND_RP1_AUDIO_OUT is not set
 # CONFIG_SND_SOC_SOF_TOPLEVEL is not set
 
 #

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.16 Kernel Configuration
+# Linux/arm64 6.12.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -1764,7 +1764,6 @@ CONFIG_EFI_EARLYCON=y
 # CONFIG_EFI_COCO_SECRET is not set
 # end of EFI (Extensible Firmware Interface) Support
 
-# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 
 #
@@ -6153,7 +6152,6 @@ CONFIG_BCM2835_VCHIQ_MMAL=m
 # CONFIG_VME_BUS is not set
 # CONFIG_GOLDFISH is not set
 # CONFIG_CHROME_PLATFORMS is not set
-# CONFIG_CZNIC_PLATFORMS is not set
 # CONFIG_MELLANOX_PLATFORM is not set
 CONFIG_SURFACE_PLATFORMS=y
 CONFIG_ARM64_PLATFORM_DEVICES=y

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.14 Kernel Configuration
+# Linux/arm64 6.12.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -5203,6 +5203,7 @@ CONFIG_SND_DACBERRY400=m
 # CONFIG_SND_I2S_HI6210_I2S is not set
 # CONFIG_SND_SOC_IMG is not set
 # CONFIG_SND_SOC_MTK_BTCVSD is not set
+# CONFIG_SND_RP1_AUDIO_OUT is not set
 # CONFIG_SND_SOC_SOF_TOPLEVEL is not set
 
 #

--- a/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi4/linux/linux.aarch64.conf
@@ -4135,6 +4135,7 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
+CONFIG_VIDEO_RPI_HEVC_DEC=m
 # CONFIG_VIDEO_RP1_CFE is not set
 
 #
@@ -6130,7 +6131,6 @@ CONFIG_VT6656=m
 CONFIG_STAGING_MEDIA=y
 # CONFIG_DVB_AV7110 is not set
 # CONFIG_VIDEO_MAX96712 is not set
-CONFIG_VIDEO_RPIVID=m
 
 #
 # StarFive media platform drivers

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.16 Kernel Configuration
+# Linux/arm64 6.12.17 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -1771,7 +1771,6 @@ CONFIG_EFI_EARLYCON=y
 # CONFIG_EFI_COCO_SECRET is not set
 # end of EFI (Extensible Firmware Interface) Support
 
-# CONFIG_IMX_SCMI_MISC_DRV is not set
 CONFIG_ARM_PSCI_FW=y
 
 #
@@ -6195,7 +6194,6 @@ CONFIG_VIDEO_RPIVID=m
 # CONFIG_VME_BUS is not set
 # CONFIG_GOLDFISH is not set
 # CONFIG_CHROME_PLATFORMS is not set
-# CONFIG_CZNIC_PLATFORMS is not set
 # CONFIG_MELLANOX_PLATFORM is not set
 CONFIG_SURFACE_PLATFORMS=y
 CONFIG_ARM64_PLATFORM_DEVICES=y

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -4161,6 +4161,7 @@ CONFIG_MEDIA_PLATFORM_DRIVERS=y
 #
 # Raspberry Pi media platform drivers
 #
+CONFIG_VIDEO_RPI_HEVC_DEC=m
 CONFIG_VIDEO_RP1_CFE=m
 
 #
@@ -6180,7 +6181,6 @@ CONFIG_VT6656=m
 CONFIG_STAGING_MEDIA=y
 # CONFIG_DVB_AV7110 is not set
 # CONFIG_VIDEO_MAX96712 is not set
-CONFIG_VIDEO_RPIVID=m
 
 #
 # StarFive media platform drivers

--- a/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
+++ b/projects/RPi/devices/RPi5/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.14 Kernel Configuration
+# Linux/arm64 6.12.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 13.0.0 20220604 (experimental) [master revision aec868578d8515763d75693c1fdfbc30ff0a1e68]"
 CONFIG_CC_IS_GCC=y
@@ -5236,6 +5236,7 @@ CONFIG_SND_DESIGNWARE_PCM=y
 # CONFIG_SND_I2S_HI6210_I2S is not set
 # CONFIG_SND_SOC_IMG is not set
 # CONFIG_SND_SOC_MTK_BTCVSD is not set
+CONFIG_SND_RP1_AUDIO_OUT=m
 # CONFIG_SND_SOC_SOF_TOPLEVEL is not set
 
 #


### PR DESCRIPTION
This depends on #9845 as the RPi kernel switched to the latest HEVC decoder which is currently being upstreamed.

Runtime tested on RPi4 and RPi5