### PR TITLE
nvidia: install missing drm module and GSP firmware files

### DIFF
--- a/packages/graphics/nvidia/package.mk
+++ b/packages/graphics/nvidia/package.mk
@@ -41,6 +41,10 @@ makeinstall_target() {
     cp -P kernel/nvidia-uvm.ko     ${INSTALL}/$(get_full_module_dir)/nvidia
     cp -P kernel/nvidia-modeset.ko ${INSTALL}/$(get_full_module_dir)/nvidia
 
+  # GSP firmware files
+  mkdir -p ${INSTALL}/$(get_full_firmware_dir)/nvidia/${PKG_VERSION}
+    cp firmware/gsp*.bin           ${INSTALL}/$(get_full_firmware_dir)/nvidia/${PKG_VERSION}
+
   # GBM
   mkdir -p ${INSTALL}/usr/lib/gbm
     cp -p libnvidia-allocator.so.${PKG_VERSION}     ${INSTALL}/usr/lib

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -43,6 +43,7 @@ makeinstall_target() {
     cp -P kernel/nvidia.ko ${INSTALL}/usr/lib/nvidia
   mkdir -p ${INSTALL}/$(get_full_module_dir)/nvidia
     ln -sf /var/lib/nvidia.ko      ${INSTALL}/$(get_full_module_dir)/nvidia/nvidia.ko
+    cp -P kernel/nvidia-drm.ko     ${INSTALL}/$(get_full_module_dir)/nvidia
     cp -P kernel/nvidia-uvm.ko     ${INSTALL}/$(get_full_module_dir)/nvidia
     cp -P kernel/nvidia-modeset.ko ${INSTALL}/$(get_full_module_dir)/nvidia
 

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -47,6 +47,10 @@ makeinstall_target() {
     cp -P kernel/nvidia-uvm.ko     ${INSTALL}/$(get_full_module_dir)/nvidia
     cp -P kernel/nvidia-modeset.ko ${INSTALL}/$(get_full_module_dir)/nvidia
 
+  # GSP firmware files
+  mkdir -p ${INSTALL}/$(get_full_firmware_dir)/nvidia/${PKG_VERSION}
+    cp firmware/gsp*.bin           ${INSTALL}/$(get_full_firmware_dir)/nvidia/${PKG_VERSION}
+
   # X driver
   mkdir -p ${INSTALL}/${XORG_PATH_MODULES}/drivers
     cp -P nvidia_drv.so ${INSTALL}/${XORG_PATH_MODULES}/drivers/nvidia-main_drv.so


### PR DESCRIPTION
This fixes the "no display" issue after the update to the 570 driver series.

see also https://forum.libreelec.tv/thread/28426-nightly-builds/?postID=198917#post198917

Runtime tested with Generic Legacy and a RTX4060 card