### PR TITLE
Generic: use a minimum SYSTEM_SIZE of 1GB

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -72,3 +72,8 @@
 
   # Default size of the ova image, in MB, eg. 4096
     OVA_SIZE="4096"
+
+  # ensure system size is at least 1 GB
+    if [ ${SYSTEM_SIZE} -lt 1024 ]; then
+      SYSTEM_SIZE=1024
+    fi


### PR DESCRIPTION
The nvidia driver and it's firmware files need a lot of space, 512MB is soon going to be too small:

```
443M	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.img.gz
4.0K	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.img.gz.sha256
40M	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.kernel
446M	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.ova
4.0K	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.ova.sha256
404M	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.system
444M	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.tar
4.0K	LibreELEC-Generic-legacy.x86_64-13.0-devel-20250309141523-a80dd47.tar.sha256
```