### PR TITLE
xorg-i915.conf: set "option DRI 3"

### DIFF
--- a/projects/Generic/devices/x11/filesystem/etc/X11/xorg-i915.conf
+++ b/projects/Generic/devices/x11/filesystem/etc/X11/xorg-i915.conf
@@ -4,4 +4,5 @@ Section "Device"
   VendorName  "INTEL Corporation"
   Option "TripleBuffer" "false"
   Option "TearFree" "false"
+  Option "DRI" "3"
 EndSection


### PR DESCRIPTION
Default dri2 was removed fro…m mesa

Fix Kodi failing to initialize on intel HW using Generic-legacy.

If there are still issues mesa has to be build with "legacy-x11=dri2"
