### PR TITLE
audiodecoder.sidplay: fix linking / update addon (22.0.0.1)

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sidplay"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="ab1f89237c91bc7157557f42dadcff50a7191eb7285ee668543defce9f1efcf2"
-PKG_REV="8"
+PKG_VERSION="8586d3fe9f6ddcb0acf4183f561cb9de92d2624f"
+PKG_SHA256="79b767b6022cf84b0b243fc8b4a832a7b73608c618e0e9b21d8c5ab3a906a873"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sidplay"
@@ -17,5 +17,3 @@ PKG_LONGDESC="audiodecoder.sidplay"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.audiodecoder"
-
-PKG_CMAKE_OPTS_TARGET="-DSIDPLAY2_LIBRARIES=${SYSROOT_PREFIX}/usr/lib"


### PR DESCRIPTION
There was a crash reported in the [forum](https://forum.libreelec.tv/thread/29563-rpi-sidplay-decoder-simply-refuses-to-work) and @chewitt's log shows a link error.

Fix the link error by using default cmake module search.

Updating to hash because there is no Piers tag.

PS: Looks like a long standing error: https://github.com/xbmc/audiodecoder.sidplay/issues/15#issuecomment-503340003 