### PR TITLE
audiodecoder.sidplay: fix linking / update addon (2)

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sidplay/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.sidplay"
 PKG_VERSION="21.0.2-Omega"
 PKG_SHA256="c7d10dd65baed2db1272ff57fde76f0b268a4a434d57022539c4dc5bf6f8b54e"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sidplay"
@@ -17,5 +17,3 @@ PKG_LONGDESC="audiodecoder.sidplay"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.audiodecoder"
-
-PKG_CMAKE_OPTS_TARGET="-DSIDPLAY2_LIBRARIES=${SYSROOT_PREFIX}/usr/lib"


### PR DESCRIPTION
Backport of #9855

There was a crash reported in the [forum](https://forum.libreelec.tv/thread/29563-rpi-sidplay-decoder-simply-refuses-to-work) and @chewitt's log shows a link error.

Fix the link error by using default cmake module search.

PS: Looks like a long standing error: https://github.com/xbmc/audiodecoder.sidplay/issues/15#issuecomment-503340003 