### PR TITLE
ffmpeg: update rpi patch

### DIFF
--- a/packages/multimedia/ffmpeg/patches/rpi/ffmpeg-001-rpi.patch
+++ b/packages/multimedia/ffmpeg/patches/rpi/ffmpeg-001-rpi.patch
@@ -19597,7 +19597,7 @@ index 000000000000..d8126676ee0c
 +#endif // AVUTIL_ARM_SAND_NEON_H
 +
 diff --git a/libavutil/frame.c b/libavutil/frame.c
-index f0a0dba018a6..cc14af82d600 100644
+index f0a0dba018a6..38458696c6ae 100644
 --- a/libavutil/frame.c
 +++ b/libavutil/frame.c
 @@ -16,6 +16,8 @@
@@ -19619,14 +19619,13 @@ index f0a0dba018a6..cc14af82d600 100644
  
  static const AVSideDataDescriptor sd_props[] = {
      [AV_FRAME_DATA_PANSCAN]                     = { "AVPanScan" },
-@@ -1077,6 +1082,13 @@ int av_frame_apply_cropping(AVFrame *frame, int flags)
+@@ -1077,6 +1082,12 @@ int av_frame_apply_cropping(AVFrame *frame, int flags)
          (frame->crop_top + frame->crop_bottom) >= frame->height)
          return AVERROR(ERANGE);
  
 +#if CONFIG_SAND
 +    // Sand cannot be cropped - do not try
-+    // If it might be encapsulated in DRM_PRIME don't crop that either
-+    if (av_rpi_is_sand_format(frame->format) || frame->format == AV_PIX_FMT_DRM_PRIME)
++    if (av_rpi_is_sand_format(frame->format))
 +        return 0;
 +#endif
 +


### PR DESCRIPTION
This fixes the "green line at bottom" issue with H264 HW decoding and no playback of interlaced videos on RPi4.

See also https://forum.libreelec.tv/thread/29564-rpi4-h264-hardware-decoding-issue/

Fixes: #9859 