### PR TITLE
gcc: 14.2.0: arm: Fix signedness of vld1q intrinsic parms

### DIFF
--- a/packages/lang/gcc/patches/gcc-14.2.0-arm--fix-signedness-of-vld1q-intrinsic-parms.patch
+++ b/packages/lang/gcc/patches/gcc-14.2.0-arm--fix-signedness-of-vld1q-intrinsic-parms.patch
@@ -1,0 +1,83 @@
+From 6e17b356a78635e66d1a895b86fbcc0bde0589bb Mon Sep 17 00:00:00 2001
+From: Hannes Braun <hannes@hannesbraun.net>
+Date: Thu, 20 Feb 2025 15:09:41 +0100
+Subject: [PATCH] arm: Fix signedness of vld1q intrinsic parms [PR118942]
+
+vld1q_s8_x3, vld1q_s16_x3, vld1q_s8_x4 and vld1q_s16_x4 were expecting
+pointers to unsigned integers. These parameters should be pointers to
+signed integers.
+
+gcc/ChangeLog:
+	PR target/118942
+	* config/arm/arm_neon.h (vld1q_s8_x3): Use int8_t instead of
+	uint16_t.
+	(vld1q_s16_x3): Use int16_t instead of uint16_t.
+	(vld1q_s8_x4): Likewise.
+	(vld1q_s16_x4): Likewise.
+
+gcc/testsuite/ChangeLog:
+	PR target/118942
+	* gcc.target/arm/simd/vld1q_base_xN_1.c: Add -Wpointer-sign.
+
+Signed-off-by: Hannes Braun <hannes@hannesbraun.net>
+(cherry picked from commit 4d0a333ef13e2da140cd44c4941b20f48a80dc0f)
+---
+ gcc/config/arm/arm_neon.h                           | 8 ++++----
+ gcc/testsuite/gcc.target/arm/simd/vld1q_base_xN_1.c | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gcc/config/arm/arm_neon.h b/gcc/config/arm/arm_neon.h
+index 8e70c7177315..11d2dc06877a 100644
+--- a/gcc/config/arm/arm_neon.h
++++ b/gcc/config/arm/arm_neon.h
+@@ -10854,7 +10854,7 @@ vld1q_s64_x2 (const int64_t * __a)
+ 
+ __extension__ extern __inline int8x16x3_t
+ __attribute__  ((__always_inline__, __gnu_inline__, __artificial__))
+-vld1q_s8_x3 (const uint8_t * __a)
++vld1q_s8_x3 (const int8_t * __a)
+ {
+   union { int8x16x3_t __i; __builtin_neon_ci __o; } __rv;
+   __rv.__o = __builtin_neon_vld1q_x3v16qi ((const __builtin_neon_qi *) __a);
+@@ -10863,7 +10863,7 @@ vld1q_s8_x3 (const uint8_t * __a)
+ 
+ __extension__ extern __inline int16x8x3_t
+ __attribute__  ((__always_inline__, __gnu_inline__, __artificial__))
+-vld1q_s16_x3 (const uint16_t * __a)
++vld1q_s16_x3 (const int16_t * __a)
+ {
+   union { int16x8x3_t __i; __builtin_neon_ci __o; } __rv;
+   __rv.__o = __builtin_neon_vld1q_x3v8hi ((const __builtin_neon_hi *) __a);
+@@ -10890,7 +10890,7 @@ vld1q_s64_x3 (const int64_t * __a)
+ 
+ __extension__ extern __inline int8x16x4_t
+ __attribute__  ((__always_inline__, __gnu_inline__, __artificial__))
+-vld1q_s8_x4 (const uint8_t * __a)
++vld1q_s8_x4 (const int8_t * __a)
+ {
+   union { int8x16x4_t __i; __builtin_neon_xi __o; } __rv;
+   __rv.__o = __builtin_neon_vld1q_x4v16qi ((const __builtin_neon_qi *) __a);
+@@ -10899,7 +10899,7 @@ vld1q_s8_x4 (const uint8_t * __a)
+ 
+ __extension__ extern __inline int16x8x4_t
+ __attribute__  ((__always_inline__, __gnu_inline__, __artificial__))
+-vld1q_s16_x4 (const uint16_t * __a)
++vld1q_s16_x4 (const int16_t * __a)
+ {
+   union { int16x8x4_t __i; __builtin_neon_xi __o; } __rv;
+   __rv.__o = __builtin_neon_vld1q_x4v8hi ((const __builtin_neon_hi *) __a);
+diff --git a/gcc/testsuite/gcc.target/arm/simd/vld1q_base_xN_1.c b/gcc/testsuite/gcc.target/arm/simd/vld1q_base_xN_1.c
+index 01b29b600847..c73afe2b723b 100644
+--- a/gcc/testsuite/gcc.target/arm/simd/vld1q_base_xN_1.c
++++ b/gcc/testsuite/gcc.target/arm/simd/vld1q_base_xN_1.c
+@@ -1,6 +1,6 @@
+ /* { dg-do assemble } */
+ /* { dg-require-effective-target arm_neon_ok } */
+-/* { dg-options "-save-temps -O2" } */
++/* { dg-options "-save-temps -O2 -Wpointer-sign" } */
+ /* { dg-add-options arm_neon } */
+ 
+ #include "arm_neon.h"
+-- 
+2.43.5
+


### PR DESCRIPTION
- required by: aom-3.12.0
- https://aomedia.issues.chromium.org/issues/397711740