### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/ncftp/patches/ncftp-0001-fix-incompatible-pointer-types-error.patch
+++ b/packages/addons/addon-depends/network-tools-depends/ncftp/patches/ncftp-0001-fix-incompatible-pointer-types-error.patch
@@ -1,0 +1,27 @@
+Use stat, fstat, and lstat structures and let the C library handle the
+related structures and system calls.
+
+Upstream: N/A, unresponsive contact email address.
+
+Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>
+--- a/ncftp/syshdrs.h
++++ b/ncftp/syshdrs.h
+@@ -266,18 +266,6 @@
+ #	define Stat WinStat64
+ #	define Lstat WinStat64
+ #	define Fstat WinFStat64
+-#elif ((defined(HAVE_LONG_LONG)) && (defined(_LARGEFILE64_SOURCE)) && (defined(HAVE_STAT64)) && (defined(HAVE_STRUCT_STAT64)))
+-#	define Stat stat64
+-#	ifdef HAVE_FSTAT64
+-#		define Fstat fstat64
+-#	else
+-#		define Fstat fstat
+-#	endif
+-#	ifdef HAVE_LSTAT64
+-#		define Lstat lstat64
+-#	else
+-#		define Lstat lstat
+-#	endif
+ #else
+ #	define Stat stat
+ #	define Fstat fstat

--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="11.4.5"
-PKG_REV="2"
-PKG_SHA256="ff6595f8c482f9921e39b97fa1122377a69f0dcbd92553c6b9032cbf0e9b5354"
+PKG_VERSION="11.8.1"
+PKG_REV="3"
+PKG_SHA256="c58e9e96e8e69dba09aa179b9bea63fc2775f3194efb72dfc2c277abfb9936e5"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://archive.mariadb.org/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.42"
-PKG_SHA256="8ee886fd21e99627582e4f71df114ee39b32809cd5e7eaf6af62069bcca5477a"
-PKG_REV="8"
+PKG_VERSION="1.3.44"
+PKG_SHA256="82d1de38516e5a9826477d0517f40c20589f8cf30bc4cdcf2efd83685cee11e1"
+PKG_REV="9"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.29.2"
-PKG_SHA256="c7b6bc36af1af6f1cb304f4ec4c16743760ef6e8b3586f31dc11439d5d5fd427"
-PKG_REV="4"
+PKG_VERSION="1.29.3"
+PKG_SHA256="cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
- ncftp: workaround gcc-14 error incompatible-pointer-types on arm and aarch64
- minisatip: update to 1.3.44 and addon (9)
- syncthing: update to 1.29.3 and addon (5)
- mariadb: update to 11.8.1 and addon (3)