### PR TITLE
libxslt: update build options aligning with upstream

### DIFF
--- a/packages/textproc/libxslt/package.mk
+++ b/packages/textproc/libxslt/package.mk
@@ -14,14 +14,14 @@ PKG_LONGDESC="A XSLT C library."
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_ALL="-DBUILD_SHARED_LIBS=ON \
-                    -DLIBXSLT_WITH_DEBUGGER=ON \
+                    -DLIBXSLT_WITH_DEBUGGER=OFF \
                     -DLIBXSLT_WITH_CRYPTO=OFF \
-                    -DLIBXSLT_WITH_MODULES=ON \
+                    -DLIBXSLT_WITH_MODULES=OFF \
                     -DLIBXSLT_WITH_PROFILER=ON \
                     -DLIBXSLT_WITH_PYTHON=OFF \
                     -DLIBXSLT_WITH_TESTS=OFF \
                     -DLIBXSLT_WITH_THREADS=ON \
-                    -DLIBXSLT_WITH_XSLT_DEBUG=ON"
+                    -DLIBXSLT_WITH_XSLT_DEBUG=OFF"
 
 PKG_CMAKE_OPTS_HOST=${PKG_CMAKE_OPTS_ALL}
 


### PR DESCRIPTION
https://github.com/GNOME/libxslt/blob/master/NEWS

The non-standard EXSLT crypto extensions and support for dynamically loaded plugins are now disabled by default. These features can be enabled by passing --with-crypto or --with-plugins to configure. In a future release, these features will be removed.

Debug output and the debugger are disabled by default and can be enabled by passing --with-debug or --with-debugger.

was identified as unnecessary upon review of incorrect pkgconfig file generation https://gitlab.gnome.org/GNOME/libxslt/-/issues/136