### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.55.2"
-PKG_SHA256="3a8bf306df73fccbd5935e5e934e18efc44b8d0b84867741a2079cb83ed3acee"
+PKG_VERSION="2.56.0"
+PKG_SHA256="80d7e8ea0be924e045525367f909d6668dfdd3e87cd40792c6cfd08e6b58e95c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.54.0"
-PKG_SHA256="d7eee7e75beddcc272cedc2b60535600f3aae6e481589ebc667afc437c0a6079"
+PKG_VERSION="2.55.2"
+PKG_SHA256="3a8bf306df73fccbd5935e5e934e18efc44b8d0b84867741a2079cb83ed3acee"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.4.0"
-PKG_SHA256="81076aac2020ec53ef6c3e2f6e8b5bee7275dad15c295bacab5c73e2727955ec"
+PKG_VERSION="1.4.1"
+PKG_SHA256="1eba67c6e5acfa23e32d70bdbabab5a3d221c4bfbb12e17aa29fd5051c095fa4"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/python/security/pycryptodome/package.mk
+++ b/packages/python/security/pycryptodome/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pycryptodome"
-PKG_VERSION="3.21.0"
-PKG_SHA256="195e5cdfbb550b03f83f2af2aa4652c14b64783574d835fe61bb06c8fc06ba21"
+PKG_VERSION="3.22.0"
+PKG_SHA256="d1499d50dfe0628fe45157956e9c522011f37043a2d3f2457631c97e56f9e6c1"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pycryptodome"
 PKG_URL="https://github.com/Legrandin/${PKG_NAME}/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/textproc/tinyxml2/package.mk
+++ b/packages/textproc/tinyxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tinyxml2"
-PKG_VERSION="10.1.0"
-PKG_SHA256="9da7e1aebbf180ef6f39044b9740a4e96fa69e54a01318488512ae92ca97a685"
+PKG_VERSION="11.0.0"
+PKG_SHA256="5556deb5081fb246ee92afae73efd943c889cef0cafea92b0b82422d6a18f289"
 PKG_LICENSE="zlib"
 PKG_SITE="http://www.grinninglizard.com/tinyxml2/index.html"
 PKG_URL="https://github.com/leethomason/tinyxml2/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- tinyxml2: update to 11.0.0
- pycryptodome: update to 3.22.0
- at-spi2-core: update to 2.56.0
- pipewire: update to 1.4.1