### PR TITLE
Package updates

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.4.3"
-PKG_SHA256="a92aa83d2ff09a1a6d6186e81d8182bd2958947dffca77a6490ffd41b3ec9dc7"
+PKG_VERSION="2.4.4"
+PKG_SHA256="fc492a255f453e65ac5b99a25e6ffbe0fbd64d6a4fe824bacd68de16fe8af7ba"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.37"
-PKG_SHA256="9831cc912bc1da6dadac15699c5a07a82c00d6f0dd5c15ec02e20908dd527d3a"
+PKG_VERSION="1.37.1"
+PKG_SHA256="1af13a9745d5c2b5ef691623c9a435417fb5549d549f17633723463c34095162"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/graphics/pango/package.mk
+++ b/packages/graphics/pango/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pango"
-PKG_VERSION="1.56.2"
-PKG_SHA256="03b7afd7ed730bef651155cbfb5320556b8ef92b0dc04abbb9784dcd4057afe7"
+PKG_VERSION="1.56.3"
+PKG_SHA256="2606252bc25cd8d24e1b7f7e92c3a272b37acd6734347b73b47a482834ba2491"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.pango.org/"
 PKG_URL="https://download.gnome.org/sources/pango/${PKG_VERSION:0:4}/pango-${PKG_VERSION}.tar.xz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="20.2.1-Nexus"
 PKG_SHA256="dd8ca6386a3beed360c1d2f989cd81553baf81652007fdfd478a28b44b68db10"
-PKG_REV="14"
+PKG_REV="15"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"

--- a/packages/network/netbase/package.mk
+++ b/packages/network/netbase/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netbase"
-PKG_VERSION="6.4"
-PKG_SHA256="fa6621826ff1150e581bd90bc3c8a4ecafe5df90404f207db6dcdf2c75f26ad7"
+PKG_VERSION="6.5"
+PKG_SHA256="9116047aebbaa1698934052d01c6e09b4c3aed643e93df63d2ddcbec243c26d1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://salsa.debian.org/md/netbase"
 PKG_URL="http://ftp.debian.org/debian/pool/main/n/netbase/netbase_${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- audiodecoder.fluidsynth: fluidsynth update to 2.4.4 and addon (15)
  - fluidsynth: update to 2.4.4
- fakeroot: update to 1.37.1
- netbase: update to 6.5
- pango: update to 1.56.3