### PR TITLE
Docker update to 28.0.2 and podman update to 5.4.1

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="abd16e3911bc7bbd00596ebe4f58baf3d577160d99eefd749a908507ddfc587b"
+PKG_SHA256="70ded7462897bab0b7d7e5716ffc787391ff5f2b483d7eb590a37bf6512bd3e4"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="9f9e4058019a37304dc6572ffcbb409d529b59d8"
+export PKG_GIT_COMMIT="0442a7378f37ef9482ade1c8addf618cb8becb00"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.0.2"
-PKG_SHA256="472747a7a6b360a0864bab0ee00a8a6f51da5795171e6a60ab17aa80cbd850a2"
+PKG_VERSION="2.0.4"
+PKG_SHA256="af0b18d125abf97fbe90d6d2cda53ffa0cd4cbb9e7d65fee61fc095bfb63cef5"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="c507a0257ea6462fbd6f5ba4f5c74facb04021f4"
+export PKG_GIT_COMMIT="1a43cb6a1035441f9aca8f5666a9b3ef9e70ab20"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="27.5.1"
-PKG_SHA256="0d071c1773c855778d85590e01b924c1857000fd786485f4b674a3be2d3b893c"
+PKG_VERSION="28.0.2"
+PKG_SHA256="7cfc0c13358497f9c6d8e1558d70195e6b72f37cbd9605ba35812ef395186927"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="4c9b3b011ae4c30145a7b344c870bdda01b454e2"
+export PKG_GIT_COMMIT="bea4de25004da0460f80ac1e0f1628e66b058287"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
@@ -4,20 +4,20 @@
 #
 #
 diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
---- a/cmd/dockerd/daemon_unix.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/cmd/dockerd/daemon_unix.go	2024-09-10 06:47:41.951753985 +0000
-@@ -23,7 +23,7 @@
+--- a/cmd/dockerd/daemon_unix.go	2025-02-19 21:53:46.000000000 +0000
++++ b/cmd/dockerd/daemon_unix.go	2025-02-20 10:29:44.441745187 +0000
+@@ -21,7 +21,7 @@
  
- func getDefaultDaemonConfigDir() (string, error) {
+ func getDefaultDaemonConfigDir() string {
  	if !honorXDG {
--		return "/etc/docker", nil
-+		return "/storage/.kodi/userdata/addon_data/service.system.docker/config", nil
+-		return "/etc/docker"
++		return "/storage/.kodi/userdata/addon_data/service.system.docker/config"
  	}
  	// NOTE: CLI uses ~/.docker while the daemon uses ~/.config/docker, because
  	// ~/.docker was not designed to store daemon configurations.
 diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
---- a/cmd/dockerd/options.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/cmd/dockerd/options.go	2024-09-10 06:47:41.951753985 +0000
+--- a/cmd/dockerd/options.go	2025-02-19 21:53:46.000000000 +0000
++++ b/cmd/dockerd/options.go	2025-02-20 10:29:44.441449933 +0000
 @@ -39,7 +39,7 @@
  	//
  	//   - DOCKER_CONFIG only affects TLS certificates, but does not change the
@@ -37,8 +37,8 @@ diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
  	//     needed for rootless, but perhaps could be used for non-rootless(?)
  	//   - When changing  the location for TLS config, (ideally) they should
 diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/authz/authz_plugin_test.go
---- a/integration/plugin/authz/authz_plugin_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/integration/plugin/authz/authz_plugin_test.go	2024-09-10 06:47:41.908420295 +0000
+--- a/integration/plugin/authz/authz_plugin_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/integration/plugin/authz/authz_plugin_test.go	2025-02-20 10:29:44.406641256 +0000
 @@ -56,15 +56,15 @@
  
  	ctrl = &authorizationController{}
@@ -58,48 +58,23 @@ diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/
  		assert.NilError(t, err)
  		ctrl = nil
  	})
-diff -Naur a/integration/plugin/graphdriver/external_test.go b/integration/plugin/graphdriver/external_test.go
---- a/integration/plugin/graphdriver/external_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/integration/plugin/graphdriver/external_test.go	2024-09-10 06:47:41.908420295 +0000
-@@ -88,7 +88,7 @@
- 
- 	sserver.Close()
- 	jserver.Close()
--	err := os.RemoveAll("/etc/docker/plugins")
-+	err := os.RemoveAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins")
- 	assert.NilError(t, err)
- }
- 
-@@ -352,10 +352,10 @@
- 		respond(w, &graphDriverResponse{Size: size})
- 	})
- 
--	err = os.MkdirAll("/etc/docker/plugins", 0o755)
-+	err = os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0o755)
- 	assert.NilError(t, err)
- 
--	specFile := "/etc/docker/plugins/" + name + "." + ext
-+	specFile := "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/" + name + "." + ext
- 	err = os.WriteFile(specFile, b, 0o644)
- 	assert.NilError(t, err)
- }
 diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integration-cli/docker_cli_external_volume_driver_test.go
---- a/integration-cli/docker_cli_external_volume_driver_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/integration-cli/docker_cli_external_volume_driver_test.go	2024-09-10 06:47:42.278423345 +0000
-@@ -262,10 +262,10 @@
+--- a/integration-cli/docker_cli_external_volume_driver_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/integration-cli/docker_cli_external_volume_driver_test.go	2025-02-20 10:29:44.713041018 +0000
+@@ -266,10 +266,10 @@
  		send(w, `{"Capabilities": { "Scope": "global" }}`)
  	})
  
 -	err := os.MkdirAll("/etc/docker/plugins", 0o755)
 +	err := os.MkdirAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", 0o755)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  
 -	err = os.WriteFile("/etc/docker/plugins/"+name+".spec", []byte(s.Server.URL), 0o644)
 +	err = os.WriteFile("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins/"+name+".spec", []byte(s.Server.URL), 0o644)
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  	return s
  }
-@@ -273,7 +273,7 @@
+@@ -277,7 +277,7 @@
  func (s *DockerExternalVolumeSuite) TearDownSuite(ctx context.Context, c *testing.T) {
  	s.volumePlugin.Close()
  
@@ -108,7 +83,7 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
  	assert.NilError(c, err)
  }
  
-@@ -367,7 +367,7 @@
+@@ -371,7 +371,7 @@
  
  // Make sure a request to use a down driver doesn't block other requests
  func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *testing.T) {
@@ -118,9 +93,9 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
  	assert.NilError(c, err)
  	defer os.RemoveAll(specPath)
 diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
---- a/integration-cli/docker_cli_network_unix_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/integration-cli/docker_cli_network_unix_test.go	2024-09-10 06:47:42.278423345 +0000
-@@ -225,14 +225,14 @@
+--- a/integration-cli/docker_cli_network_unix_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/integration-cli/docker_cli_network_unix_test.go	2025-02-20 10:29:44.713475312 +0000
+@@ -226,14 +226,14 @@
  		}
  	})
  
@@ -138,7 +113,7 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
  	err = os.WriteFile(ipamFileName, []byte(url), 0o644)
  	assert.NilError(t, err)
  }
-@@ -244,7 +244,7 @@
+@@ -245,7 +245,7 @@
  
  	s.server.Close()
  
@@ -148,9 +123,9 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
  }
  
 diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_cli_swarm_test.go
---- a/integration-cli/docker_cli_swarm_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/integration-cli/docker_cli_swarm_test.go	2024-09-10 06:47:42.281756705 +0000
-@@ -823,14 +823,14 @@
+--- a/integration-cli/docker_cli_swarm_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/integration-cli/docker_cli_swarm_test.go	2025-02-20 10:29:44.716710173 +0000
+@@ -825,14 +825,14 @@
  		}
  	})
  
@@ -168,7 +143,7 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	err = os.WriteFile(ipamFileName, []byte(url), 0o644)
  	assert.NilError(t, err)
  }
-@@ -843,7 +843,7 @@
+@@ -845,7 +845,7 @@
  	setupRemoteGlobalNetworkPlugin(c, mux, s.server.URL, globalNetworkPlugin, globalIPAMPlugin)
  	defer func() {
  		s.server.Close()
@@ -178,9 +153,9 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	}()
  
 diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remote/driver_test.go
---- a/libnetwork/drivers/remote/driver_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/libnetwork/drivers/remote/driver_test.go	2024-09-10 06:47:42.268423262 +0000
-@@ -42,7 +42,7 @@
+--- a/libnetwork/drivers/remote/driver_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/libnetwork/drivers/remote/driver_test.go	2025-02-20 10:29:44.707404748 +0000
+@@ -44,7 +44,7 @@
  }
  
  func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
@@ -190,8 +165,8 @@ diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remot
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/remote_test.go
---- a/libnetwork/ipams/remote/remote_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/libnetwork/ipams/remote/remote_test.go	2024-09-10 06:47:42.261756541 +0000
+--- a/libnetwork/ipams/remote/remote_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/libnetwork/ipams/remote/remote_test.go	2025-02-20 10:29:44.699434031 +0000
 @@ -38,7 +38,7 @@
  }
  
@@ -202,8 +177,8 @@ diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/re
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_test.go
---- a/libnetwork/libnetwork_unix_test.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/libnetwork/libnetwork_unix_test.go	2024-09-10 06:47:42.271756623 +0000
+--- a/libnetwork/libnetwork_unix_test.go	2025-02-19 21:53:46.000000000 +0000
++++ b/libnetwork/libnetwork_unix_test.go	2025-02-20 10:29:44.709262867 +0000
 @@ -2,4 +2,4 @@
  
  package libnetwork_test
@@ -211,8 +186,8 @@ diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_tes
 -var specPath = "/etc/docker/plugins"
 +var specPath = "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins"
 diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
---- a/pkg/plugins/discovery.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/pkg/plugins/discovery.go	2024-09-10 06:47:41.915087017 +0000
+--- a/pkg/plugins/discovery.go	2025-02-19 21:53:46.000000000 +0000
++++ b/pkg/plugins/discovery.go	2025-02-20 10:29:44.412930502 +0000
 @@ -128,12 +128,12 @@
  //
  // On Unix in non-rootless mode:
@@ -229,8 +204,8 @@ diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
  func SpecsPaths() []string {
  	return specsPaths()
 diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
---- a/pkg/plugins/discovery_unix.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/pkg/plugins/discovery_unix.go	2024-09-10 06:47:41.915087017 +0000
+--- a/pkg/plugins/discovery_unix.go	2025-02-19 21:53:46.000000000 +0000
++++ b/pkg/plugins/discovery_unix.go	2025-02-20 10:29:44.412746807 +0000
 @@ -12,7 +12,7 @@
  	if configHome, err := homedir.GetConfigHome(); err != nil {
  		return filepath.Join(configHome, "docker/plugins")
@@ -248,8 +223,8 @@ diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
 +	return []string{"/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", "/usr/lib/docker/plugins"}
  }
 diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
---- a/pkg/plugins/plugins.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/pkg/plugins/plugins.go	2024-09-10 06:47:41.915087017 +0000
+--- a/pkg/plugins/plugins.go	2025-02-19 21:53:46.000000000 +0000
++++ b/pkg/plugins/plugins.go	2025-02-20 10:29:44.413216747 +0000
 @@ -4,7 +4,7 @@
  // Docker discovers plugins by looking for them in the plugin directory whenever
  // a user or container tries to use one by name. UNIX domain socket files must
@@ -260,8 +235,8 @@ diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
  // its name if it exists.
  //
 diff -Naur a/registry/config_unix.go b/registry/config_unix.go
---- a/registry/config_unix.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/registry/config_unix.go	2024-09-10 06:47:42.275089984 +0000
+--- a/registry/config_unix.go	2025-02-19 21:53:46.000000000 +0000
++++ b/registry/config_unix.go	2025-02-20 10:29:44.712430143 +0000
 @@ -5,7 +5,7 @@
  // defaultCertsDir is the platform-specific default directory where certificates
  // are stored. On Linux, it may be overridden through certsDir, for example, when
@@ -272,8 +247,8 @@ diff -Naur a/registry/config_unix.go b/registry/config_unix.go
  // cleanPath is used to ensure that a directory name is valid on the target
  // platform. It will be passed in something *similar* to a URL such as
 diff -Naur a/registry/search_endpoint_v1.go b/registry/search_endpoint_v1.go
---- a/registry/search_endpoint_v1.go	2024-09-06 09:57:40.000000000 +0000
-+++ b/registry/search_endpoint_v1.go	2024-09-10 06:47:42.278423345 +0000
+--- a/registry/search_endpoint_v1.go	2025-02-19 21:53:46.000000000 +0000
++++ b/registry/search_endpoint_v1.go	2025-02-20 10:29:44.712695815 +0000
 @@ -54,7 +54,7 @@
  		if endpoint.IsSecure {
  			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`
@@ -283,3 +258,15 @@ diff -Naur a/registry/search_endpoint_v1.go b/registry/search_endpoint_v1.go
  		}
  
  		// registry is insecure and HTTPS failed, fallback to HTTP.
+diff -Naur a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go
+--- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-02-19 21:53:46.000000000 +0000
++++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-02-20 10:29:44.668972179 +0000
+@@ -578,7 +578,7 @@
+ 	return filepath.Join(base, p)
+ }
+ 
+-// loadCertsDir loads certs from certsDir like "/etc/docker/certs.d" .
++// loadCertsDir loads certs from certsDir like "/storage/.kodi/userdata/addon_data/service.system.docker/config/certs.d" .
+ // Compatible with Docker file layout
+ //   - files ending with ".crt" are treated as CA certificate files
+ //   - files ending with ".cert" are treated as client certificates, and

--- a/packages/addons/addon-depends/podman/conmon/package.mk
+++ b/packages/addons/addon-depends/podman/conmon/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="conmon"
-PKG_VERSION="2.1.12"
-PKG_SHA256="842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6"
+PKG_VERSION="2.1.13"
+PKG_SHA256="350992cb2fe4a69c0caddcade67be20462b21b4078dae00750e8da1774926d60"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/conmon"
 PKG_URL="https://github.com/containers/conmon/archive/v${PKG_VERSION}.tar.gz"
@@ -11,7 +11,7 @@ PKG_DEPENDS_TARGET="toolchain glib libseccomp systemd"
 PKG_LONGDESC="An OCI container runtime monitor"
 
 # Git commit of the matching release https://github.com/containers/conmon
-export PKG_GIT_COMMIT="e8896631295ccb0bfdda4284f1751be19b483264"
+export PKG_GIT_COMMIT="82de887596ed8ee6d9b2ee85e4f167f307bb569b"
 
 pre_configure_target() {
   export PKG_CONFIG_PATH="$(get_install_dir libseccomp)/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"

--- a/packages/addons/addon-depends/podman/libassuan/package.mk
+++ b/packages/addons/addon-depends/podman/libassuan/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libassuan"
-PKG_VERSION="3.0.1"
-PKG_SHA256="c8f0f42e6103dea4b1a6a483cb556654e97302c7465308f58363778f95f194b1"
+PKG_VERSION="3.0.2"
+PKG_SHA256="d2931cdad266e633510f9970e1a2f346055e351bb19f9b78912475b8074c36f6"
 PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://gnupg.org/software/libassuan/index.html"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/podman/netavark/package.mk
+++ b/packages/addons/addon-depends/podman/netavark/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netavark"
-PKG_VERSION="1.14.0"
-PKG_SHA256="d2ded5412e5037e84f79a28c774378c864aa6f6e43023dd88891c70cfaf963ef"
+PKG_VERSION="1.14.1"
+PKG_SHA256="fd4a25db0abe73e2d0d7a9958f298ace134671edc64259cbc8ea3c2907f89dd8"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/netavark"
 PKG_URL="https://github.com/containers/netavark/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.4.0"
-PKG_SHA256="e5efb825558624d0539dac94847c39aafec68e6d4dd712435ff4ec1b17044b69"
+PKG_VERSION="5.4.1"
+PKG_SHA256="502117195c06678db612313aaf42505cabeea860f8668802a0608754eb0df9f6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="f9f7d48b24b1ca4403f189caaeab1cb8ff4a9aa2"
+export PKG_GIT_COMMIT="b79bc8afe796cba51dd906270a7e1056ccdfcf9e"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.2.4"
-PKG_SHA256="9785c144c97974b52b6091b7a79168b73681ff574bc8438b44f3f5f8c112f171"
+PKG_VERSION="1.2.6"
+PKG_SHA256="19b280702341f33ff353fa254d1dbdb67f6aab2c74395f6d651a17524f68e752"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="6c52b3fc541fb26fe8c374d5f58112a0a5dbda66"
+export PKG_GIT_COMMIT="e89a29929c775025419ab0d218a43588b4c12b9a"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"


### PR DESCRIPTION
- podman: update to 5.4.1 and addon (4)
  - conmon: update to 2.1.13
  - libassuan: update to 3.0.2
  - podman-bin: update to 5.4.1
  - netavark: update to 1.14.1
- docker: update to 28.0.2 and addon (8)
  - runc: update to 1.2.6
  - containerd: update to 2.0.4
  - moby: update to 28.0.2
  - cli: update to 28.0.2