### PR TITLE
kodi: update to githash 3299328

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="5a5daca6f60e1de5929e8635a6766c91ff4c418e"
-PKG_SHA256="daa357382f1a06399349a45a0239f818098d08dcc370818b7839cfb385b69943"
+PKG_VERSION="32993285404dd1dcb69e2655b7ceb8cc5f323c22"
+PKG_SHA256="f7a19c05184a36ea6d54a6bef969fa6a930f1f2fa5d33b8d56f85d233bc275b0"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/5a5daca6f60e1de5929e8635a6766c91ff4c418e...32993285404dd1dcb69e2655b7ceb8cc5f323c22

```
=== tested on ===
Generic.x86_64-devel-20250322114817-f7500e0
Linux nuc12 6.14.0-rc7 #1 SMP Sat Mar 22 08:50:20 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:32993285404dd1dcb69e2655b7ceb8cc5f323c22). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-03-22 by GCC 15.0.1 for Linux x86 64-bit version 6.14.0 (396800)
Running on LibreELEC (heitbaum): devel-20250322114817-f7500e0 13.0, kernel: Linux x86 64-bit version 6.14.0-rc7
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.2
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.1.4 (8474935e94)
```