### PR TITLE
Package updates

### DIFF
--- a/packages/audio/sbc/package.mk
+++ b/packages/audio/sbc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sbc"
-PKG_VERSION="2.0"
-PKG_SHA256="8f12368e1dbbf55e14536520473cfb338c84b392939cc9b64298360fd4a07992"
+PKG_VERSION="2.1"
+PKG_SHA256="426633cabd7c798236443516dfa8335b47e004b0ef37ff107e0c7ead3299fcc2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.bluez.org/"
 PKG_URL="https://www.kernel.org/pub/linux/bluetooth/sbc-${PKG_VERSION}.tar.xz"

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccache"
-PKG_VERSION="4.11.1"
-PKG_SHA256="245a24e26f08defbf700b813b0be0706a703e9d26a925260ce935e6ce601324d"
+PKG_VERSION="4.11.2"
+PKG_SHA256="319390f276123968cfa565acc3da0b1e18414374b40ff25274230e6860352125"
 PKG_LICENSE="GPL"
 PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="10.4.0"
-PKG_SHA256="480b6d25014169300669aa1fc39fb356c142d5028324ea52b3a27648b9beaad8"
+PKG_VERSION="11.0.0"
+PKG_SHA256="f16351bafe214725fe2c1d5b59f0d93e49905a4b247899fb90d70cff953a2b9b"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.27.1"
-PKG_SHA256="641df745984baff8f6f822066b4e32f28482d267e95448158732eb2f65ea7fe9"
+PKG_VERSION="1.28.0"
+PKG_SHA256="18fc1c8c81e48e86a00df5ecc40ed1e7981aa8560949f26ebf800d698fa1e7cd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.41"
-PKG_SHA256="2786b6b1b79965e313f2c289c12075b9ed700d41844810c51afda10ee329576b"
+PKG_VERSION="1.42"
+PKG_SHA256="23ba80d410d1200a86fe29592c19766eae8f1c350b67289999e9e7ea12d9f7aa"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libinput: update to 1.28.0
- harfbuzz: update to 11.0.0
- ccache: update to 4.11.2
- sbc: update to 2.1
- wayland-protocols: update to 1.42