### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.56.0"
-PKG_SHA256="80d7e8ea0be924e045525367f909d6668dfdd3e87cd40792c6cfd08e6b58e95c"
+PKG_VERSION="2.56.1"
+PKG_SHA256="fd177fecd8c95006ff0a355eafd7066fe110a2e17eb5eb5fe17ff70e49a4eace"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
-PKG_VERSION="3.0.1"
-PKG_SHA256="6a514ae31254b43e06e2a89fe1cbc9c447fdbf26edc6f794f3eb722f36e28261"
+PKG_VERSION="3.0.3"
+PKG_SHA256="baf343041420e2924e1760bbbc0c111101c44e1cecb998e7951f646a957ee05f"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/microsoft/mimalloc"
 PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/tbb/package.mk
+++ b/packages/devel/tbb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tbb"
-PKG_VERSION="2022.0.0"
-PKG_SHA256="e8e89c9c345415b17b30a2db3095ba9d47647611662073f7fbf54ad48b7f3c2a"
+PKG_VERSION="2022.1.0"
+PKG_SHA256="ed067603ece0dc832d2881ba5c516625ac2522c665d95f767ef6304e34f961b5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/oneapi-src/oneTBB"
 PKG_URL="https://github.com/oneapi-src/oneTBB/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/jasper/package.mk
+++ b/packages/graphics/jasper/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="jasper"
-PKG_VERSION="4.2.4"
-PKG_SHA256="23a3d58cdeacf3abdf9fa1d81dcefee58da6ab330940790c0f27019703bfd2cd"
+PKG_VERSION="4.2.5"
+PKG_SHA256="3f4b1df7cab7a3cc67b9f6e28c730372f030b54b0faa8548a9ee04ae83fffd44"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.ece.uvic.ca/~mdadams/jasper/"
 PKG_URL="https://github.com/jasper-software/jasper/archive/refs/tags/version-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-headers/package.mk
+++ b/packages/graphics/spirv-headers/package.mk
@@ -6,8 +6,10 @@ PKG_NAME="spirv-headers"
 # The SPIRV-Headers pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
-PKG_VERSION="3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b"
-PKG_SHA256="2301e11e5c77213258d6863bf4e6c607a8c6431fa8336e98ac6a2131bd6284f8"
+# When updating spirv-llvm-translator pkg_version validate the minimum githash from 
+# https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/spirv-headers-tag.conf
+PKG_VERSION="09913f088a1197aba4aefd300a876b2ebbaa3391"
+PKG_SHA256="6d4aad5a86d7d5af144747aee1d616f624897d64d842f282aca7777f84244318"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="4d2f0b40bfe290dea6c6904dafdf7fd8328ba346"
-PKG_SHA256="41481a45441d92b2404aa06bdecbb0302f22636335be4e19023632c83fa89aa1"
+PKG_VERSION="f289d047f49fb60488301ec62bafab85573668cc"
+PKG_SHA256="5fbd56baf226a04435656bae408287365102b69a24fa73bab8353c5f44b55615"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="15.1.0"
-PKG_SHA256="4bdcd8cdb330313f0d4deed7be527b0ac1c115ff272e492853a6e98add61b4bc"
+PKG_VERSION="15.2.0"
+PKG_SHA256="45e3920d264d5c2cc3bfaec0e5dbb66cffd549255e0aaaf38cd283918e35c8ba"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="3.4"
-PKG_SHA256="0e7b99390fc971b85b25c4eb4ffeee082717123cb9726d51cec9481b621f6723"
+PKG_VERSION="3.5"
+PKG_SHA256="19f128d924b206f5fcaac34b41f4a001f6e21caa356179321ebe01849790e134"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"

--- a/packages/sysutils/kmod/package.mk
+++ b/packages/sysutils/kmod/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 
 PKG_NAME="kmod"
-PKG_VERSION="34.1"
-PKG_SHA256="125957c9125fc5db1bd6a2641a1c9a6a0b500882fb8ccf7fb6483fcae5309b17"
+PKG_VERSION="34.2"
+PKG_SHA256="5a5d5073070cc7e0c7a7a3c6ec2a0e1780850c8b47b3e3892226b93ffcb9cb54"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
 PKG_URL="https://www.kernel.org/pub/linux/utils/kernel/kmod/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.7.0"
-PKG_SHA256="25df13dd2819e85fb27a1ce0431772b7047d72af81ae78dc26b4c6e0805f48d1"
+PKG_VERSION="2.7.1"
+PKG_SHA256="354552544b8f99012e5062f7d570ec77f14b412a3ff5c7d8d0dae62c0d217c30"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libexpat.github.io"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.13.6"
-PKG_SHA256="c8ec960e907b851be3fa83313c548e84ccce9a9f71d6ae2dabab93815f0c653b"
+PKG_VERSION="2.14.0"
+PKG_SHA256="4884b61038ea5e3bb9163ad86a08b36667b5bb6b1f44e2d65e2f35ee7a2bcec2"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"

--- a/packages/textproc/xmlstarlet/patches/xmlstarlet-0900-fix-compile-with-libxml-2-14-0.patch
+++ b/packages/textproc/xmlstarlet/patches/xmlstarlet-0900-fix-compile-with-libxml-2-14-0.patch
@@ -1,0 +1,26 @@
+From 10684eea54a2c3b0b3738dfd8d70014f54e8e282 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 29 Mar 2025 02:23:34 +1100
+Subject: [PATCH] Fix build with libxml2-2.14.0
+
+---
+ src/xml_pyx.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/xml_pyx.c b/src/xml_pyx.c
+index ab295f12..e5ec64f1 100644
+--- a/src/xml_pyx.c
++++ b/src/xml_pyx.c
+@@ -21,6 +21,12 @@
+ 
+ #include "xmlstar.h"
+ 
++#if __GNUC__ * 100 + __GNUC_MINOR__ >= 207
++  #define ATTRIBUTE_UNUSED __attribute__((unused))
++#else
++  #define ATTRIBUTE_UNUSED
++#endif
++
+ /**
+  *  Output newline and tab characters as escapes
+  *  Required both for attribute values and character data (#PCDATA)

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qemu"
-PKG_VERSION="9.2.2"
-PKG_SHA256="752eaeeb772923a73d536b231e05bcc09c9b1f51690a41ad9973d900e4ec9fbf"
+PKG_VERSION="9.2.3"
+PKG_SHA256="baed494270c361bf69816acc84512e3efed71c7a23f76691642b80bc3de7693e"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.qemu.org"
 PKG_URL="https://download.qemu.org/qemu-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- qemu: update to 9.2.3
- jasper: update to 4.2.5
- iwd: update to 3.5
- spirv-tools: update to githash f289d04
- spirv-headers: update to githash 09913f0
- glslang: update to 15.2.0
- mimalloc: update to 3.0.3
- at-spi2-core: update to 2.56.1
- xmlstarlet: fix compile with libxml 2.14.0
- libxml2: update to 2.14.0
- kmod: update to 34.2
- tbb: update to 2022.1.0
- expat: update to 2.7.1