### PR TITLE
CMake update to 4.x

### DIFF
--- a/packages/addons/service/mariadb/patches/mariadb-246-build-with-cmake-4.0.0.patch
+++ b/packages/addons/service/mariadb/patches/mariadb-246-build-with-cmake-4.0.0.patch
@@ -1,0 +1,22 @@
+From 2abb5e794fdaf6114d4691f7921ec7bda2902603 Mon Sep 17 00:00:00 2001
+From: fundawang <fundawang@yeah.net>
+Date: Sat, 22 Mar 2025 23:08:46 +0800
+Subject: [PATCH] Update cmake minimum version range
+
+---
+ wsrep-lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wsrep-lib/CMakeLists.txt b/wsrep-lib/CMakeLists.txt
+index ef2f4c8b..b6dd69f1 100644
+--- a/wsrep-lib/CMakeLists.txt
++++ b/wsrep-lib/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Copyright (C) 2021 Codership Oy <info@codership.com>
+ #
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 2.8...4.0)
+ 
+ # Parse version from version header file and store it into
+ # WSREP_LIB_VERSION.

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="3.31.6"
-PKG_SHA256="653427f0f5014750aafff22727fb2aa60c6c732ca91808cfb78ce22ddd9e55f0"
+PKG_VERSION="4.0.1"
+PKG_SHA256="d630a7e00e63e520b25259f83d425ef783b4661bdc8f47e21c7f23f3780a21e1"
 PKG_LICENSE="BSD"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
~This is a draft tracking pr with all the required patches/changes (except hyperhdr) to build LE and addons with cmake-4.0.0 on x86_64. Some of these patches will be separated out to be merged directly (especially the local patches for the unmaintained / local fixes.)~

~The build is wip to test build on other targets.~

~It is expected that some of these patches will be incorporated in package updates, depending on upstream release schedules.~

- Fixes #9916
- first group of changes #9937
- Second group of change #9964