### PR TITLE
kodi: update to githash c45a28a

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="32993285404dd1dcb69e2655b7ceb8cc5f323c22"
-PKG_SHA256="f7a19c05184a36ea6d54a6bef969fa6a930f1f2fa5d33b8d56f85d233bc275b0"
+PKG_VERSION="c45a28aef18e30c9e289b378ed9ece6b692b97a7"
+PKG_SHA256="1b52f86f0c632d448456087e4193da837f3c8a4e74106609c4bf3b07d64245da"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/32993285404dd1dcb69e2655b7ceb8cc5f323c22...c45a28aef18e30c9e289b378ed9ece6b692b97a7

```
=== tested on ===
Generic.x86_64-devel-20250329124642-bf12261
Linux nuc12 6.14.0 #1 SMP Sat Mar 29 12:55:10 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:c45a28aef18e30c9e289b378ed9ece6b692b97a7). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-03-29 by GCC 15.0.1 for Linux x86 64-bit version 6.14.0 (396800)
Running on LibreELEC (heitbaum): devel-20250329124642-bf12261 13.0, kernel: Linux x86 64-bit version 6.14.0
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.2
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.1.4 (bf122612d5)
```