### PR TITLE
u-boot: update to 2025.04

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="u-boot"
-PKG_VERSION="2025.01"
-PKG_SHA256="cdef7d507c93f1bbd9f015ea9bc21fa074268481405501945abc6f854d5b686f"
+PKG_VERSION="2025.04"
+PKG_SHA256="439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.denx.de/wiki/U-Boot"


### PR DESCRIPTION
- u-boot: update to 2025.04

Notes:
- Qualcomm still does not build No valid dtbs found

All builds 2025.04 successful apart from afore mentioned Qualcomm
```

LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-orangepi-win.img.gz
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-orangepi-win.img.gz.sha256
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64.img.gz
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64.img.gz.sha256
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64-lts.img.gz
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64-lts.img.gz.sha256
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64-plus.img.gz
LibreELEC-A64.aarch64-13.0-devel-20250408180000-c603035-pine64-plus.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-alta.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-alta.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m2-pro.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m2-pro.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m2s.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m2s.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m5.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-bananapi-m5.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-box.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-box.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim3.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim3.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim3l.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim3l.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-khadas-vim.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-lafrite.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-lafrite.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-lepotato.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-lepotato.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-nanopi-k2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-nanopi-k2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-c2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-c2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-c4.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-c4.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-hc4.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-hc4.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-n2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-odroid-n2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-radxa-zero2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-radxa-zero2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-radxa-zero.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-radxa-zero.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-solitude.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-solitude.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-wetek-core2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-wetek-core2.img.gz.sha256
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-wetek-play2.img.gz
LibreELEC-AMLGX.aarch64-13.0-devel-20250408134351-c603035-wetek-play2.img.gz.sha256
LibreELEC-Exynos.arm-13.0-devel-20250408170907-c603035-odroid-xu3.img.gz
LibreELEC-Exynos.arm-13.0-devel-20250408170907-c603035-odroid-xu3.img.gz.sha256
LibreELEC-Exynos.arm-13.0-devel-20250408170907-c603035-odroid-xu4.img.gz
LibreELEC-Exynos.arm-13.0-devel-20250408170907-c603035-odroid-xu4.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-bananapi-m2p.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-bananapi-m2p.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-beelink-x2.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-beelink-x2.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-libretech-h3.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-libretech-h3.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-nanopi-m1.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-nanopi-m1.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-2.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-2.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-pc.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-pc.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-pc-plus.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-pc-plus.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-plus2e.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-plus2e.img.gz.sha256
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-plus.img.gz
LibreELEC-H3.arm-13.0-devel-20250408185633-c603035-orangepi-plus.img.gz.sha256
LibreELEC-H5.aarch64-13.0-devel-20250408195108-c603035-orangepi-pc2.img.gz
LibreELEC-H5.aarch64-13.0-devel-20250408195108-c603035-orangepi-pc2.img.gz.sha256
LibreELEC-H5.aarch64-13.0-devel-20250408195108-c603035-tritium-h5.img.gz
LibreELEC-H5.aarch64-13.0-devel-20250408195108-c603035-tritium-h5.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-beelink-gs1.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-beelink-gs1.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-3.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-3.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-3-lts.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-3-lts.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-lite2.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-lite2.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-one-plus.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-orangepi-one-plus.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-pine-h64.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-pine-h64.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-pine-h64-model-b.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-pine-h64-model-b.img.gz.sha256
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-tanix-tx6.img.gz
LibreELEC-H6.aarch64-13.0-devel-20250408124045-c603035-tanix-tx6.img.gz.sha256
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-cubox.img.gz
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-cubox.img.gz.sha256
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-udoo.img.gz
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-udoo.img.gz.sha256
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-wandboard.img.gz
LibreELEC-iMX6.arm-13.0-devel-20250408143131-c603035-wandboard.img.gz.sha256
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-mq-evk.img.gz
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-mq-evk.img.gz.sha256
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-phanbell.img.gz
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-phanbell.img.gz.sha256
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-pico-mq.img.gz
LibreELEC-iMX8.aarch64-13.0-devel-20250408152225-c603035-pico-mq.img.gz.sha256
LibreELEC-RK3288.arm-13.0-devel-20250408204657-c603035-miqi.img.gz
LibreELEC-RK3288.arm-13.0-devel-20250408204657-c603035-miqi.img.gz.sha256
LibreELEC-RK3288.arm-13.0-devel-20250408204657-c603035-tinker.img.gz
LibreELEC-RK3288.arm-13.0-devel-20250408204657-c603035-tinker.img.gz.sha256
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-a1.img.gz
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-a1.img.gz.sha256
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-roc-cc.img.gz
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-roc-cc.img.gz.sha256
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-rock64.img.gz
LibreELEC-RK3328.aarch64-13.0-devel-20250408212827-c603035-rock64.img.gz.sha256
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-hugsun-x99.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-khadas-edge.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-nanopc-t4.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-nanopi-m4.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-orangepi.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rock-4c-plus.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rock960.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rock-pi-4.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rock-pi-4-plus.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rock-pi-n10.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-rockpro64.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-roc-pc.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-roc-pc-plus.img.gz
LibreELEC-RK3399.aarch64-13.0-devel-20250408222509-c603035-sapphire.img.gz



``` 