### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/service/mariadb/patches/mariadb-0003-build-with-libxml2-2-14-0.patch
+++ b/packages/addons/service/mariadb/patches/mariadb-0003-build-with-libxml2-2-14-0.patch
@@ -1,0 +1,11 @@
+--- a/storage/connect/plgxml.h	2025-02-12 10:13:23.000000000 +0000
++++ b/storage/connect/plgxml.h	2025-03-30 13:35:43.002151245 +0000
+@@ -5,7 +5,7 @@
+ /******************************************************************/
+ /*  Dual XML implementation base classes defines.                 */
+ /******************************************************************/
+-#if !defined(BASE_BUFFER_SIZE)
++#if !defined(__XML_TREE_H__)
+ enum ElementType {               // libxml2
+      XML_ELEMENT_NODE       =  1,
+      XML_ATTRIBUTE_NODE     =  2,

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.45"
-PKG_SHA256="12d4c4f2b967faf6c982293e3200aed1808b44160ad414c8aa4cccdf9b06d047"
-PKG_REV="10"
+PKG_VERSION="1.3.47"
+PKG_SHA256="a51392a851d235362ca2a8fbe13809ed591d97e6583fe7fdc3e4101b02c3dcbd"
+PKG_REV="11"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.24.1"
-PKG_SHA256="b0920be6c63e3b857242ed168f29c3eee077f450a9f82bb9ff65f39fa587c8e8"
-PKG_REV="4"
+PKG_VERSION="0.24.2"
+PKG_SHA256="d69251fdd15bbd8fbcd1c486dd4dc6a4e008e045975b2408cb2f37461c10f1e4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"

--- a/packages/addons/tools/btrfs-progs/package.mk
+++ b/packages/addons/tools/btrfs-progs/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="btrfs-progs"
-PKG_VERSION="6.13"
-PKG_SHA256="8d6419856a7bc6ec23b622818238858172cdf6c3679d6c4a3d7732fc83535406"
-PKG_REV="3"
+PKG_VERSION="6.14"
+PKG_SHA256="5a85b791f0f32a4994e864ac4cb7abccce08e56db3010a1855ad0edeebc70b4c"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://btrfs.readthedocs.io/"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.dumb/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.dumb"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="d2ef04e80645f0bd1c9d31c9633d2a27d1757198fbcd2d43d00c84889e6ae585"
-PKG_REV="8"
+PKG_VERSION="6adb3bff0d0ba4fb35a6d38d598a7e7a9dd3e0da"
+PKG_SHA256="716f99fe1c655abf6c0cd2fbd37932b8446aba3107944a272d872319afebf197"
+PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.dumb"


### PR DESCRIPTION
- minisatip: update to 1.3.47 and addon (11)
- audiodecoder.dumb: update to githash 6adb3bf (Piers 22.0.0+)
- mpd: update to 0.24.2 and addon (5)
- btrfs-progs: update to 6.14 and addon (4)
- mariadb: build with libxml2-2.14.0