### PR TITLE
[le12] linux (RPi): backport RPI5 HEVC zoom fix

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="08d4e8f52256bd422d8a1f876411603f627d0a82" # 6.6.78
-    PKG_SHA256="6db6a1dd14cb2a6be48c1727e30fcf896b7349671135faeae09ce2cf2f952c60"
+    PKG_VERSION="bba53a117a4a5c29da892962332ff1605990e17a" # 6.6.78
+    PKG_SHA256="901dbc05b56e519d1f0beaefa83dac4a8d915e5b5f85190fd1adda640c345287"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default"
     ;;
   raspberrypi)
-    PKG_VERSION="9afba138031d6ee69824935b507cc9339427ddaf" # 6.6.78
-    PKG_SHA256="61928e06851b9955e9b63523a4847ce1f942fb506d9cf2a2d2601a0cc6cf7b51"
+    PKG_VERSION="08d4e8f52256bd422d8a1f876411603f627d0a82" # 6.6.78
+    PKG_SHA256="6db6a1dd14cb2a6be48c1727e30fcf896b7349671135faeae09ce2cf2f952c60"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;

--- a/packages/linux/patches/raspberrypi/linux-001-backport-pr6741-rpi5-sand-fixes.patch
+++ b/packages/linux/patches/raspberrypi/linux-001-backport-pr6741-rpi5-sand-fixes.patch
@@ -1,0 +1,130 @@
+From 7ac0b48fa963cbc7e8b1f3702a4ae8d1947e65a2 Mon Sep 17 00:00:00 2001
+From: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Date: Tue, 25 Mar 2025 16:02:24 +0000
+Subject: [PATCH 1/2] drm/vc4: plane: Correct SAND30 word sizing for cropping
+ on BCM2712
+
+BCM2712/vc6 uses 256bit words when reading in P030/SAND128,
+increased from 128bit on BCM2711/vc5.
+
+Update the code for cropping the read area to handle the correct
+word length.
+
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+---
+ drivers/gpu/drm/vc4/vc4_plane.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_plane.c b/drivers/gpu/drm/vc4/vc4_plane.c
+index fdd6ba310324..f1333d89cd92 100644
+--- a/drivers/gpu/drm/vc4/vc4_plane.c
++++ b/drivers/gpu/drm/vc4/vc4_plane.c
+@@ -1934,18 +1934,18 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
+ 
+ 			if (fb->format->format == DRM_FORMAT_P030) {
+ 				/*
+-				 * Spec says: bits [31:4] of the given address
+-				 * should point to the 128-bit word containing
+-				 * the desired starting pixel, and bits[3:0]
+-				 * should be between 0 and 11, indicating which
+-				 * of the 12-pixels in that 128-bit word is the
++				 * Spec says: bits [31:5] of the given address
++				 * should point to the 256-bit word containing
++				 * the desired starting pixel, and bits[4:0]
++				 * should be between 0 and 23, indicating which
++				 * of the 24-pixels in that 256-bit word is the
+ 				 * first pixel to be used
+ 				 */
+ 				u32 remaining_pixels = src_x % 96;
+-				u32 aligned = remaining_pixels / 12;
+-				u32 last_bits = remaining_pixels % 12;
++				u32 aligned = remaining_pixels / 24;
++				u32 last_bits = remaining_pixels % 24;
+ 
+-				x_off = aligned * 16 + last_bits;
++				x_off = aligned * 32 + last_bits;
+ 				tile_w = 128;
+ 				pix_per_tile = 96;
+ 			} else {
+-- 
+2.39.5
+
+
+From 3064adb25c5af41920f62d80dabf47a252b233a0 Mon Sep 17 00:00:00 2001
+From: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Date: Mon, 31 Mar 2025 17:03:40 +0100
+Subject: [PATCH 2/2] drm/vc4: plane: Ensure fetch_count is sufficient for hw
+ in SAND mode
+
+The number of words to fetch for SAND formats on vc6 needs to account
+for all pixels requested by width.
+
+If cropping fractional pixels, then the width was being increased, but
+fetch_count had already been computed. That led to insufficient words
+being fetched, and the HVS locked up solid.
+
+Apply the fixup for fractional pixel source cropping before computing
+fetch_count.
+
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+---
+ drivers/gpu/drm/vc4/vc4_plane.c | 36 ++++++++++++++++-----------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/gpu/drm/vc4/vc4_plane.c b/drivers/gpu/drm/vc4/vc4_plane.c
+index f1333d89cd92..7a203a702c22 100644
+--- a/drivers/gpu/drm/vc4/vc4_plane.c
++++ b/drivers/gpu/drm/vc4/vc4_plane.c
+@@ -1874,6 +1874,24 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
+ 
+ 	src_x = vc4_state->src_x >> 16;
+ 
++	/* fetch an extra pixel if we don't actually line up with the left edge. */
++	if ((vc4_state->src_x & 0xffff) && vc4_state->src_x < (state->fb->width << 16))
++		width++;
++
++	/* same for the right side */
++	if (((vc4_state->src_x + vc4_state->src_w[0]) & 0xffff) &&
++	    vc4_state->src_x + vc4_state->src_w[0] < (state->fb->width << 16))
++		width++;
++
++	/* now for the top */
++	if ((vc4_state->src_y & 0xffff) && vc4_state->src_y < (state->fb->height << 16))
++		height++;
++
++	/* and the bottom */
++	if (((vc4_state->src_y + vc4_state->src_h[0]) & 0xffff) &&
++	    vc4_state->src_y + vc4_state->src_h[0] < (state->fb->height << 16))
++		height++;
++
+ 	switch (base_format_mod) {
+ 	case DRM_FORMAT_MOD_LINEAR:
+ 		tiling = SCALER6_CTL0_ADDR_MODE_LINEAR;
+@@ -1988,24 +2006,6 @@ static int vc6_plane_mode_set(struct drm_plane *plane,
+ 		return -EINVAL;
+ 	}
+ 
+-	/* fetch an extra pixel if we don't actually line up with the left edge. */
+-	if ((vc4_state->src_x & 0xffff) && vc4_state->src_x < (state->fb->width << 16))
+-		width++;
+-
+-	/* same for the right side */
+-	if (((vc4_state->src_x + vc4_state->src_w[0]) & 0xffff) &&
+-	    vc4_state->src_x + vc4_state->src_w[0] < (state->fb->width << 16))
+-		width++;
+-
+-	/* now for the top */
+-	if ((vc4_state->src_y & 0xffff) && vc4_state->src_y < (state->fb->height << 16))
+-		height++;
+-
+-	/* and the bottom */
+-	if (((vc4_state->src_y + vc4_state->src_h[0]) & 0xffff) &&
+-	    vc4_state->src_y + vc4_state->src_h[0] < (state->fb->height << 16))
+-		height++;
+-
+ 	/* for YUV444 hardware wants double the width, otherwise it doesn't
+ 	 * fetch full width of chroma
+ 	 */
+-- 
+2.39.5
+

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="89191fad6cc2ce8776f028fcf2dbcf50b7ffd595"
-PKG_SHA256="814da755cb14178a0be6a8d2a135f8ad4e9bbef210b4e86a943e6c4b33b378bc"
+PKG_VERSION="80f23d4be56a481938b0239d565f46c94b1f2dd4"
+PKG_SHA256="b3db446e8c63df06a06f39ea05a4413763a6c13dd84962b67dac3c089cce4d96"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="9995946dce284505d3dd46c7563d74a691f38a70"
-PKG_SHA256="b85fd1c08308f8d6d66c82e6c8deb533291028b9c3f7d85092a6ed208db4920c"
+PKG_VERSION="89191fad6cc2ce8776f028fcf2dbcf50b7ffd595"
+PKG_SHA256="814da755cb14178a0be6a8d2a135f8ad4e9bbef210b4e86a943e6c4b33b378bc"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="80f23d4be56a481938b0239d565f46c94b1f2dd4"
-PKG_SHA256="b3db446e8c63df06a06f39ea05a4413763a6c13dd84962b67dac3c089cce4d96"
+PKG_VERSION="d828cc856bc81901a2a3fe5e1ad6231e72f21c97"
+PKG_SHA256="2e4f1b76113855ddf75cf45322e740c33070c85430dccecf75f9d79cbdf1de7e"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="78d08e9763079c6608506e25eefeee5ceb0ceabc"
-PKG_SHA256="9ad6613d74063f2ec2b5d9605479cf60b9ed2c583191b5dad25041a374dcaa8b"
+PKG_VERSION="6c2e2d6833df14134463ea8968151f031950a21e"
+PKG_SHA256="74dc46174620ee56ab83b42c2662a679efad80c66ecd38428d21b11a0bbe080e"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="3a16bd016f533877079c3bfad188539abd31fb8a"
-PKG_SHA256="c833aeeaa7fcae516c2971b5084b479a62b8c1e348a380cf76e3b8d1dfe82a78"
+PKG_VERSION="d50b2b32f162292ab6e235932075ce00bddda4ae"
+PKG_SHA256="bf52955a5c4f9fd02caed02f6e7ee2359d79d30938c19118b3414103f55df676"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="6c2e2d6833df14134463ea8968151f031950a21e"
-PKG_SHA256="74dc46174620ee56ab83b42c2662a679efad80c66ecd38428d21b11a0bbe080e"
+PKG_VERSION="7f66ffe483698e788858fe51000217849fa6331f"
+PKG_SHA256="f2eb730acf53c11a3f765ca72d3d9dcaa7399372f31f6a4d37db15f39d48e2d3"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="50d7bfcf8273816262ac85711bc579bfa5f90df0"
-PKG_SHA256="5c53c658c6b2ea4ac8752713c549b1c32f7ae23dad73f71772096487e5a60c78"
+PKG_VERSION="3a16bd016f533877079c3bfad188539abd31fb8a"
+PKG_SHA256="c833aeeaa7fcae516c2971b5084b479a62b8c1e348a380cf76e3b8d1dfe82a78"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="d50b2b32f162292ab6e235932075ce00bddda4ae"
-PKG_SHA256="bf52955a5c4f9fd02caed02f6e7ee2359d79d30938c19118b3414103f55df676"
+PKG_VERSION="78d08e9763079c6608506e25eefeee5ceb0ceabc"
+PKG_SHA256="9ad6613d74063f2ec2b5d9605479cf60b9ed2c583191b5dad25041a374dcaa8b"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Runtime tested on RPi5, zooming HEVC videos works fine now.
