### PR TITLE
CMake patches and fix for unmaintained packages to build with cmake 4.0.0

### DIFF
--- a/packages/addons/service/hyperion/patches/hyperion-0002-build-with-cmake-4.0.0.patch
+++ b/packages/addons/service/hyperion/patches/hyperion-0002-build-with-cmake-4.0.0.patch
@@ -1,0 +1,112 @@
+From f4dc444284ffb941c202610e8e60af37d1a5b99c Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 31 Mar 2025 03:39:43 +0000
+Subject: [PATCH] CMakeLists.txt: update to build with cmake 4.0.0
+
+---
+ CMakeLists.txt                          | 7 +------
+ src/hyperion-aml/CMakeLists.txt         | 2 +-
+ src/hyperion-dispmanx/CMakeLists.txt    | 2 +-
+ src/hyperion-framebuffer/CMakeLists.txt | 2 +-
+ src/hyperion-osx/CMakeLists.txt         | 2 +-
+ src/hyperion-remote/CMakeLists.txt      | 2 +-
+ src/hyperion-v4l2/CMakeLists.txt        | 2 +-
+ src/hyperion-x11/CMakeLists.txt         | 2 +-
+ 8 files changed, 8 insertions(+), 13 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb05792..3245063 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,12 +2,7 @@
+ project(hyperion)
+ 
+ # define the minimum cmake version (as required by cmake)
+-cmake_minimum_required(VERSION 2.8)
+-
+-IF ( POLICY CMP0026 )
+-	CMAKE_POLICY( SET CMP0026 OLD )
+-ENDIF()
+-
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ SET ( DEFAULT_AMLOGIC    OFF )
+ SET ( DEFAULT_DISPMANX   OFF )
+diff --git a/src/hyperion-aml/CMakeLists.txt b/src/hyperion-aml/CMakeLists.txt
+index 492c1ac..b63f5d6 100644
+--- a/src/hyperion-aml/CMakeLists.txt
++++ b/src/hyperion-aml/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Configure minimum CMAKE version
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ # Set the project name
+ project(hyperion-aml)
+diff --git a/src/hyperion-dispmanx/CMakeLists.txt b/src/hyperion-dispmanx/CMakeLists.txt
+index 987c37d..bbc9aaa 100644
+--- a/src/hyperion-dispmanx/CMakeLists.txt
++++ b/src/hyperion-dispmanx/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Configure minimum CMAKE version
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ # Set the project name
+ project(hyperion-dispmanx)
+diff --git a/src/hyperion-framebuffer/CMakeLists.txt b/src/hyperion-framebuffer/CMakeLists.txt
+index e9056b5..508cc97 100644
+--- a/src/hyperion-framebuffer/CMakeLists.txt
++++ b/src/hyperion-framebuffer/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Configure minimum CMAKE version
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ # Set the project name
+ project(hyperion-framebuffer)
+diff --git a/src/hyperion-osx/CMakeLists.txt b/src/hyperion-osx/CMakeLists.txt
+index c492de6..c18afb1 100644
+--- a/src/hyperion-osx/CMakeLists.txt
++++ b/src/hyperion-osx/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Configure minimum CMAKE version
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ # Set the project name
+ project(hyperion-osx)
+diff --git a/src/hyperion-remote/CMakeLists.txt b/src/hyperion-remote/CMakeLists.txt
+index 6af8fd0..a8885b9 100644
+--- a/src/hyperion-remote/CMakeLists.txt
++++ b/src/hyperion-remote/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ project(hyperion-remote)
+ 
+diff --git a/src/hyperion-v4l2/CMakeLists.txt b/src/hyperion-v4l2/CMakeLists.txt
+index 1c09746..33dd295 100644
+--- a/src/hyperion-v4l2/CMakeLists.txt
++++ b/src/hyperion-v4l2/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ project(hyperion-v4l2)
+ 
+diff --git a/src/hyperion-x11/CMakeLists.txt b/src/hyperion-x11/CMakeLists.txt
+index 6ddbe5d..e1dde89 100644
+--- a/src/hyperion-x11/CMakeLists.txt
++++ b/src/hyperion-x11/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # Configure minimum CMAKE version
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ # Set the project name
+ project(hyperion-x11)
+-- 
+2.43.0
+

--- a/packages/audio/soxr/patches/soxr-0001-build-with-cmake-4.0.0.patch
+++ b/packages/audio/soxr/patches/soxr-0001-build-with-cmake-4.0.0.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2018-02-23 21:39:25.000000000 +0000
++++ b/CMakeLists.txt	2025-03-28 00:22:35.418513539 +0000
+@@ -1,7 +1,7 @@
+ # SoX Resampler Library       Copyright (c) 2007-18 robs@users.sourceforge.net
+ # Licence for this file: LGPL v2.1                  See LICENCE for details.
+ 
+-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
++cmake_minimum_required (VERSION 3.1...3.10 FATAL_ERROR)
+ 
+ project (soxr C)
+ set (DESCRIPTION_SUMMARY

--- a/packages/emulation/rcheevos/source/CMakeLists.txt
+++ b/packages/emulation/rcheevos/source/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(rcheevos)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 # Disable Lua for now
 add_definitions(-DRC_DISABLE_LUA)

--- a/packages/mediacenter/p8-platform/patches/p8-platform-03-build-with-cmake-4.0.0.patch
+++ b/packages/mediacenter/p8-platform/patches/p8-platform-03-build-with-cmake-4.0.0.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2025-03-28 00:26:02.527981499 +0000
++++ b/CMakeLists.txt	2025-03-28 04:27:36.151280308 +0000
+@@ -1,6 +1,6 @@
+ project(p8-platform)
+ 
+-cmake_minimum_required(VERSION 2.8.9)
++cmake_minimum_required(VERSION 2.8.9...3.10)
+ enable_language(CXX)
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Patches and fix for downstream unmaintained packages. These have no upstream.
- p8-platform: allow build with cmake-4.0.0
- soxr: allow build with cmake-4.0.0
- hyperion: allow build with cmake-4.0.0
- rcheevos: fix build with cmake-4.0.0

future PRs will complete the build fixes for #9916 
- upstreamed patches accepted but not in the current release
- hopefully package update containing the submitted upstream pacthes
- and lastly patches yet to be accepted