### PR TITLE
Pillow: bump to 11.2.1

### DIFF
--- a/packages/python/graphics/Pillow/package.mk
+++ b/packages/python/graphics/Pillow/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Pillow"
-PKG_VERSION="11.2.0"
-PKG_SHA256="33f553388ca95f33a249298c4120ab541761ff15d6015cc7d6c12220ecc9875f"
+PKG_VERSION="11.2.1"
+PKG_SHA256="67dd6d40e282fd3b50189bd7f68a6e9b8e59b297d3684cb35ab107e7aec8379e"
 PKG_LICENSE="BSD"
 PKG_SITE="https://python-pillow.org/"
 PKG_URL="https://github.com/python-pillow/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Pillow 11.2.0 was pulled upstream due to a packaging issue and has been replaced by 11.2.1.