### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="22.0.3-Piers"
-PKG_SHA256="6bd4acb94b81eb9004a795822e6416639f167d2641a1f05eaa5f44b925794217"
-PKG_REV="2"
+PKG_VERSION="22.0.4-Piers"
+PKG_SHA256="bf73f524e7f53332a473799e719eebc7cb51352a26cd2d6ea68a86338d17c767"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="22.4.2-Piers"
-PKG_SHA256="40b2875e1c9f0daa57cf3adbbcaf9cb7a563c47f10d24453fe56e7aa83091f2d"
-PKG_REV="2"
+PKG_VERSION="22.5.0-Piers"
+PKG_SHA256="4ef7b560d7cfb0c0bc87e3360607f2571bf2965990b7a81972b9d94b11563094"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-pvr/pvr.iptvsimple"


### PR DESCRIPTION
- peripheral.joystick: update 22.0.3-Piers to 22.0.4-Piers
- pvr.iptvsimple: update 22.4.2-Piers to 22.5.0-Piers