### PR TITLE
kodi-binary-addons: sync up Nexus to Omega versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.asap/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.asap"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="9f54285866766b80d0d0c5210561678579d396591ab16cf70c83c4968bfbc8ba"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="3de7386ada364ad67531b0548f86f0827c81538168b34113a2115404a760a54c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.asap"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gme/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gme"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="5aaec959e92f4af2684aa0439576d7f576f28a0a43f50439a6f38d0738792bdc"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="2bf1fa5a11fe1ac86d02468bea9a30479a1a74261a4efd72b76b7cba62f75ddd"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gme"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.gsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.gsf"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="b09dcb379bdc536117a956b10b37cf50c8afaa65337993c44a6847d382d7e2a5"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="024bf9d270a84dc40b020678d8bb8404100a8e83bc59d1c60195e11448b1f13d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.gsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.modplug/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.modplug"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="619ba20ea19dd9aea15e7d30aa12a146b412c7fcd9e709528f6758e82a3d85e7"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="b2828685f1c353bf7123d0f9e88b28f53064388f6ea3ee357b8fb22d5c237ac8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.modplug"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ncsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.ncsf"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="31b25846a9b8213306456eb6f8ab8fdaeede5cad35627e77aff2c422f370b211"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="24492f4db00df298f819da1c903c536d0bfe5d2eb6164f81916cd8334b1e198b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ncsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.nosefart/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.nosefart"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="2f7a92bfaddcd5aa63e2ea7348ae9eeefd07dee2aba46840ce5376677e2abc19"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="4c82bf0ffab2d09f26b84d382fd00f70695d5f6a6d781be2818f9f5e10bc675a"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.nosefart"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.openmpt/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.openmpt"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="388fb4c9fcb5bd9edc978e3db5f54fa531c7f397393f3e421757e4e0de2d9c54"
-PKG_REV="11"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="33b69eb155babd9b595af1af3714a1a3cc51a10e931543b13e9950663d1ec402"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.openmpt"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.organya/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.organya"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="df5db2c94161c7c578d672a8cc36bdbde6c345142c9bb5212759ad0dc30fd59d"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="f85c59c581eed985d39746cd567318d36daed2f0d8475e6be2081a35c769bb7b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.organya"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.qsf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.qsf"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="3116bb31b3fe53b85675ba664a7a8d5885e157940a4bcf57b96050844b11a377"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="20a47a31546aae950d4dbfd1285aada32266aa318082514bf7bb7e324ac7be1d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.qsf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.sacd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.sacd"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="6d54f6cf81e13aadcec1b43689551feba6e9426453a758d955e96348ba996277"
-PKG_REV="7"
+PKG_VERSION="21.0.1-Omega"
+PKG_SHA256="a57863b9d37b41c087e2f71d2cf2675d7cd5d9920f5ad20f20092565be6df36f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.sacd"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.snesapu/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.snesapu"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="f216a7d25c864986618118236c575687ab62d129a16cb1f73c15860948d9ac92"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="98afd81a9653efd9c6fe69dd7918755c75a4671322b793a35bce610acac0d128"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.snesapu"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.ssf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.ssf"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="c2d5fbba35d2d73ed5891567d507f77bc64fa447dfcb4474f5d58594e9a07b2d"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="5d7272adf24db4e9806f0687abdc867804214f0af9160d16e1fcc0bdd6dc7f87"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.ssf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.stsound/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.stsound"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="a8138fb075a480c59d7041a9408eca6e52dc88f188daed519cd9e684b430f333"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="089ddd6c890e571f69eda0a85077d8ffe91c4b31fd0f9e20f47d4053c1e984a8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.stsound"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.timidity/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.timidity"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="ef1b384090df3c2c78d00ed33de1d989ce802702b0a9aa13575946409a5cd0f1"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="eb7bee9453825f86275ae05c4561fb52ee7fd9fa21857e303933cb57d28ccc4b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.timidity"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.upse/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.upse"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="d9f75e5cbab3ba5fc391cb40e0585bf22fad0eebfaf002d1d58bc896b6f2a5d6"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="f11c7e92d90fa18dc7a2d7ddc69e620ca9eaecb55ac5eac14fd10639c8869d09"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.upse"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.usf"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="3ce9ef8823c773d894fd0018455ea5000e9b5a64f3cd8d66ddb4cf8f6c9ea836"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="2322f1f1dbe03fa35a0a452e849033aac5f58b598907ac5c73dd64a56c4df74c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.usf"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.vgmstream/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.vgmstream"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="72367d7196f8049ef1fae426d32d3de1eac56bd4cb5a8fc38a6ba0c3da1b23d8"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="6f5dddc0e6161426b8c40bfd1136ca555588db27ae78c02178b6ac5da93b377c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.vgmstream"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.wsr/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audiodecoder.wsr"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="e8f8e06b61fbf612d59d689c38a6acade485aabae2382f3fbbedb0ce0c00048d"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="dd87fb43fe3355da87bba4aa87072b95952041b28d209921ac7a8ee29e25857f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.wsr"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.flac/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.flac"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="71daf8c35bbf644591600fef93412cd068a6bf6173d2258dc243ee04c8e5b091"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="2e7f21f4c42ac2c627ed381436d430a83f18ebc07cb92e91b6c98c4ff9528cc5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.flac"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.lame/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.lame"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="90f36ee0b4972669ed2876eae2502e58d86287aacdbf4bb25180aca01385e1c1"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="cf593053e7413f6790352ab3c2fcf227763a23c8e7a90381b46afdde3d92df7f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.lame"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.vorbis/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.vorbis"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="359e972ddcc498727620ff224a82f970fa2ae22b71ea6ab30b96898dffe6f1f9"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="5acd05c5e90459c1f07abe60c1df40f72ebcb3519287f104968c7cad17aca07d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.vorbis"

--- a/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audioencoder.wav/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="audioencoder.wav"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="1baf69cca688ebd389705ea2bef2c5285ba75dcfd0d0b534b6ab1e61c0020979"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="2bbc3e15706e02bbd3e6be3c232522e2091509a6fdf88d8af5db4cd6bf7b3476"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audioencoder.wav"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.heif"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="17f50aada11528c02db2ff3871a355c89709ab7e2a5e6b5e33957b790cf207ff"
-PKG_REV="11"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="ac4d6604400cccd16399be19ce0fa9129575cb933d8fb5ff4c76b57c3a39eeeb"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.mpo"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="a6f38f95e5e844f75365ae083ca0a78c012bb4dc670770b3dd5d99160a64187f"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="09c2466da38cc270051cd8c6df29b40628803ab4f17be5a2895c17e0e5c040b6"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.mpo"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asterwave"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="2c07219218fad17ef285577ff8309f7b6503302e52048d12ee20459dbcedf89c"
-PKG_REV="4"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="de92f8773f23c77f388201d316273f1a06103965bdb9684cbda19a73180c1488"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asterwave"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.matrixtrails"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="929af1a5a08399449497a13c2eb9761b4770b41445a13ee61d78b82677978ea5"
-PKG_REV="3"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="cc342d201606e682fc9def894a308784b74633f981209570c87d1bd206894311"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.matrixtrails"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.shadertoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.shadertoy"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="91500d2c4eb97390d77fbaf5700ee472c41afa30cb76c6ecbe7e2683a14795fc"
-PKG_REV="7"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="90ef1c38afcc6c2d03a06946148a3a87ec01b1ffb5c2bb794af46da0a1309d96"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.libarchive"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="06be9bfcda3e676e0757ea9602351d67f2bf0aa9aa9e408b14d947772a615e4f"
-PKG_REV="12"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="aab35cb6b03191609a7e97df02f2f102659c12e414f7b95595f9bb2047554daf"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.libarchive"

--- a/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.rar/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.rar"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="50870b24a3663f8d8d88802b327a8fd2fec441a9fed952baf71faba6854a8e1b"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="7492cf73d52299218acc982c4b35b020ea801d36d47e40460341f4dde712de50"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/vfs.rar"

--- a/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.sftp/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vfs.sftp"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="66f139d3d06c06d03ceccdcee12b79d3886bd0ea7aec662341736f1c9bdd63e2"
-PKG_REV="7"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="01a23958331cb0cd78fd2e9367d1269d4319c20b84db5b132632f9c1acd5f3c5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/xbmc/vfs.sftp"

--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.fishbmc"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="168788d7cd292edf9c13c0e0e0148f19b2ecd35edd8f65f24240dff99f01677a"
-PKG_REV="11"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="d7433e4e88e29f1dd3524d2d0b660ce529852561f14f479f4b83a9c5ac436ffc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.fishbmc"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.goom"
-PKG_VERSION="20.1.1-Nexus"
-PKG_SHA256="75102a8c3f066a889493b77fbe26070be78c6dff8e7d44ebda89295ddb2da3b0"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="f87356122f91ea40d096d559d1180571e701e39867448768d14d6c2ba3b2e264"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.goom"

--- a/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.matrix"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="f0b76edf45df7161d8525fa2ba623dee64ca66d515342e942100dc46c8220553"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="b1d1f3da5470d657e70c4b914a77445fe1d0a0ba35007fc402982a8b1b4cf9b0"
+PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.matrix"
 PKG_URL="https://github.com/xbmc/visualization.matrix/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.shadertoy"
-PKG_VERSION="20.3.0-Nexus"
-PKG_SHA256="2f97a34f74ee3e3e1d9fe8cfd37796564f8f88eb4c07d60b27ff635d64a5a724"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="30a5081365cea1dbdf49ccbb059076d4c7abc28604a58749fcd0d025e2faa760"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.spectrum"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="1c405ea9b6f43ba5f24df13ebce12cb428369279336deb97790917aa675c809f"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="7b6635789d226ee4cd4e17d54d57e880731d0762835802835d0d5ac4f0084b99"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.spectrum"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.starburst"
-PKG_VERSION="20.2.0-Nexus"
-PKG_SHA256="0d63b38ba8d5b3bac542546b1ecfb7d722b79652da485d75b22086e26ef4f825"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="a3f70985fee6b1014e7e7599431e646f36bd3870ead78bbc8936151b805e4241"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.starburst"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.waveform"
-PKG_VERSION="20.2.1-Nexus"
-PKG_SHA256="865e72a5f2ed8fd53469518280cbe26f9516467d091009fe5e012ea0d85d5edd"
-PKG_REV="9"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="fe6d2f3990ea5f2ea2d4a0a905f451b1c2c7f1300529d8957b5d93a97421f415"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.waveform"


### PR DESCRIPTION
Piers (master) https://github.com/xbmc/repo-binary-addons.git are still pointing at Nexus, update Nexus to Omega.

- audiodecoder.asap: update 20.3.0-Nexus to 21.0.2-Omega
- audiodecoder.gme: update 20.2.1-Nexus to 21.0.2-Omega
- audiodecoder.gsf: update 20.2.1-Nexus to 21.0.2-Omega
- audiodecoder.modplug: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.ncsf: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.nosefart: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.openmpt: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.organya: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.qsf: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.sacd: update 20.3.0-Nexus to 21.0.1-Omega
- audiodecoder.snesapu: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.ssf: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.stsound: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.timidity: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.upse: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.usf: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.vgmstream: update 20.2.0-Nexus to 21.0.2-Omega
- audiodecoder.wsr: update 20.2.0-Nexus to 21.0.2-Omega
- audioencoder.flac: update 20.2.0-Nexus to 21.0.2-Omega
- audioencoder.lame: update 20.3.0-Nexus to 21.0.2-Omega
- audioencoder.vorbis: update 20.2.0-Nexus to 21.0.2-Omega
- audioencoder.wav: update 20.2.0-Nexus to 21.0.2-Omega
- imagedecoder.heif: update 20.1.0-Nexus to 21.0.2-Omega
- imagedecoder.mpo: update 20.1.0-Nexus to 21.0.2-Omega
- screensaver.asterwave: update 20.2.0-Nexus to 21.0.2-Omega
- screensaver.matrixtrails: update 20.1.0-Nexus to 21.0.2-Omega
- screensaver.shadertoy: update 20.2.0-Nexus to 21.0.2-Omega
- vfs.libarchive: update 20.3.0-Nexus to 21.0.2-Omega
- vfs.rar: update 20.1.0-Nexus to 21.0.2-Omega
- vfs.sftp: update 20.2.0-Nexus to 21.0.2-Omega
- visualization.fishbmc: update 20.2.0-Nexus to 21.0.2-Omega
- visualization.goom: update 20.1.1-Nexus to 21.0.2-Omega
- visualization.matrix: update 20.2.0-Nexus to 21.0.2-Omega
- visualization.shadertoy: update 20.3.0-Nexus to 21.0.2-Omega
- visualization.spectrum: update 20.2.0-Nexus to 21.0.2-Omega
- visualization.starburst: update 20.2.0-Nexus to 21.0.2-Omega
- visualization.waveform: update 20.2.1-Nexus to 21.0.2-Omega