### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/fdupes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fdupes"
-PKG_VERSION="2.3.2"
-PKG_SHA256="808d8decbe7fa41cab407ae4b7c14bfc27b8cb62227540c3dcb6caf980592ac7"
+PKG_VERSION="2.4.0"
+PKG_SHA256="527b27a39d031dcbe1d29a220b3423228c28366c2412887eb72c25473d7b1736"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/adrianlopezroche/fdupes"
 PKG_URL="https://github.com/adrianlopezroche/fdupes/releases/download/v${PKG_VERSION}/fdupes-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/htop/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/htop/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="htop"
-PKG_VERSION="3.4.0"
-PKG_SHA256="7a45cd93b393eaa5804a7e490d58d0940b1c74bb24ecff2ae7b5c49e7a3c1198"
+PKG_VERSION="3.4.1"
+PKG_SHA256="af9ec878f831b7c27d33e775c668ec79d569aa781861c995a0fbadc1bdb666cf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://hisham.hm/htop"
 PKG_URL="https://github.com/htop-dev/htop/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.18.11"
-PKG_SHA256="f4388c4d4d53172431cd77e029139ddd0dacb249ef59053dbc1f0c42188e3e35"
+PKG_VERSION="0.18.12"
+PKG_SHA256="20401a5a52a3b3b5d84fbdd561e4daf1076b0368a1ccbbbc8d41af2be6ea6f34"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-iptv/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-iptv/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-iptv"
-PKG_VERSION="f7369c9578c1437c7a19cf11e21424844f42a341"
-PKG_SHA256="9045ec034182d19535ab3478152ef6a7fd2640478c78d697d2f2c93f11482316"
+PKG_VERSION="f80cd74389576abea552311bade45363247a1c32"
+PKG_SHA256="b26ac5b96f573cf405ad8a6f2fe81cced67c261fcb941f74a588f99fe2fef464"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.saunalahti.fi/~rahrenbe/vdr/iptv/"
-PKG_URL="https://github.com/rofafor/vdr-plugin-iptv/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/Zabrimus/vdr-plugin-iptv/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain vdr curl"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr)"
 PKG_LONGDESC="vdr-iptv is an IPTV plugin for the Video Disk Recorder (VDR)"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-vnsiserver/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-vnsiserver"
-PKG_VERSION="47a90dd9298753083a9a6482bb9990ea9a88aa7a"
-PKG_SHA256="cd8087306dc5d77b150ca9f77bba91460507dc9a2336b9f61ce13aeefecf23e3"
+PKG_VERSION="65bfc62b16ffd278f40eb35a749fb3d1f467e112"
+PKG_SHA256="e34533c0aed3f6e1dac3bfb608509df532089736ff04632d762438d796d339db"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/mdre77/vdr-plugin-vnsiserver"
-PKG_URL="https://github.com/mdre77/vdr-plugin-vnsiserver/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/vdr-projects/vdr-plugin-vnsiserver"
+PKG_URL="https://github.com/vdr-projects/vdr-plugin-vnsiserver/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain vdr"
 PKG_DEPENDS_UNPACK="vdr-plugin-wirbelscan"
 PKG_NEED_UNPACK="$(get_pkg_directory vdr) $(get_pkg_directory vdr-plugin-wirbelscan)"

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.7.4"
-PKG_SHA256="6e3d4fb34ec5072e3344f89f998f5dc0793b8d921f773e91c1737d0ad492fa11"
+PKG_VERSION="2.7.5"
+PKG_SHA256="e1f1c46f984dfcb4f1a00bf16010dcb863ffaaf31b87872bd90c7cf800129f99"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://git.tvdr.de/?p=vdr.git;a=snapshot;h=refs/tags/${PKG_VERSION};sf=tbz2"

--- a/packages/addons/service/hyperhdr/package.mk
+++ b/packages/addons/service/hyperhdr/package.mk
@@ -44,6 +44,7 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON \
                        -DUSE_STATIC_QT_PLUGINS=ON \
                        -DUSE_SYSTEM_FLATBUFFERS_LIBS=OFF \
                        -DFLATBUFFERS_FLATC_EXECUTABLE=${TOOLCHAIN}/bin/flatc \
+                       -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                        -Wno-dev"
 
 pre_configure_target() {

--- a/packages/addons/service/hyperion/patches/hyperion-0001-fix-build-with-python-313.patch
+++ b/packages/addons/service/hyperion/patches/hyperion-0001-fix-build-with-python-313.patch
@@ -1,0 +1,21 @@
+From 8647a93f99121084e8749982f6f8f56e254d815d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Dec 2024 11:18:31 +1100
+Subject: [PATCH] Remove PyEval_ReleaseLock();
+
+---
+ libsrc/effectengine/Effect.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libsrc/effectengine/Effect.cpp b/libsrc/effectengine/Effect.cpp
+index b89a36cb..a60c935a 100644
+--- a/libsrc/effectengine/Effect.cpp
++++ b/libsrc/effectengine/Effect.cpp
+@@ -120,7 +120,6 @@ void Effect::run()
+ 	// Clean up the thread state
+ 	Py_EndInterpreter(_interpreterThreadState);
+ 	_interpreterThreadState = nullptr;
+-	PyEval_ReleaseLock();
+ }
+ 
+ int Effect::getPriority() const

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.47"
-PKG_SHA256="a51392a851d235362ca2a8fbe13809ed591d97e6583fe7fdc3e4101b02c3dcbd"
-PKG_REV="0"
+PKG_VERSION="1.3.48"
+PKG_SHA256="fe77ca93cdd53023ad5c67c1a01c5a296c88e34f6761c46b3ab73e7a7abb6325"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.29.3"
-PKG_SHA256="cfbe9cc3a37deca1405e0cf92f12e57ca8767d50f193d52d00360522ae02d417"
-PKG_REV="0"
+PKG_VERSION="1.29.5"
+PKG_SHA256="17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.7.4"
-PKG_REV="0"
+PKG_VERSION="2.7.5"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/graphics/libraw/package.mk
+++ b/packages/graphics/libraw/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libraw"
-PKG_VERSION="0.21.3"
-PKG_SHA256="dba34b7fc1143503942fa32ad9db43e94f714e62a4a856e91617f8f3e1e0aa5c"
+PKG_VERSION="0.21.4"
+PKG_SHA256="6be43f19397e43214ff56aab056bf3ff4925ca14012ce5a1538a172406a09e63"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.libraw.org/"
 PKG_URL="https://www.libraw.org/data/LibRaw-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.raw"
-PKG_VERSION="20.1.0-Nexus"
-PKG_SHA256="6235c0be431bbb814b3e464753af9ad17febf6001f77cbf030e6c6e1cdc41a04"
-PKG_REV="10"
+PKG_VERSION="21.0.2-Omega"
+PKG_SHA256="421812f6ca8d70e6736c920935461b43f1338ee04a919dcf7e5f7ce1879b54e2"
+PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"


### PR DESCRIPTION
- vdr-addon: update to 2.7.5 and addon (1)
  - vdr: update to 2.7.5
  - vdr-plugin-vnsiserver: update to githash 65bfc62 on maintained fork
  - vdr-plugin-iptv: update to githash f80cd74 on maintained fork
- system-tools: update addon (1)
  - htop: update to 3.4.1
  - stress-ng: update to 0.18.12
  - fdupes: update to 2.4.0
- minisatip: update to 1.3.48 and addon (1)
- imagedecoder.raw: update to 21.0.2-Omega and addon (0)
  - libraw: update to 0.21.4
- syncthing: update to 1.29.5 and addon (1)

others:
- hyperhdr: use CMAKE_POLICY_VERSION_MINIMUM workaround to compile with cmake-4.0.0
- hyperion: fix build with Python 3.13