### PR TITLE
mesa: update to 25.1.0

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="25.0.5"
-PKG_SHA256="c0d245dea0aa4b49f74b3d474b16542e4a8799791cd33d676c69f650ad4378d0"
+PKG_VERSION="25.1.0"
+PKG_SHA256="b1c45888969ee5df997e2542654f735ab1b772924b442f3016d2293414c99c14"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
@@ -119,5 +119,5 @@ fi
 makeinstall_host() {
   mkdir -p "${TOOLCHAIN}/bin"
     cp -a src/compiler/clc/mesa_clc "${TOOLCHAIN}/bin"
-    cp -a src/compiler/spirv/vtn_bindgen "${TOOLCHAIN}/bin"
+    cp -a src/compiler/spirv/vtn_bindgen2 "${TOOLCHAIN}/bin"
 }


### PR DESCRIPTION
- https://docs.mesa3d.org/relnotes/25.1.0.html

```
=== tested on ===
Generic.x86_64-devel-20250508005225-fba6825
Linux nuc12 6.14.5 #1 SMP Thu May  8 00:57:55 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:264adc124d4770ffef0e3de5b11478077cfd4152). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-05-08 by GCC 15.1.0 for Linux x86 64-bit version 6.14.5 (396805)
Running on LibreELEC (heitbaum): devel-20250508005225-fba6825 13.0, kernel: Linux x86 64-bit version 6.14.5
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.0
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.1 (fba68257d6)
```