### PR TITLE
Patches required for LE to compile with gcc-15

### DIFF
--- a/packages/databases/mariadb-connector-c/patches/mariadb-connector-c-0001-fix-build-with-gcc-15.patch
+++ b/packages/databases/mariadb-connector-c/patches/mariadb-connector-c-0001-fix-build-with-gcc-15.patch
@@ -1,0 +1,21 @@
++++ a/include/ma_global.h	2024-11-22 10:01:02.006088573 +0000
++++ b/include/ma_global.h	2024-11-22 10:01:02.006088573 +0000
+@@ -684,7 +684,6 @@
+ typedef char		my_bool; /* Small bool */
+ typedef unsigned long long my_ulonglong;
+ #if !defined(bool) && !defined(bool_defined) && (!defined(HAVE_BOOL) || !defined(__cplusplus))
+-typedef char		bool;	/* Ordinary boolean values 0 1 */
+ #endif
+ 	/* Macros for converting *constants* to the right type */
+ #define INT8(v)		(int8) (v)
+--- a/libmariadb/ma_alloc.c	2024-11-22 10:08:46.473445080 +0000
++++ b/libmariadb/ma_alloc.c	2024-11-22 10:08:46.473445080 +0000
+@@ -170,7 +170,7 @@
+   va_list args;
+   char **ptr,*start,*res;
+   size_t tot_length,length;
+-
++if(myFlags){}
+   va_start(args,myFlags);
+   tot_length=0;
+   while ((ptr=va_arg(args, char **)))

--- a/packages/network/libtirpc/patches/libtirpc-0001-fix-build-with-gcc-15.patch
+++ b/packages/network/libtirpc/patches/libtirpc-0001-fix-build-with-gcc-15.patch
@@ -1,0 +1,35 @@
+--- a/src/auth_none.c	2024-11-20 09:02:12.504925593 +0000
++++ b/src/auth_none.c	2024-11-20 09:03:45.129971786 +0000
+@@ -62,7 +62,7 @@
+ static bool_t authnone_refresh (AUTH *, void *);
+ static void authnone_destroy (AUTH *);
+ 
+-extern bool_t xdr_opaque_auth();
++extern bool_t xdr_opaque_auth(XDR *, struct opaque_auth *);
+ 
+ static struct auth_ops *authnone_ops();
+ 
+--- a/src/svc_auth_none.c	2024-11-20 09:10:27.426038143 +0000
++++ b/src/svc_auth_none.c	2024-11-20 09:10:27.426038143 +0000
+@@ -37,8 +37,8 @@
+ 
+ #include <rpc/rpc.h>
+ 
+-static bool_t	svcauth_none_destroy();
+-static bool_t   svcauth_none_wrap();
++static bool_t	svcauth_none_destroy(SVCAUTH *);
++static bool_t   svcauth_none_wrap(SVCAUTH *, XDR *, bool_t (*)(XDR *, ...), char *);
+ 
+ struct svc_auth_ops svc_auth_none_ops = {
+ 	svcauth_none_wrap,
+--- a/src/getpublickey.c	2024-11-20 09:16:57.168954233 +0000
++++ b/src/getpublickey.c	2024-11-20 09:16:57.168954233 +0000
+@@ -52,7 +52,7 @@
+ /*
+  * Hack to let ypserv/rpc.nisd use AUTH_DES.
+  */
+-int (*__getpublickey_LOCAL)() = 0;
++int (*__getpublickey_LOCAL)(const char *, char *) = 0;
+ 
+ /*
+  * Get somebody's public key

--- a/packages/network/libtirpc/patches/libtirpc-0002-fix-build-with-gcc-15.patch
+++ b/packages/network/libtirpc/patches/libtirpc-0002-fix-build-with-gcc-15.patch
@@ -1,0 +1,35 @@
+--- libtirpc-1.3.6/src/auth_time.c	2024-10-17 07:50:55.000000000 +0000
++++ libtirpc-1.3.6/src/auth_time.c	2024-12-12 13:55:14.420375907 +0000
+@@ -248,7 +248,7 @@
+ 	char			ut[64], ipuaddr[64];
+ 	endpoint		teps[32];
+ 	nis_server		tsrv;
+-	void			(*oldsig)() = NULL; /* old alarm handler */
++	void			(*oldsig)(int) = NULL; /* old alarm handler */
+ 	struct sockaddr_in	sin;
+ 	int			s = RPC_ANYSOCK;
+ 	socklen_t len;
+@@ -417,7 +417,7 @@
+ 		} else {
+ 			int res;
+ 
+-			oldsig = (void (*)())signal(SIGALRM, alarm_hndler);
++			oldsig = (void (*)(int))signal(SIGALRM, alarm_hndler);
+ 			saw_alarm = 0; /* global tracking the alarm */
+ 			alarm(20); /* only wait 20 seconds */
+ 			res = connect(s, (struct sockaddr *)&sin, sizeof(sin));
+--- libtirpc-1.3.6/src/key_call.c	2024-10-17 07:50:55.000000000 +0000
++++ libtirpc-1.3.6/src/key_call.c	2024-12-12 13:49:15.720634534 +0000
+@@ -72,9 +72,9 @@
+  * implementations of these functions, and to call those in key_call().
+  */
+ 
+-cryptkeyres *(*__key_encryptsession_pk_LOCAL)() = 0;
+-cryptkeyres *(*__key_decryptsession_pk_LOCAL)() = 0;
+-des_block *(*__key_gendes_LOCAL)() = 0;
++cryptkeyres *(*__key_encryptsession_pk_LOCAL)(uid_t, char *) = 0;
++cryptkeyres *(*__key_decryptsession_pk_LOCAL)(uid_t, char *) = 0;
++des_block *(*__key_gendes_LOCAL)(uid_t, char *) = 0;
+ 
+ static int key_call( u_long, xdrproc_t, void *, xdrproc_t, void *);
+ 

--- a/packages/sysutils/parted/patches/parted-0001-fix-do_version-declaration.patch
+++ b/packages/sysutils/parted/patches/parted-0001-fix-do_version-declaration.patch
@@ -1,0 +1,40 @@
+From 7dae5d837562a494e14f69702601bcc2240cab3e Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 20 Nov 2024 12:17:07 +0000
+Subject: [PATCH] parted: fix do_version declaration
+
+With gcc 15-20241117 compile fails with the below error, update the
+do_version declaration to match the header in command.h
+
+../../parted/parted.c: In function '_init_commands':
+../../parted/parted.c:2469:9: error: passing argument 2 of 'command_create' from incompatible pointer type [-Wincompatible-pointer-types]
+ 2469 |         do_version,
+      |         ^~~~~~~~~~
+      |         |
+      |         int (*)(void)
+In file included from ../../parted/parted.c:28:
+../../parted/command.h:35:39: note: expected 'int (*)(PedDevice **, PedDisk **)' {aka 'int (*)(struct _PedDevice **, struct _PedDisk **)'} but argument is of type 'int (*)(void)'
+   35 |                                 int (*method) (PedDevice** dev, PedDisk** diskp),
+      |                                 ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+---
+ parted/parted.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/parted/parted.c b/parted/parted.c
+index 3abb52f..fc2aeba 100644
+--- a/parted/parted.c
++++ b/parted/parted.c
+@@ -2172,7 +2172,7 @@ do_unit (PedDevice** dev, PedDisk** diskp)
+ }
+ 
+ static int
+-do_version ()
++do_version (PedDevice** dev, PedDisk** diskp)
+ {
+     printf ("\n%s\n%s",
+             prog_name,
+-- 
+2.43.0
+

--- a/packages/tools/grub/patches/grub-0001-fix-build-with-gcc-15.patch
+++ b/packages/tools/grub/patches/grub-0001-fix-build-with-gcc-15.patch
@@ -1,0 +1,24 @@
+--- a/bootstrap.conf	2023-12-20 15:54:46.000000000 +0000
++++ b/bootstrap.conf	2025-04-19 04:54:21.402235320 +0000
+@@ -85,6 +85,7 @@
+   # changes to gnulib and update the hash above when they've merged.  Do not
+   # add new patches here.
+   patch -d grub-core/lib/gnulib -p2 < grub-core/lib/gnulib-patches/fix-width.patch
++  patch -d grub-core/lib/gnulib -p2 < grub-core/lib/gnulib-patches/fix-unterminated-string-initialization.patch
+ 
+   for patchname in \
+       0001-Support-POTFILES-shell \
+--- /dev/null	2025-04-18 22:05:54.154307831 +0000
++++ a/grub-core/lib/gnulib-patches/fix-unterminated-string-initialization.patch	2025-04-19 04:33:15.890395708 +0000
+@@ -0,0 +1,11 @@
++--- a/lib/base64.c	2025-04-19 04:11:46.591729777 +0000
+++++ b/lib/base64.c	2025-04-19 04:24:36.861877165 +0000
++@@ -61,7 +61,7 @@
++   return ch;
++ }
++ 
++-static const char b64c[64] =
+++static const char b64c[64] __attribute__((nonstring)) =
++   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
++ 
++ /* Base64 encode IN array of size INLEN into OUT array. OUT needs

--- a/packages/x11/driver/xf86-video-nvidia/patches/nvidia-kernel-ccflags-y-fix-linux-6.14.patch
+++ b/packages/x11/driver/xf86-video-nvidia/patches/nvidia-kernel-ccflags-y-fix-linux-6.14.patch
@@ -1,0 +1,235 @@
+diff -Naur nvidia-kmod-570.133.07-x86_64.old/kernel/Kbuild nvidia-kmod-570.133.07-x86_64/kernel/Kbuild
+--- nvidia-kmod-570.133.07-x86_64.old/kernel/Kbuild	2025-04-12 09:54:19.974786018 +0200
++++ nvidia-kmod-570.133.07-x86_64/kernel/Kbuild	2025-04-12 09:56:58.900332108 +0200
+@@ -74,22 +74,15 @@
+ $(foreach _module, $(NV_KERNEL_MODULES), \
+  $(eval include $(src)/$(_module)/$(_module).Kbuild))
+ 
+-
+-#
+-# Define CFLAGS that apply to all the NVIDIA kernel modules. EXTRA_CFLAGS
+-# is deprecated since 2.6.24 in favor of ccflags-y, but we need to support
+-# older kernels which do not have ccflags-y. Newer kernels append
+-# $(EXTRA_CFLAGS) to ccflags-y for compatibility.
+-#
+-
+-EXTRA_CFLAGS += -I$(src)/common/inc
+-EXTRA_CFLAGS += -I$(src)
+-EXTRA_CFLAGS += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-format-extra-args
+-EXTRA_CFLAGS += -D__KERNEL__ -DMODULE -DNVRM
+-EXTRA_CFLAGS += -DNV_VERSION_STRING=\"570.133.07\"
++ccflags-y += -std=gnu17
++ccflags-y += -I$(src)/common/inc
++ccflags-y += -I$(src)
++ccflags-y += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-format-extra-args
++ccflags-y += -D__KERNEL__ -DMODULE -DNVRM
++ccflags-y += -DNV_VERSION_STRING=\"570.133.07\"
+ 
+ ifneq ($(SYSSRCHOST1X),)
+- EXTRA_CFLAGS += -I$(SYSSRCHOST1X)
++ ccflags-y += -I$(SYSSRCHOST1X)
+ endif
+ 
+ # Some Android kernels prohibit driver use of filesystem functions like
+@@ -99,57 +92,57 @@
+ PLATFORM_IS_ANDROID ?= 0
+ 
+ ifeq ($(PLATFORM_IS_ANDROID),1)
+- EXTRA_CFLAGS += -DNV_FILESYSTEM_ACCESS_AVAILABLE=0
++ ccflags-y += -DNV_FILESYSTEM_ACCESS_AVAILABLE=0
+ else
+- EXTRA_CFLAGS += -DNV_FILESYSTEM_ACCESS_AVAILABLE=1
++ ccflags-y += -DNV_FILESYSTEM_ACCESS_AVAILABLE=1
+ endif
+ 
+-EXTRA_CFLAGS += -Wno-unused-function
++ccflags-y += -Wno-unused-function
+ 
+ ifneq ($(NV_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -Wuninitialized
++ ccflags-y += -Wuninitialized
+ endif
+ 
+-EXTRA_CFLAGS += -fno-strict-aliasing
++ccflags-y += -fno-strict-aliasing
+ 
+ ifeq ($(ARCH),arm64)
+- EXTRA_CFLAGS += -mstrict-align
++ ccflags-y += -mstrict-align
+ endif
+ 
+ ifeq ($(NV_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -g
++ ccflags-y += -g
+ endif
+ 
+-EXTRA_CFLAGS += -ffreestanding
++ccflags-y += -ffreestanding
+ 
+ ifeq ($(ARCH),arm64)
+- EXTRA_CFLAGS += -mgeneral-regs-only -march=armv8-a
+- EXTRA_CFLAGS += $(call cc-option,-mno-outline-atomics,)
++ ccflags-y += -mgeneral-regs-only -march=armv8-a
++ ccflags-y += $(call cc-option,-mno-outline-atomics,)
+ endif
+ 
+ ifeq ($(ARCH),x86_64)
+- EXTRA_CFLAGS += -mno-red-zone -mcmodel=kernel
++ ccflags-y += -mno-red-zone -mcmodel=kernel
+ endif
+ 
+ ifeq ($(ARCH),powerpc)
+- EXTRA_CFLAGS += -mlittle-endian -mno-strict-align
++ ccflags-y += -mlittle-endian -mno-strict-align
+ endif
+ 
+-EXTRA_CFLAGS += -DNV_UVM_ENABLE
+-EXTRA_CFLAGS += $(call cc-option,-Werror=undef,)
+-EXTRA_CFLAGS += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
+-EXTRA_CFLAGS += -DNV_KERNEL_INTERFACE_LAYER
++ccflags-y += -DNV_UVM_ENABLE
++ccflags-y += $(call cc-option,-Werror=undef,)
++ccflags-y += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
++ccflags-y += -DNV_KERNEL_INTERFACE_LAYER
+ 
+ #
+ # Detect SGI UV systems and apply system-specific optimizations.
+ #
+ 
+ ifneq ($(wildcard /proc/sgi_uv),)
+- EXTRA_CFLAGS += -DNV_CONFIG_X86_UV
++ ccflags-y += -DNV_CONFIG_X86_UV
+ endif
+ 
+ ifdef VGX_FORCE_VFIO_PCI_CORE
+- EXTRA_CFLAGS += -DNV_VGPU_FORCE_VFIO_PCI_CORE
++ ccflags-y += -DNV_VGPU_FORCE_VFIO_PCI_CORE
+ endif
+ 
+ WARNINGS_AS_ERRORS ?=
+@@ -183,7 +176,7 @@
+ 
+ NV_CFLAGS_FROM_CONFTEST := $(shell $(NV_CONFTEST_CMD) build_cflags)
+ 
+-NV_CONFTEST_CFLAGS = $(NV_CFLAGS_FROM_CONFTEST) $(EXTRA_CFLAGS) -fno-pie
++NV_CONFTEST_CFLAGS = $(NV_CFLAGS_FROM_CONFTEST) $(ccflags-y) -fno-pie
+ NV_CONFTEST_CFLAGS += $(call cc-disable-warning,pointer-sign)
+ NV_CONFTEST_CFLAGS += $(call cc-option,-fshort-wchar,)
+ NV_CONFTEST_CFLAGS += $(call cc-option,-Werror=incompatible-pointer-types,)
+diff -Naur nvidia-kmod-570.133.07-x86_64.old/kernel-open/Kbuild nvidia-kmod-570.133.07-x86_64/kernel-open/Kbuild
+--- nvidia-kmod-570.133.07-x86_64.old/kernel-open/Kbuild	2025-04-12 09:54:20.039786545 +0200
++++ nvidia-kmod-570.133.07-x86_64/kernel-open/Kbuild	2025-04-12 09:56:51.436478034 +0200
+@@ -75,21 +75,15 @@
+  $(eval include $(src)/$(_module)/$(_module).Kbuild))
+ 
+ 
+-#
+-# Define CFLAGS that apply to all the NVIDIA kernel modules. EXTRA_CFLAGS
+-# is deprecated since 2.6.24 in favor of ccflags-y, but we need to support
+-# older kernels which do not have ccflags-y. Newer kernels append
+-# $(EXTRA_CFLAGS) to ccflags-y for compatibility.
+-#
+-
+-EXTRA_CFLAGS += -I$(src)/common/inc
+-EXTRA_CFLAGS += -I$(src)
+-EXTRA_CFLAGS += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-format-extra-args
+-EXTRA_CFLAGS += -D__KERNEL__ -DMODULE -DNVRM
+-EXTRA_CFLAGS += -DNV_VERSION_STRING=\"570.133.07\"
++ccflags-y += -std=gnu17
++ccflags-y += -I$(src)/common/inc
++ccflags-y += -I$(src)
++ccflags-y += -Wall $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-format-extra-args
++ccflags-y += -D__KERNEL__ -DMODULE -DNVRM
++ccflags-y += -DNV_VERSION_STRING=\"570.133.07\"
+ 
+ ifneq ($(SYSSRCHOST1X),)
+- EXTRA_CFLAGS += -I$(SYSSRCHOST1X)
++ ccflags-y += -I$(SYSSRCHOST1X)
+ endif
+ 
+ # Some Android kernels prohibit driver use of filesystem functions like
+@@ -99,57 +93,57 @@
+ PLATFORM_IS_ANDROID ?= 0
+ 
+ ifeq ($(PLATFORM_IS_ANDROID),1)
+- EXTRA_CFLAGS += -DNV_FILESYSTEM_ACCESS_AVAILABLE=0
++ ccflags-y += -DNV_FILESYSTEM_ACCESS_AVAILABLE=0
+ else
+- EXTRA_CFLAGS += -DNV_FILESYSTEM_ACCESS_AVAILABLE=1
++ ccflags-y += -DNV_FILESYSTEM_ACCESS_AVAILABLE=1
+ endif
+ 
+-EXTRA_CFLAGS += -Wno-unused-function
++ccflags-y += -Wno-unused-function
+ 
+ ifneq ($(NV_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -Wuninitialized
++ ccflags-y += -Wuninitialized
+ endif
+ 
+-EXTRA_CFLAGS += -fno-strict-aliasing
++ccflags-y += -fno-strict-aliasing
+ 
+ ifeq ($(ARCH),arm64)
+- EXTRA_CFLAGS += -mstrict-align
++ ccflags-y += -mstrict-align
+ endif
+ 
+ ifeq ($(NV_BUILD_TYPE),debug)
+- EXTRA_CFLAGS += -g
++ ccflags-y += -g
+ endif
+ 
+-EXTRA_CFLAGS += -ffreestanding
++ccflags-y += -ffreestanding
+ 
+ ifeq ($(ARCH),arm64)
+- EXTRA_CFLAGS += -mgeneral-regs-only -march=armv8-a
+- EXTRA_CFLAGS += $(call cc-option,-mno-outline-atomics,)
++ ccflags-y += -mgeneral-regs-only -march=armv8-a
++ ccflags-y += $(call cc-option,-mno-outline-atomics,)
+ endif
+ 
+ ifeq ($(ARCH),x86_64)
+- EXTRA_CFLAGS += -mno-red-zone -mcmodel=kernel
++ ccflags-y += -mno-red-zone -mcmodel=kernel
+ endif
+ 
+ ifeq ($(ARCH),powerpc)
+- EXTRA_CFLAGS += -mlittle-endian -mno-strict-align
++ ccflags-y += -mlittle-endian -mno-strict-align
+ endif
+ 
+-EXTRA_CFLAGS += -DNV_UVM_ENABLE
+-EXTRA_CFLAGS += $(call cc-option,-Werror=undef,)
+-EXTRA_CFLAGS += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
+-EXTRA_CFLAGS += -DNV_KERNEL_INTERFACE_LAYER
++ccflags-y += -DNV_UVM_ENABLE
++ccflags-y += $(call cc-option,-Werror=undef,)
++ccflags-y += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
++ccflags-y += -DNV_KERNEL_INTERFACE_LAYER
+ 
+ #
+ # Detect SGI UV systems and apply system-specific optimizations.
+ #
+ 
+ ifneq ($(wildcard /proc/sgi_uv),)
+- EXTRA_CFLAGS += -DNV_CONFIG_X86_UV
++ ccflags-y += -DNV_CONFIG_X86_UV
+ endif
+ 
+ ifdef VGX_FORCE_VFIO_PCI_CORE
+- EXTRA_CFLAGS += -DNV_VGPU_FORCE_VFIO_PCI_CORE
++ ccflags-y += -DNV_VGPU_FORCE_VFIO_PCI_CORE
+ endif
+ 
+ WARNINGS_AS_ERRORS ?=
+@@ -183,7 +177,7 @@
+ 
+ NV_CFLAGS_FROM_CONFTEST := $(shell $(NV_CONFTEST_CMD) build_cflags)
+ 
+-NV_CONFTEST_CFLAGS = $(NV_CFLAGS_FROM_CONFTEST) $(EXTRA_CFLAGS) -fno-pie
++NV_CONFTEST_CFLAGS = $(NV_CFLAGS_FROM_CONFTEST) $(ccflags-y) -fno-pie
+ NV_CONFTEST_CFLAGS += $(call cc-disable-warning,pointer-sign)
+ NV_CONFTEST_CFLAGS += $(call cc-option,-fshort-wchar,)
+ NV_CONFTEST_CFLAGS += $(call cc-option,-Werror=incompatible-pointer-types,)


### PR DESCRIPTION
Group of patches required for gcc-15 build of LE

- xf86-video-nvidia: allow build with 6.14.1 as well as gcc-15
  - https://github.com/NVIDIA/open-gpu-kernel-modules/pull/841
  - https://github.com/NVIDIA/open-gpu-kernel-modules/issues/814
- grub: patch grub gnulib to allow build with gcc-15
- mariadb-connector-c: fix build with gcc-15
- parted: gcc-15 upstream fix
- libtirpc: gcc-15 upstream fixes
- part of #9981 (#9705)
  - ~update or patch is required~
  - gcc update to 15.1 itself