### PR TITLE
kodi: update to githash 13574db

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="230e3b401749690aeedfe2471bbbe876cc53fff2"
-PKG_SHA256="be7938f19629f1c9596b7d2ec3596e07666fb7c535bedb8d8f1d71f2509352eb"
+PKG_VERSION="13574dbbc2a902f1308abe83f27587274fc351c1"
+PKG_SHA256="2e7a2a4ca67bc03144b37c838732b906bc1e0c09b0af1f9d1d41a8b4ffc7611f"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/230e3b401749690aeedfe2471bbbe876cc53fff2...13574dbbc2a902f1308abe83f27587274fc351c1

```
=== tested on ===
Generic.x86_64-devel-20250420132323-006b71c
Linux nuc12 6.14.2 #1 SMP Sun Apr 20 12:16:14 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:13574dbbc2a902f1308abe83f27587274fc351c1). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-04-20 by GCC 15.0.1 for Linux x86 64-bit version 6.14.2 (396802)
Running on LibreELEC (heitbaum): devel-20250420132323-006b71c 13.0, kernel: Linux x86 64-bit version 6.14.2
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.0-rc1
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.0 (c85b975c55)
```