### PR TITLE
readline: update to 8.2.13

### DIFF
--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="readline"
-PKG_VERSION="8.2"
-PKG_SHA256="3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"
+PKG_VERSION="8.2.13"
+PKG_SHA256="0e5be4d2937e8bd9b7cd60d46721ce79f88a33415dd68c2d738fb5924638f656"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.gnu.org/software/readline/"
 PKG_URL="https://ftpmirror.gnu.org/readline/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/devel/readline/patches/readline-0001-fix-gcc-15.patch
+++ b/packages/devel/readline/patches/readline-0001-fix-gcc-15.patch
@@ -1,0 +1,14 @@
+--- a/readline.h	2022-02-18 16:13:59.000000000 +0000
++++ b/readline.u	2025-01-31 13:31:09.481233005 +0000
+@@ -404,11 +404,7 @@
+ extern void rl_deactivate_mark (void);
+ extern int rl_mark_active_p (void);
+ 
+-#if defined (USE_VARARGS) && defined (PREFER_STDARG)
+ extern int rl_message (const char *, ...)  __attribute__((__format__ (printf, 1, 2)));
+-#else
+-extern int rl_message ();
+-#endif
+ 
+ extern int rl_show_char (int);
+ 


### PR DESCRIPTION
include fix for c23 compile - upstreamed patch from:
- https://git.savannah.gnu.org/cgit/readline.git/commit/readline.h?h=readline-8.3-beta&id=69e5c5e4c9778bf86c3d1c6b058ddece70854de8