### PR TITLE
chrome: update to 135.0.7049.95 and addon (1) And fix buid

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libxkbcommon/package.mk
@@ -11,5 +11,5 @@ PKG_BUILD_FLAGS="-sysroot"
 
 unpack() {
   mkdir -p ${PKG_BUILD}
-  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.gz -C ${PKG_BUILD}
 }

--- a/packages/addons/addon-depends/chrome-depends/cups/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/cups/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cups"
-PKG_VERSION="2.4.11"
-PKG_SHA256="e66cb3769dfe1e392e495e2532304a3b4b7b3136cff7b387fd5898955a6f64e4"
+PKG_VERSION="2.4.12"
+PKG_SHA256="7a4d32822b320aa2999b18fdfc4ce5ca9ad204fe6302ff69e6c24b21f8d0eaa0"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.cups.org"
 PKG_URL="https://github.com/openprinting/cups/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gtk3"
-PKG_VERSION="3.24.43"
-PKG_SHA256="7e04f0648515034b806b74ae5d774d87cffb1a2a96c468cb5be476d51bf2f3c7"
+PKG_VERSION="3.24.49"
+PKG_SHA256="5ea52c6a28f0e5ecf2e9a3c2facbb30d040b73871fcd5f33cd1317e9018a146e"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
-PKG_URL="https://ftp.gnome.org/pub/gnome/sources/gtk+/${PKG_VERSION:0:4}/gtk+-${PKG_VERSION}.tar.xz"
+PKG_URL="https://download.gnome.org/sources/gtk/${PKG_VERSION:0:4}/gtk-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain at-spi2-core atk cairo gdk-pixbuf glib libX11 libXi libXrandr libepoxy pango libxkbcommon"
 PKG_DEPENDS_CONFIG="libXft pango gdk-pixbuf shared-mime-info"
 PKG_LONGDESC="A library for creating graphical user interfaces for the X Window System."

--- a/packages/addons/addon-depends/chrome-depends/libXft/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/libXft/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libXft"
-PKG_VERSION="2.3.8"
-PKG_SHA256="5e8c3c4bc2d4c0a40aef6b4b38ed2fb74301640da29f6528154b5009b1c6dd49"
+PKG_VERSION="2.3.9"
+PKG_SHA256="60a25b78945ed6932635b3bb1899a517d31df7456e69867ffba27f89ff3976f5"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/lib/libXft-${PKG_VERSION}.tar.xz"
@@ -12,5 +12,4 @@ PKG_DEPENDS_TARGET="toolchain fontconfig freetype libXrender util-macros xorgpro
 PKG_LONGDESC="X FreeType library."
 PKG_BUILD_FLAGS="+pic -sysroot"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared"
+PKG_MESON_OPTS_TARGET="-Ddefault_library=static"

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="134.0.6998.165"
-PKG_REV="0"
+PKG_VERSION_NUMBER="135.0.7049.95"
+PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"


### PR DESCRIPTION
Fix build issue
```
<<< chrome-libxkbcommon:target seq 205 <<<
UNPACK      libxkbcommon
UNPACK      chrome-libxkbcommon
tar: /build/sources/libxkbcommon/libxkbcommon-1.8.1.tar.xz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
FAILURE: scripts/unpack chrome-libxkbcommon during unpack (package.mk)
```
- chrome: update to 135.0.7049.95 and addon (1)
- chrome-libxkbcommon: fix source tar file reference
- libXft: update to 2.3.9 and meson
- gtk3: update to 3.24.49 and PKG_URL
- cups: update to 2.4.12