### PR TITLE
media-driver: update to 25.2.1

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="25.2.0"
-PKG_SHA256="be7a1aa9341c637a6adb26164adffeffcad859980246fab4df04f3d7d8e2114b"
+PKG_VERSION="25.2.1"
+PKG_SHA256="fc7ffad0ef83979247ae641b0382816129387a0dc29822dd4a78f5bc990c1b1f"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20250422114319-4b49e30
Linux nuc12 6.14.2 #1 SMP Mon Apr 21 07:04:50 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:13574dbbc2a902f1308abe83f27587274fc351c1). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-04-21 by GCC 15.0.1 for Linux x86 64-bit version 6.14.2 (396802)
Running on LibreELEC (heitbaum): devel-20250422114319-4b49e30 13.0, kernel: Linux x86 64-bit version 6.14.2
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.0-rc1
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.1 (4b49e30aba)
```