### PR TITLE
Package updates

### DIFF
--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="valgrind"
-PKG_VERSION="3.24.0"
-PKG_SHA256="71aee202bdef1ae73898ccf7e9c315134fa7db6c246063afc503aef702ec03bd"
+PKG_VERSION="3.25.0"
+PKG_SHA256="295f60291d6b64c0d90c1ce645634bdc5361d39b0c50ecf9de6385ee77586ecc"
 PKG_LICENSE="GPL"
 PKG_SITE="https://valgrind.org/"
 PKG_URL="https://sourceware.org/pub/valgrind/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/elfutils/package.mk
+++ b/packages/devel/elfutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="elfutils"
-PKG_VERSION="0.192"
-PKG_SHA256="616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4"
+PKG_VERSION="0.193"
+PKG_SHA256="7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635"
 PKG_LICENSE="GPL"
 PKG_SITE="https://sourceware.org/elfutils/"
 PKG_URL="https://sourceware.org/elfutils/ftp/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/elfutils/patches/elfutils-001-make-executables-optional.patch
+++ b/packages/devel/elfutils/patches/elfutils-001-make-executables-optional.patch
@@ -12,24 +12,24 @@ diff --git a/Makefile.am b/Makefile.am
 index bd8926b..1733937 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -27,7 +27,11 @@
+@@ -29,7 +29,11 @@
  pkginclude_HEADERS = version.h
  
- SUBDIRS = config lib libelf libcpu backends libebl libdwelf libdwfl libdw \
--	  libasm debuginfod src po doc tests
-+	  libasm debuginfod po doc tests
+ SUBDIRS = config lib libelf libcpu backends libebl libdwelf libdwfl \
+-	  libdwfl_stacktrace libdw libasm debuginfod src po doc tests
++	  libdwfl_stacktrace libdw libasm debuginfod po doc tests
 +
 +if BUILD_PROGRAMS
 +  SUBDIRS += src
 +endif
  
- EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
- 	     COPYING COPYING-GPLV2 COPYING-LGPLV3
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING SECURITY \
+ 	     COPYING COPYING-GPLV2 COPYING-LGPLV3 CONDUCT
 diff --git a/configure.ac b/configure.ac
 index 5a2dc37..a1e856a 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -88,6 +88,11 @@ AS_IF([test "$use_locks" = yes],
+@@ -82,6 +82,11 @@
  
  AH_TEMPLATE([USE_LOCKS], [Defined if libraries should be thread-safe.])
  
@@ -38,9 +38,9 @@ index 5a2dc37..a1e856a 100644
 +               [build_programs=$enableval], [build_programs=no])
 +AM_CONDITIONAL(BUILD_PROGRAMS, test "$build_programs" = yes)
 +
- m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
- AC_PROG_CXX
- AC_PROG_RANLIB
+ # Provided by gnulib's m4/std-gnu11.m4 for autoconf pre 2.70
+ AC_PROG_CC
+ AS_IF([test "x$ac_cv_prog_cc_c11" = "xno"],
 -- 
 2.7.4
 

--- a/packages/graphics/spirv-headers/package.mk
+++ b/packages/graphics/spirv-headers/package.mk
@@ -8,8 +8,8 @@ PKG_NAME="spirv-headers"
 # When updating glslang pkg_version please update to the known_good spirv-headers pkg_version.
 # When updating spirv-llvm-translator pkg_version validate the minimum githash from 
 # https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/spirv-headers-tag.conf
-PKG_VERSION="09913f088a1197aba4aefd300a876b2ebbaa3391"
-PKG_SHA256="6d4aad5a86d7d5af144747aee1d616f624897d64d842f282aca7777f84244318"
+PKG_VERSION="aa6cef192b8e693916eb713e7a9ccadf06062ceb"
+PKG_SHA256="1bf0568bad1f9e30fce8d3199e54ae7ade1c16dbe913b5afd9b499149a9bb9a5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-headers"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-headers/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="spirv-tools"
 # The SPIRV-Tools pkg_version needs to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools pkg_version.
-PKG_VERSION="f289d047f49fb60488301ec62bafab85573668cc"
-PKG_SHA256="5fbd56baf226a04435656bae408287365102b69a24fa73bab8353c5f44b55615"
+PKG_VERSION="a62abcb402009b9ca5975e6167c09f237f630e0e"
+PKG_SHA256="7f6561171be2f314a26cb2a686d653050ee318655a89970d41ab3bef3269a4db"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/vulkan/glslang/package.mk
+++ b/packages/graphics/vulkan/glslang/package.mk
@@ -6,8 +6,8 @@ PKG_NAME="glslang"
 # The SPIRV-Tools & SPIRV-Headers pkg_version/s need to match the compatible (known_good) glslang pkg_version.
 # https://raw.githubusercontent.com/KhronosGroup/glslang/${PKG_VERSION}/known_good.json
 # When updating glslang pkg_version please update to the known_good spirv-tools & spirv-headers pkg_version/s.
-PKG_VERSION="15.2.0"
-PKG_SHA256="45e3920d264d5c2cc3bfaec0e5dbb66cffd549255e0aaaf38cd283918e35c8ba"
+PKG_VERSION="15.3.0"
+PKG_SHA256="c6c21fe1873c37e639a6a9ac72d857ab63a5be6893a589f34e09a6c757174201"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/glslang"
 PKG_URL="https://github.com/KhronosGroup/glslang/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="14.0.1"
-PKG_SHA256="a8150505b126a59df781fe8c30c8e6f87da7013e179039eb844a5bbbcc7c79b3"
+PKG_VERSION="14.0.2"
+PKG_SHA256="b47216b3530da76d02a3a1acbf1846a9cd41d24caa86448f9c46f78f20b6e0ac"
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/weston/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- elfutils: update to 0.193
- valgrind: update to 3.25.0
- weston: update to 14.0.2
- spirv-headers: update to githash aa6cef1
- spirv-tools: update to githash a62abcb
- glslang: update to 15.3.0