### PR TITLE
kodi: update to githash 49b8882

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="e30d10f4204d8301d8d9d62730edfe6f51344e4d"
-PKG_SHA256="e643c4c4d5d559c33e1ee8fd8596b4ad7ee0aa3e2bb8a13da46f5841e92d5b11"
+PKG_VERSION="49b8882536fe1909c86a1cd8d67b19e32cddfdc3"
+PKG_SHA256="f44c8be8e25535aeaf99e17dc952de7a8a315980bcdcbbc1b04d5f726ef51f3a"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt rapidjson sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libxkbcommon"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt nlohmann-json sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libxkbcommon"
 PKG_DEPENDS_UNPACK="commons-lang3 commons-text groovy"
 PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/e30d10f4204d8301d8d9d62730edfe6f51344e4d...49b8882536fe1909c86a1cd8d67b19e32cddfdc3

- includes migration of rapidjson to nlohmann-json
  - [CVariant] Replace rapidjson with nlohmann-json
  - https://github.com/xbmc/xbmc/pull/26612

Places when rapidjson is still used in LE:
- https://github.com/rbuehlma/pvr.zattoo/issues/224
- https://github.com/flubshi/pvr.waipu/issues/418
- https://github.com/rbuehlma/pvr.teleboy/issues/99
- https://github.com/kodi-pvr/pvr.plutotv/issues/99
- https://github.com/xbmc/inputstream.adaptive/issues/1835