### PR TITLE
Package updates

### DIFF
--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
-PKG_VERSION="2.38.0"
-PKG_SHA256="c48298c826ba07b99f03f2cb69764bc5b8e9d5531286462554e0d75c21c61e40"
+PKG_VERSION="2.38.1"
+PKG_SHA256="14bfb259fd7d0a1fdce9b66f8ed2dd0b134d15019cb359699646afeee1f18118"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/rui314/mold"
 PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/devel/mold/package.mk
+++ b/packages/devel/mold/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mold"
-PKG_VERSION="2.37.1"
-PKG_SHA256="b8e36086c95bd51e9829c9755c138f5c4daccdd63b6c35212b84229419f3ccbe"
+PKG_VERSION="2.38.0"
+PKG_SHA256="c48298c826ba07b99f03f2cb69764bc5b8e9d5531286462554e0d75c21c61e40"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/rui314/mold"
 PKG_URL="https://github.com/rui314/mold/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="11.1.0"
-PKG_SHA256="477f0d48c34dc32093b45304178eb9733361ca1832b5159879c99e6d40227969"
+PKG_VERSION="11.2.0"
+PKG_SHA256="50f7d0a208367e606dbf6eecc5cfbecc01a47be6ee837ae7aff2787e24b09b45"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.19.7"
-PKG_SHA256="161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3"
+PKG_VERSION="1.19.8"
+PKG_SHA256="6c4a5b08e6eae66d199977468859dea3b5e059081db8928f7c7c16e53836c906"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="1.7.2"
-PKG_SHA256="4d40d63aa748a9c139cc41ab9bffe43edd113c5639d78bde81544ca955aea890"
+PKG_VERSION="1.8.0"
+PKG_SHA256="0a9b23311271519bd03dca12d7d8b0eab582c3a2c5da433d465b6e519dc88e2f"
 PKG_LICENSE="Apache"
 PKG_SITE="https://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="79.0.1"
-PKG_SHA256="128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88"
+PKG_VERSION="80.0.0"
+PKG_SHA256="c40a5b3729d58dd749c0f08f1a07d134fb8a0a3d7f87dc33e7c5e1f762138650"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="80.0.0"
-PKG_SHA256="c40a5b3729d58dd749c0f08f1a07d134fb8a0a3d7f87dc33e7c5e1f762138650"
+PKG_VERSION="80.0.1"
+PKG_SHA256="20fe373a22ef9f3925512650d1db90b1b8de01cdb6df91ab1788263139cbf9a2"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.8.1"
-PKG_SHA256="c65c668810db305c4454ba26a10b6d84a96b5469719fe3c729e1c6542b8d0d87"
+PKG_VERSION="1.9.0"
+PKG_SHA256="c8c4ccf203ff73b647ea70b67afa2fd749cd428cd027fc2e5ca3b9954f1d77a8"
 PKG_LICENSE="MIT"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${PKG_VERSION}.tar.gz"

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="foot"
-PKG_VERSION="1.22.0"
-PKG_SHA256="93e1a94b6870d3b45a0a52c9d98a7a21dd115945a7bd43b028f1acef1076d4b3"
+PKG_VERSION="1.22.1"
+PKG_SHA256="d388cfa2b0b1b65264eea806865d4a976a677292ef09040965078aa62f3a08ab"
 PKG_LICENSE="MIT"
 PKG_SITE="https://codeberg.org/dnkl/foot/"
 PKG_URL="https://codeberg.org/dnkl/foot/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/wayland-protocols/package.mk
+++ b/packages/wayland/wayland-protocols/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wayland-protocols"
-PKG_VERSION="1.43"
-PKG_SHA256="ba3c3425dd27c57b5291e93dba97be12479601e00bcab24d26471948cb643653"
+PKG_VERSION="1.44"
+PKG_SHA256="3df1107ecf8bfd6ee878aeca5d3b7afd81248a48031e14caf6ae01f14eebb50e"
 PKG_LICENSE="OSS"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/${PKG_NAME}/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libxkbcommon: update to 1.9.0
- foot: update to 1.22.1
- libheif: update to 1.19.8
- setuptools: update to 80.0.0
- wayland-protocols: update to 1.44
- mold: update to 2.38.1
- harfbuzz: update to 11.2.0
- meson: update to 1.8.0