### PR TITLE
docker: update to 28.1.1 and addon (1)

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="70ded7462897bab0b7d7e5716ffc787391ff5f2b483d7eb590a37bf6512bd3e4"
+PKG_SHA256="98b305725d453b6802a4df1e4c8184b66cf8d74e9050bbf3d92b2804621cb9f6"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="0442a7378f37ef9482ade1c8addf618cb8becb00"
+export PKG_GIT_COMMIT="4eba3773274f9d21ba90ae5bc719c3f1e4bb07a1"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.0.4"
-PKG_SHA256="af0b18d125abf97fbe90d6d2cda53ffa0cd4cbb9e7d65fee61fc095bfb63cef5"
+PKG_VERSION="2.0.5"
+PKG_SHA256="617917606c64df1cab19a0f5cc20fd724ed9187314bcd40eaacf66a9e75b1eb8"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="1a43cb6a1035441f9aca8f5666a9b3ef9e70ab20"
+export PKG_GIT_COMMIT="fb4c30d4ede3531652d86197bf3fc9515e5276d9"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="28.0.2"
-PKG_SHA256="7cfc0c13358497f9c6d8e1558d70195e6b72f37cbd9605ba35812ef395186927"
+PKG_VERSION="28.1.1"
+PKG_SHA256="5c9402ef5886be7683260a424c02de199b45b7e15633d90e03faaf672f7041fc"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="bea4de25004da0460f80ac1e0f1628e66b058287"
+export PKG_GIT_COMMIT="01f442b84d6a669c1e335b800d4670997cd5aa93"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.2.6"
-PKG_SHA256="19b280702341f33ff353fa254d1dbdb67f6aab2c74395f6d651a17524f68e752"
+PKG_VERSION="1.3.0"
+PKG_SHA256="3262492ce42bea0919ee1a2d000b6f303fd14877295bc38d094876b55fdd448b"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="e89a29929c775025419ab0d218a43588b4c12b9a"
+export PKG_GIT_COMMIT="4ca628d1d4c974f92d24daccb901aa078aad748e"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"


### PR DESCRIPTION
- docker: update to 28.1.1 and addon (1)
  - cli: update to 28.1.1
  - moby: update to 28.1.1
  - containerd: update to 2.0.5
  - runc: update to 1.3.0