### PR TITLE
kodi: update to githash c55eee6

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="49b8882536fe1909c86a1cd8d67b19e32cddfdc3"
-PKG_SHA256="f44c8be8e25535aeaf99e17dc952de7a8a315980bcdcbbc1b04d5f726ef51f3a"
+PKG_VERSION="c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4"
+PKG_SHA256="f5f80e3997c4250f6690f4f6793b214c75157c99a71ea0aeeb477722031c93d6"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
@@ -254,7 +254,6 @@ configure_package() {
                          -DENABLE_INTERNAL_EXIV2=OFF \
                          -DENABLE_INTERNAL_FFMPEG=OFF \
                          -DENABLE_INTERNAL_FLATBUFFERS=OFF \
-                         -DENABLE_INTERNAL_RapidJSON=OFF \
                          -DENABLE_INTERNAL_SPDLOG=OFF \
                          -DENABLE_UDEV=ON \
                          -DENABLE_DBUS=ON \


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/49b8882536fe1909c86a1cd8d67b19e32cddfdc3...c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4
- remove RapidJSON remanents
- Includes fix - https://github.com/xbmc/xbmc/pull/26705

```
=== tested on ===
Generic.x86_64-devel-20250430234304-750969d
Linux nuc12 6.14.2 #1 SMP Wed Apr 30 09:53:25 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-04-30 by GCC 15.1.0 for Linux x86 64-bit version 6.14.2 (396802)
Running on LibreELEC (heitbaum): devel-20250430234304-750969d 13.0, kernel: Linux x86 64-bit version 6.14.2
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.5
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.1 (b772b09483)
```