### PR TITLE
mesa: update to 25.0.5

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="25.0.4"
-PKG_SHA256="76293cf4372ca4e4e73fd6c36c567b917b608a4db9d11bd2e33068199a7df04d"
+PKG_VERSION="25.0.5"
+PKG_SHA256="c0d245dea0aa4b49f74b3d474b16542e4a8799791cd33d676c69f650ad4378d0"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Hello everyone,

The bugfix release 25.0.5 is now available.

If you find any issues, please report them here:
https://gitlab.freedesktop.org/mesa/mesa/-/issues/new

The next bugfix release is due in two weeks, on May 14th.

Cheers,
  Eric

---

Connor Abbott (1):
      tu: Fix flushing when using a staging buffer for copies

Danylo Piliaiev (1):
      tu,freedreno: Don't fallback to LINEAR with DRM_FORMAT_MOD_QCOM_COMPRESSED

David Rosca (1):
      radv: Use radv_format_to_pipe_format instead of vk_format_to_pipe_format

Dmitry Baryshkov (1):
      meson: disable SIMD blake optimisations on x32 host

Ella Stanforth (1):
      v3d/compiler: Fixup output types for all 8 outputs

Eric Engestrom (10):
      docs: add sha sum for 25.0.4
      .pick_status.json: Update to 5f3a3740dcc6d243f2ef14138fb1c09bcbb9b5fd
      pick-ui: make `Backport-to: 25.0` backport to 25.0 *and more recent release branches*
      aco: help clang 20 do some additions and subtractions
      .pick_status.json: Update to 091d52965f805d61dd3a8e091ac20869a794e632
      pick-ui: add missing dependency
      .pick_status.json: Update to 3493500abb78a4dc22aba14840bba5c777fde745
      .pick_status.json: Update to 5a55133ce7d5bb2419f2aa99c5296037afb7ba6a
      docs: add release notes for 25.0.5
      VERSION: bump for 25.0.5

Faith Ekstrand (2):
      nak/legalize: Take a RegFile in copy_alu_src_and_lower_fmod
      nak/sm70: Fix the bit74_75_ar_mod assert

Georg Lehmann (2):
      nir/opt_algebraic: disable fsat(a + 1.0) opt if a can be NaN
      aco: set opsel_hi to 1 for WMMA

Ian Romanick (4):
      brw/algebraic: Clear condition modifier on optimized SEL instruction
      brw/algebraic: Don't optimize float SEL.CMOD to MOV
      elk/algebraic: Clear condition modifier on optimized SEL instruction
      elk/algebraic: Don't optimize float SEL.CMOD to MOV

Janne Grunau (2):
      venus: Do not use instance pointer before NULL check
      venus: virtgpu: Require stable wire format

John Anthony (1):
      panvk: Enable VK_EXT_direct_mode_display

José Roberto de Souza (3):
      intel: Program XY_FAST_COLOR_BLT::Destination Mocs for gfx12
      intel: Fix the MOCS values in XY_FAST_COLOR_BLT for Xe2+
      intel: Fix the MOCS values in XY_BLOCK_COPY_BLT for Xe2+

Karol Herbst (2):
      rusticl/device: fix panic when disabling 3D image write support
      nir_lower_mem_access_bit_sizes: fix negative chunk offsets

Lionel Landwerlin (1):
      anv: use companion batch for operations with HIZ/STC_CCS destination

Loïc Minier (1):
      freedreno: check if GPU supported in fd_pipe_new2

Marek Olšák (1):
      radv: fix incorrect patch_outputs_read for TCS with dynamic state

Mary Guillemard (3):
      panvk: reset dyn_bufs map count to 0 in create_copy_table
      panvk: Take rasterization sample into account in indirect draw on v10+
      panvk: Take resource index in valhall_lower_get_ssbo_size

Mel Henning (3):
      nvk: SET_STATISTICS_COUNTER at start of meta_begin
      nvk: Override render enable for blits and resolves
      wsi/headless: Override finish_create

Mike Blumenkrantz (1):
      zink: verify that surface exists when adding implicit feedback loop

Olivia Lee (1):
      panfrost: allow promoting sysval UBO to push constants

Patrick Lerda (1):
      mesa_interface: fix legacy dri2 compatibility

Pierre-Eric Pelloux-Prayer (1):
      radeonsi: fix potential use after free in si_set_debug_callback

Rhys Perry (3):
      aco/gfx12: don't use second VALU for VOPD's OPX if there is a WaR
      aco: combine VALU lanemask hazard into VALUMaskWriteHazard
      aco/gfx11: create waitcnt for workgroup vmem barriers

Samuel Pitoiset (3):
      radv: only enable DCC for invisible VRAM on GFX12
      radv: fix re-emitting VRS state when rendering begins
      radv: set radv_disable_dcc=true for WWE 2k23

Tapani Pälli (2):
      iris: force reallocate on eglCreateImage with GFX >= 20
      iris: make sure to not mix compressed vs non-compressed

Tomeu Vizoso (1):
      etnaviv: Release screen->[dummy_desc_reloc.bo](http://dummy_desc_reloc.bo/)

Yinjie Yao (2):
      gallium/pipe: Increase hevc max slice to 600
      frontends/va: Handle properly when decoding more slices than limit

Yiwei Zhang (1):
      venus: fix missing renderer destructions

git tag: mesa-25.0.5

https://mesa.freedesktop.org/archive/mesa-25.0.5.tar.xz
SHA256: c0d245dea0aa4b49f74b3d474b16542e4a8799791cd33d676c69f650ad4378d0  mesa-25.0.5.tar.xz
SHA512: d65e027829e3bef60bc0e3e71160e6b3721e797e2157c71dbeef0cd6e202f8f8098b3cd41159cd0e96e520eaf92ea49c2c9bb1af1a54867b6a7c551c2197c068  mesa-25.0.5.tar.xz
PGP:  https://mesa.freedesktop.org/archive/mesa-25.0.5.tar.xz.sig

```
=== tested on ===
Generic.x86_64-devel-20250430234304-750969d
Linux nuc12 6.14.2 #1 SMP Wed Apr 30 09:53:25 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-04-30 by GCC 15.1.0 for Linux x86 64-bit version 6.14.2 (396802)
Running on LibreELEC (heitbaum): devel-20250430234304-750969d 13.0, kernel: Linux x86 64-bit version 6.14.2
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.0.5
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.1 (b772b09483)
```