### PR TITLE
fluxbox: allow build with gettext-0.24.1

### DIFF
--- a/packages/x11/other/fluxbox/patches/fluxbox-80-fix-gettext-build.patch
+++ b/packages/x11/other/fluxbox/patches/fluxbox-80-fix-gettext-build.patch
@@ -1,0 +1,22 @@
+From e9c3dacdbbd3d948c7c6aaa80ee65e0fb8d46d62 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 5 May 2025 19:33:06 +1000
+Subject: [PATCH] allow build with gettext 0.24.1
+
+make sure iconv.m4 is available for autoconf to find it
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index 5e8d09347..ef1a00b3a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -186,6 +186,7 @@ AC_COMPILE_IFELSE([
+ 	AC_MSG_RESULT([no])
+ ])
+ 
++AM_GNU_GETTEXT_VERSION([0.11.5])
+ AM_ICONV
+ AS_IF([test x$am_cv_proto_iconv_arg1 = "xconst"], [
+ 	AC_DEFINE([HAVE_CONST_ICONV], [1], [Is second argument of iconv() is of type 'const char **' or 'char **'])


### PR DESCRIPTION
- https://github.com/fluxbox/fluxbox/pull/80

fixes
```
BUILD      fluxbox (target)
    TOOLCHAIN      autotools
    AUTORECONF      fluxbox
autoreconf: export WARNINGS=
autoreconf: Entering directory '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/fluxbox-1.3.7'
autoreconf: configure.ac: not using Gettext
autoreconf: running: /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/aclocal -I /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/aclocal -I /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/aclocal --force -I m4
configure.ac:188: warning: macro 'AM_ICONV' not found in library
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/autoconf --include=/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/aclocal --force
configure.ac:16: warning: The macro 'AC_LANG_CPLUSPLUS' is obsolete.
configure.ac:16: You should run autoupdate.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/autoconf-2.72/lib/autoconf/c.m4:270: AC_LANG_CPLUSPLUS is expanded from...
configure.ac:16: the top level
configure.ac:48: warning: The macro 'AC_HEADER_STDC' is obsolete.
configure.ac:48: You should run autoupdate.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/autoconf-2.72/lib/autoconf/headers.m4:663: AC_HEADER_STDC is expanded from...
configure.ac:48: the top level
configure.ac:132: warning: The macro 'AC_CHECK_LIBM' is obsolete.
configure.ac:132: You should run autoupdate.
aclocal.m4:5294: AC_CHECK_LIBM is expanded from...
configure.ac:132: the top level
configure.ac:554: warning: The macro 'AC_TYPE_SIGNAL' is obsolete.
configure.ac:554: You should run autoupdate.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/autoconf-2.72/lib/autoconf/types.m4:805: AC_TYPE_SIGNAL is expanded from...
configure.ac:554: the top level
configure.ac:557: warning: The macro 'AC_CONFIG_HEADER' is obsolete.
configure.ac:557: You should run autoupdate.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/autoconf-2.72/lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:557: the top level
configure.ac:559: warning: AC_OUTPUT should be used without arguments.
configure.ac:559: You should run autoupdate.
configure.ac:188: error: possibly undefined macro: AM_ICONV
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
``` 