### PR TITLE
kodi: update to githash 264adc1

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4"
-PKG_SHA256="f5f80e3997c4250f6690f4f6793b214c75157c99a71ea0aeeb477722031c93d6"
+PKG_VERSION="264adc124d4770ffef0e3de5b11478077cfd4152"
+PKG_SHA256="1057f12c69dfc1397848692d6e8aa79518585e2e7a9ff3647cecab53b9a88025"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4...264adc1
24d4770ffef0e3de5b11478077cfd4152

- ~https://github.com/xbmc/xbmc/compare/c55eee6017203fdcedfa8411b5b40ae0b0c7e3e4...cfbd42ac9513c54d10cc4e24bccac487e248b57c~
- ~revert of~
  - ~https://github.com/xbmc/xbmc/pull/26738/commits/b1fe4d815a8d2d1fb743a69576919bff737a433f~
  - ~https://github.com/xbmc/xbmc/pull/26738/commits/f902ec5c5956fcc293aea7492ed1c30b6164d7ec~
  - ~See https://github.com/xbmc/xbmc/pull/26738#issue comment-2850946071~
  - ~https://github.com/xbmc/xbmc/pull/26738~~

```
=== tested on ===
Generic.x86_64-devel-20250505131610-4e7fc89
Linux nuc12 6.14.5 #1 SMP Mon May  5 04:55:47 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:cfbd42ac9513c54d10cc4e24bccac487e248b57c). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-05-05 by GCC 15.1.0 for Linux x86 64-bit version 6.14.5 (396805)
Running on LibreELEC (heitbaum): devel-20250505131610-4e7fc89 13.0, kernel: Linux x86 64-bit version 6.14.5
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0094.2024.0806.1458 08/06/2024
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.0-rc3
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.1 (9d3e74f47f7)
```