### PR TITLE
Package Updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.24.2"
-PKG_SHA256="aed36493f20f6701b2832ce12b8d531ab36785da2ffb68553badbcdf8212b116"
+PKG_VERSION="1.24.3"
+PKG_SHA256="4358c465e80e2124bee1969dd5e8f84d4f445a2c5a58b4b33f17bfe9e9deefed"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.49.1"
+PKG_VERSION="3.49.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254"
+PKG_SHA256="5c6d8697e8a32a1512a9be5ad2b2e7a891241c334f56f8b0fb4fc6051e1652e8"
 PKG_LICENSE="PublicDomain"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2025/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gettext"
-PKG_VERSION="0.24.1"
-PKG_SHA256="6164ec7aa61653ac9cdfb41d5c2344563b21f707da1562712e48715f1d2052a6"
+PKG_VERSION="0.25"
+PKG_SHA256="05240b29f5b0f422e5a4ef8e9b5f76d8fa059cc057693d2723cdb76f36a88ab0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/s/gettext/"
 PKG_URL="https://ftp.gnu.org/pub/gnu/gettext/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.394"
-PKG_SHA256="b7c3fd7214a3b7c49d2661db127a712dc11cffd1799f793947aa1cb20aaf3298"
+PKG_VERSION="0.395"
+PKG_SHA256="1166f733c57afa82cfdad56e62ef044835fbc8c99ef65f033e6a5802716b5c66"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="3.7"
-PKG_SHA256="ba3e577a61e78f860f376025c3243bbf19eac7ccbfdfac3aebe566556ace2e08"
+PKG_VERSION="3.8"
+PKG_SHA256="c556a5a5376270af68940e04e26765026fbbbe4941668317c274c91042611cdf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"

--- a/packages/network/libnl/package.mk
+++ b/packages/network/libnl/package.mk
@@ -10,6 +10,7 @@ PKG_SITE="https://github.com/thom311/libnl"
 PKG_URL="https://github.com/thom311/libnl/releases/download/libnl${PKG_VERSION//./_}/libnl-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="A library for applications dealing with netlink socket."
+PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --disable-shared \

--- a/packages/security/libgcrypt/package.mk
+++ b/packages/security/libgcrypt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgcrypt"
-PKG_VERSION="1.11.0"
-PKG_SHA256="09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
+PKG_VERSION="1.11.1"
+PKG_SHA256="24e91c9123a46c54e8371f3a3a2502f1198f2893fbfbf59af95bc1c21499b00e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org/"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgcrypt/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/security/libgcrypt/patches/libgcrypt-01-dont_replace_parts_of_path-0.1.patch
+++ b/packages/security/libgcrypt/patches/libgcrypt-01-dont_replace_parts_of_path-0.1.patch
@@ -1,12 +1,12 @@
 diff -Naur libgcrypt-1.11.0/cipher/Makefile.am libgcrypt-1.11.0.patch/cipher/Makefile.am
 --- libgcrypt-1.11.0/cipher/Makefile.am	2009-12-11 16:31:38.000000000 +0100
 +++ libgcrypt-1.11.0.patch/cipher/Makefile.am	2011-05-08 03:21:56.463021968 +0200
-@@ -169,7 +169,7 @@
+@@ -174,7 +174,7 @@
  
  
  if ENABLE_O_FLAG_MUNGING
--o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
-+o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
+-o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
++o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
  else
  o_flag_munging = cat
  endif
@@ -14,12 +14,12 @@ diff -Naur libgcrypt-1.11.0/cipher/Makefile.in libgcrypt-1.11.0.patch/cipher/Mak
 --- libgcrypt-1.11.0/cipher/Makefile.in	2010-07-13 17:42:20.000000000 +0200
 +++ libgcrypt-1.11.0.patch/cipher/Makefile.in	2011-05-08 03:22:12.059208971 +0200
 @ENABLE_O_FLAG_MUNGING_TRUE@o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
-@@ -643,7 +643,7 @@
+@@ -654,7 +654,7 @@
  	blake2s-amd64-avx.S blake2s-amd64-avx512.S
  
  @ENABLE_O_FLAG_MUNGING_FALSE@o_flag_munging = cat
--@ENABLE_O_FLAG_MUNGING_TRUE@o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
-+@ENABLE_O_FLAG_MUNGING_TRUE@o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]\)/ -O1 /' -e 's/[[:blank:]]-Ofast/ -O1 /g'
+-@ENABLE_O_FLAG_MUNGING_TRUE@o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]*\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
++@ENABLE_O_FLAG_MUNGING_TRUE@o_flag_munging = sed -e 's/[[:blank:]]-O\([2-9sgz][2-9sgz]\)/ -O1 /g' -e 's/[[:blank:]]-Ofast/ -O1 /g'
  @ENABLE_INSTRUMENTATION_MUNGING_FALSE@instrumentation_munging = cat
  
  # We need to disable instrumentation for these modules as they use cc as

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.9.1"
-PKG_SHA256="763b914c4779e9579ab4d06caffff39cc8f43a1c126ec3b7a2f920bf9817097b"
+PKG_VERSION="1.9.2"
+PKG_SHA256="8d68a8b45796f34f7cace357b9f89b8c92b158557274fef5889b03648b55fe59"
 PKG_LICENSE="MIT"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- go: update to 1.24.3
- gettext: update to 0.25
- hwdata: update to 0.395
- iwd: update to 3.8
- libgcrypt: update to 1.11.1
- sqlite: update to 3.49.2
- libnl: build with pic
- libxkbcommon: update to 1.9.2