### PR TITLE
rust: update to 1.87.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="37156542b702e8b4ffd1c5c75017632582343e93ca378285cdc92196c85c77e3"
+    PKG_SHA256="51e237e7f383840a404a5be721491a8ca4671bf9c14e62566ecadccfcc6e4291"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="406915facc75bca5142a0c25f88d1df94859a8e42dcd571c8596b664d681e050"
+    PKG_SHA256="661376af716de8d6abf943891bc0d8ff6b1733d97ee7da9be92820b8e11d20d1"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="c5c1590f7e9246ad9f4f97cfe26ffa92707b52a769726596a9ef81565ebd908b"
+    PKG_SHA256="469d5dc479835adadd728bc3587f8abf1941b3dd71f9865abd3e0783ae662555"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="176129577a5d560bbd94bcd2d24c0228bb495b73219df02556b4e4b4f0815bf7"
+    PKG_SHA256="80fab79c1f57b7cd89a1e6379b2196a208352403aa7bd7f674341a172ac0697f"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="71a3fd8a5c028e34791740ca15b59cc946a052c4e41403f39e1743f298aaa508"
+    PKG_SHA256="a3f6fd620fb284318e349197a50f9ecf4bccbfb21d8e55a93d7fe1bfdf9d6e92"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="67be7184ea388d8ce0feaf7fdea46f1775cfc2970930264343b3089898501d37"
+    PKG_SHA256="1b57253bd32b8b292c965b3a2d992a266763158494cab8555584c09360b90f77"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.86.0"
-PKG_SHA256="022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80"
+PKG_VERSION="1.87.0"
+PKG_SHA256="149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -33,7 +33,7 @@ configure_host() {
   esac
 
   cat >${PKG_BUILD}/config.toml  <<END
-change-id = 136941
+change-id = 138986
 
 [llvm]
 download-ci-llvm = false

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="ccece9e59546d2e6ff3fc3b8f4b033aab21631c271eefbe814b3cbace6628c6e"
+    PKG_SHA256="93c59a880632aa1c69e3ffaa1830b5b19c08341ae2cd364bf4e6d13901facfed"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="4eccec69511e8d4dc74ad48e9d5bd4b0f98899f4b3cea148f55c25a4c9a64359"
+    PKG_SHA256="87d7dabf505b057f13feb291e253ef35d1483b61b5284df43ce0fff9a51e91cf"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="4438b809ce4a083af31ed17aeeedcc8fc60ccffc0625bef1926620751b6989d7"
+    PKG_SHA256="e8395c5c5756253b76107055e093ffbc4431af7b30aeebe72ce2684b9cb53973"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/
- rust: update to 1.87.0
  - rustc-snapshot: update to 1.87.0
  - rust-std-snapshot: update to 1.87.0
  - cargo-snapshot: update to 1.87.0
