### PR TITLE
allow libclc target builds for AArch64

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -63,6 +63,12 @@ get_graphicdrivers() {
     VAAPI_SUPPORT="yes"
   fi
 
+  if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+    GALLIUM_DRIVERS+=" pvr"
+    LLVM_SUPPORT="yes"
+    V4L2_SUPPORT="yes"
+  fi
+
   if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
     GALLIUM_DRIVERS+=" iris"
     XORG_DRIVERS+=" intel"

--- a/packages/devel/libclc/package.mk
+++ b/packages/devel/libclc/package.mk
@@ -6,6 +6,7 @@ PKG_VERSION="$(get_pkg_version llvm)"
 PKG_LICENSE="NCSA OR MIT"
 PKG_URL=""
 PKG_DEPENDS_HOST="toolchain:host llvm:host"
+PKG_DEPENDS_TARGET="toolchain llvm:host"
 PKG_LONGDESC="Low-Level Virtual Machine (LLVM) is a compiler infrastructure."
 PKG_DEPENDS_UNPACK+=" llvm"
 PKG_PATCH_DIRS+=" $(get_pkg_directory llvm)/patches"
@@ -26,4 +27,15 @@ pre_configure_host() {
   mkdir -p "${PKG_BUILD}/.${HOST_NAME}"
   cd ${PKG_BUILD}/.${HOST_NAME}
   PKG_CMAKE_OPTS_HOST="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD}"
+}
+
+pre_configure_target() {
+  LIBCLC_TARGETS_TO_BUILD="spirv64-mesa3d-"
+
+  mkdir -p "${PKG_BUILD}/.${TARGET_NAME}"
+  cd ${PKG_BUILD}/.${TARGET_NAME}
+  # cross-compile: use HOST LLVM so cmake finds clang/llvm-spirv, not sysroot LLVM whose tools were stripped
+  PKG_CMAKE_OPTS_TARGET="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD} \
+                         -DLLVM_DIR=${TOOLCHAIN}/lib/cmake/llvm \
+                         -DLIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR=${TOOLCHAIN}/bin"
 }

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -79,6 +79,10 @@ if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
   PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system -Dprecomp-compiler=system"
 fi
 
+if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+  PKG_DEPENDS_TARGET+=" libclc"
+fi
+
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
               [ "${OPENGL_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" != "x11" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -122,14 +122,30 @@ post_makeinstall_host() {
 }
 
 pre_configure_target() {
+  case "${TARGET_ARCH}" in
+    "aarch64")
+      LLVM_BUILD_TARGETS="AArch64"
+      # build clang (required to build libclc runtime for imagination mesa driver)
+      # llvm:target is only required to build mesa imagination for some aarch64 targets
+      LLVM_BUILD_CLANG="-DLLVM_ENABLE_PROJECTS='clang' \
+                        -DCLANG_LINK_CLANG_DYLIB=ON"
+      ;;
+    "x86_64")
+      LLVM_BUILD_TARGETS="AMDGPU"
+      # do not build clang (not needed)
+      # llvm:target is only required to build mesa amd on x86_64 targets
+      LLVM_BUILD_CLANG="-DLLVM_ENABLE_PROJECTS=''"
+      ;;
+  esac
+
   mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
   cd ${PKG_BUILD}/.${TARGET_NAME}
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_COMMON} \
                          -DCMAKE_BINARY_DIR=${PKG_BUILD}/.${TARGET_NAME} \
                          -DLLVM_NATIVE_BUILD=${PKG_BUILD}/.${TARGET_NAME}/native \
                          -DCMAKE_CROSSCOMPILING=ON \
-                         -DLLVM_ENABLE_PROJECTS='' \
-                         -DLLVM_TARGETS_TO_BUILD=AMDGPU \
+                         ${LLVM_BUILD_CLANG} \
+                         -DLLVM_TARGETS_TO_BUILD=${LLVM_BUILD_TARGETS} \
                          -DLLVM_TARGET_ARCH="${TARGET_ARCH}" \
                          -DLLVM_TABLEGEN=${TOOLCHAIN}/bin/llvm-tblgen"
 }

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -42,13 +42,13 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_ENABLE_Z3_SOLVER=OFF \
                        -DCMAKE_SKIP_RPATH=ON"
 
-if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
   PKG_DEPENDS_UNPACK="spirv-headers spirv-llvm-translator"
   PKG_CMAKE_OPTS_COMMON+=" -DLLVM_SPIRV_INCLUDE_TESTS=OFF"
 fi
 
 post_unpack() {
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     mkdir -p "${PKG_BUILD}"/llvm/projects/{SPIRV-Headers,SPIRV-LLVM-Translator}
       tar --strip-components=1 \
         -xf "${SOURCES}/spirv-headers/spirv-headers-$(get_pkg_version spirv-headers).tar.gz" \
@@ -104,7 +104,7 @@ post_make_host() {
                       llvm-profdata llvm-readobj llvm-size llvm-strip \
                       llvm-tblgen opt
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     ninja ${NINJA_OPTS} llvm-spirv
   fi
 }
@@ -116,7 +116,7 @@ post_makeinstall_host() {
     cp -a bin/{llvm-profdata,llvm-readobj,llvm-size,llvm-strip} "${TOOLCHAIN}/bin"
     cp -a bin/{llvm-tblgen,opt} "${TOOLCHAIN}/bin"
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     cp -a bin/llvm-spirv "${TOOLCHAIN}/bin"
   fi
 }


### PR DESCRIPTION
- llvm: enable target builds for aarch64
- libclc: allow for target builds

The draft WIP looks to have been mostly correct. With the issue being the inclusion of the cmake cross-compile flags (`-DLLVM_DIR` and `-DLIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR`) — without these cmake finds the sysroot's LLVM config (whose binaries were stripped by post_makeinstall_target()), can't locate clang/llvm-spirv, and the configure fails

Also adding the plumbing for imagination:
- config/graphic: add imagination driver block
  - GALLIUM_DRIVERS+=pvr (Mesa PowerVR gallium driver)
  - LLVM_SUPPORT=yes (llvm:target with AArch64+clang for libclang.so)
  - V4L2_SUPPORT=yes
- llvm: extend (iris|panfrost) condition to include imagination
  - spirv-headers and spirv-llvm-translator unpacked for imagination builds
  - llvm-spirv built and installed to TOOLCHAIN/bin so libclc:target can
    find it at configure time
- mesa: add libclc to PKG_DEPENDS_TARGET for imagination builds
  - libclc:target installs spirv64-mesa3d-.spv to /usr/share/clc/ on device
    for runtime SPIR-V lookup by the pvr driver


```diff
@@ -33,5 +34,8 @@ pre_configure_target() {

   mkdir -p "${PKG_BUILD}/.${TARGET_NAME}"
   cd ${PKG_BUILD}/.${TARGET_NAME}
-  PKG_CMAKE_OPTS_TARGET="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD}"
+  # cross-compile: use HOST LLVM so cmake finds clang/llvm-spirv, not sysroot LLVM whose tools were stripped
+  PKG_CMAKE_OPTS_TARGET="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD} \
+                         -DLLVM_DIR=${TOOLCHAIN}/lib/cmake/llvm \
+                         -DLIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR=${TOOLCHAIN}/bin"
 }
```