### PR TITLE
rust: fix aarch64 build against llvm-20.1

### DIFF
--- a/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
@@ -1,7 +1,7 @@
 {
   "arch": "aarch64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,


### PR DESCRIPTION
ref:
- https://github.com/llvm/llvm-project/commit/c9f27275c1330a325661bdf14fb3bc444a5e3648