### PR TITLE
wireguard-tools: update to 1.0.20250521

### DIFF
--- a/packages/network/wireguard-tools/package.mk
+++ b/packages/network/wireguard-tools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireguard-tools"
-PKG_VERSION="1.0.20210914"
-PKG_SHA256="69de713458a887cddb46b2fd1d43bf20548f693136af95792e65ec925538c770"
+PKG_VERSION="1.0.20250521"
+PKG_SHA256="6afe492647c3b0b2f68ab6df524e9e4290d03c34c3027e069e5bbc486949960e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.wireguard.com"
 PKG_URL="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-v${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
log: https://github.com/WireGuard/wireguard-tools/compare/v1.0.20210914...v1.0.20250521