### PR TITLE
mesa: fix logic error in glvnd selection

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -69,8 +69,7 @@ if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
-              [ "${OPENGL_SUPPORT}" = "yes" ] &&
-              [ "${DISPLAYSERVER}" != "x11" ]; then
+              [ "${OPENGL_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" != "x11" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"
   PKG_MESON_OPTS_TARGET+=" -Dglvnd=enabled"
 else


### PR DESCRIPTION
Commit 9d2001f14ec7 ("Add Generic-gl device") introduced a subtle error in the glvnd enablement logic that lead to the Generic-Legacy image being built without glvnd which breaks nvidia support.

Unlike most programming languages "||" and "&&" have the same precedence in shell and "A || B && C" get evaluated as "(A || B) && C" instead of the intended "A || (B && C)".

Fix this by moving the "AND not-X11" check into the "GL" test and adjust formatting to make the intention clear.

ping @smp79 