### PR TITLE
Package updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.4.2"
-PKG_SHA256="4712aada64b9b49ad41fbb8b440914481432a560f2619ffbdd49461f8d22994f"
+PKG_VERSION="1.4.3"
+PKG_SHA256="93e31e49016ab3e44f9ecd45f5d6bfa5b99a000d486ac6e27fd01b7fc0b8a8ec"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.4.5"
-PKG_SHA256="07803adff502edf9b294ba1953cd99e2729d728bcb13c20f823633f7507040a6"
+PKG_VERSION="3.4.6"
+PKG_SHA256="27b57790896b7464e1b87fb29bad49e31ee36fdb6942e5c86284c6af9630be0e"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/debug/libunwind/package.mk
+++ b/packages/debug/libunwind/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libunwind"
-PKG_VERSION="1.8.1"
-PKG_SHA256="38833b7b1582db7d76485a62a213706c9252b3dab7380069fea5824e823d8e41"
+PKG_VERSION="1.8.2"
+PKG_SHA256="3b888e01f3d25f7914bbfd31139066bb4547e079322975134b03c92e4c6a2066"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.nongnu.org/libunwind/"
 PKG_URL="https://github.com/libunwind/libunwind/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="10.0p1"
+PKG_VERSION="10.0p2"
 PKG_SHA256="021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"

--- a/packages/python/devel/meson/package.mk
+++ b/packages/python/devel/meson/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="meson"
-PKG_VERSION="1.8.0"
-PKG_SHA256="0a9b23311271519bd03dca12d7d8b0eab582c3a2c5da433d465b6e519dc88e2f"
+PKG_VERSION="1.8.1"
+PKG_SHA256="b4e3b80e8fa633555abf447a95a700aba1585419467b2710d5e5bf88df0a7011"
 PKG_LICENSE="Apache"
 PKG_SITE="https://mesonbuild.com"
 PKG_URL="https://github.com/mesonbuild/meson/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- meson: update to 1.8.1
- libunwind: update to 1.8.2
- mariadb-connector-c: update to 3.4.6
- openssh: update to 10.0p2
  - version number is bumped but source is the same with same hash
- pipewire: update to 1.4.3