### PR TITLE
flex: revert chnage to use TARGET_CC

### DIFF
--- a/packages/devel/flex/package.mk
+++ b/packages/devel/flex/package.mk
@@ -18,14 +18,6 @@ PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared --disable-rpath --with
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_realloc_0_nonnull=yes \
                            ac_cv_func_malloc_0_nonnull=yes"
 
-pre_configure_target() {
-  export CC_FOR_BUILD="${CC}";
-  export CFLAGS_FOR_BUILD="${CFLAGS}";
-  export CPP_FOR_BUILD="${CPP}";
-  export CPPFLAGS_FOR_BUILD="${CPPFLAGS}";
-  export LDFLAGS_FOR_BUILD="${LDFLAGS}";
-}
-
 post_makeinstall_host() {
   cat >${TOOLCHAIN}/bin/lex  <<"EOF"
 #!/bin/sh


### PR DESCRIPTION
- fixes https://github.com/LibreELEC/LibreELEC.tv/pull/10083#issuecomment-2907804315
- Need to revisit the flex:target build and best use the stage1flex binary from host, instead to building it in target.
- #10083 