### PR TITLE
libretro-scummvm: fix findstring armv7 check

### DIFF
--- a/packages/emulation/libretro-scummvm/patches/0003-libretro-fix-armv7-GCC-15.1-internal-compiler-error.patch
+++ b/packages/emulation/libretro-scummvm/patches/0003-libretro-fix-armv7-GCC-15.1-internal-compiler-error.patch
@@ -15,7 +15,7 @@ index 0181825bfbbc..383a25cab706 100644
     DEFINES += -Os
  else ifneq (,$(findstring $(platform), ios osx))
     DEFINES += -O1
-+else ifneq (,$(findstring $(platform), armv7)) # fixes a GCC 15.1 internal compiler error. TODO check if it is fixed in GCC newer releases.
++else ifneq (,$(findstring armv7, $(platform))) # fixes a GCC 15.1 internal compiler error. TODO check if it is fixed in GCC newer releases.
 +   DEFINES += -O1
  else ifneq (,$(findstring $(platform), msvc genode rpi))
     DEFINES += -O2


### PR DESCRIPTION
- ref: https://github.com/libretro/scummvm/issues/81#issuecomment-2910940105

> fixed by [e566a64](https://github.com/libretro/scummvm/commit/e566a6432fd1951417bf78280cc7c741957fc419)

I got round to checking CI/CD and it was still failing. I have had to reverse the lookup as findstring was not finding platform in armv7.

```
Executing (target): make all platform=armv7a-libreelec-linux-gnueabihf
Platform is armv7a-libreelec-linux-gnueabihf 32bit
```
fix should be
```diff
diff --git a/packages/emulation/libretro-scummvm/patches/0003-libretro-fix-armv7-GCC-15.1-internal-compiler-error.patch b/packages/emulation/libretro-scummvm/patches/0003-libretr
o-fix-armv7-GCC-15.1-internal-compiler-error.patch
index 29728dfcb3..360ca9d8d6 100644
--- a/packages/emulation/libretro-scummvm/patches/0003-libretro-fix-armv7-GCC-15.1-internal-compiler-error.patch
+++ b/packages/emulation/libretro-scummvm/patches/0003-libretro-fix-armv7-GCC-15.1-internal-compiler-error.patch
@@ -15,7 +15,7 @@ index 0181825bfbbc..383a25cab706 100644
     DEFINES += -Os
  else ifneq (,$(findstring $(platform), ios osx))
     DEFINES += -O1
-+else ifneq (,$(findstring $(platform), armv7)) # fixes a GCC 15.1 internal compiler error. TODO check if it is fixed in GCC newer releases.
++else ifneq (,$(findstring armv7, $(platform))) # fixes a GCC 15.1 internal compiler error. TODO check if it is fixed in GCC newer releases.
 +   DEFINES += -O1
  else ifneq (,$(findstring $(platform), msvc genode rpi))
     DEFINES += -O2
```
