### PR TITLE
busybox: unbrand and simplify the sudo warning

### DIFF
--- a/packages/sysutils/busybox/scripts/sudo
+++ b/packages/sysutils/busybox/scripts/sudo
@@ -2,14 +2,9 @@
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
-message="$message\n There is no working 'sudo'."
-message="$message\n "
-message="$message\n On debian/ubuntu/all general purpose linux distributions 'sudo'"
-message="$message\n allows a permitted user to execute a command as the superuser"
-message="$message\n or another user, as specified by the security policy"
-message="$message\n "
-message="$message\n With LibreELEC you have root access by default, so you dont need 'sudo'"
+message="$message\n You are 'root' so 'sudo' is not required or supported"
 message="$message\n "
 
 echo -e $message


### PR DESCRIPTION
This unbrands the sudo warning and greatly simplifies the current warning text.