### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="98b305725d453b6802a4df1e4c8184b66cf8d74e9050bbf3d92b2804621cb9f6"
+PKG_SHA256="4a95c430381101c418e02e1ad87679237f3b59d909fa26d9fd36103d0cd36930"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="4eba3773274f9d21ba90ae5bc719c3f1e4bb07a1"
+export PKG_GIT_COMMIT="e6534b4eb700e592f25e7213568a02f3ce37460d"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.0.5"
-PKG_SHA256="617917606c64df1cab19a0f5cc20fd724ed9187314bcd40eaacf66a9e75b1eb8"
+PKG_VERSION="2.1.1"
+PKG_SHA256="6ac779e87926ac1fe4360ffee63efd9f829b15a887e612be9a7d2f8a652674e9"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="fb4c30d4ede3531652d86197bf3fc9515e5276d9"
+export PKG_GIT_COMMIT="cb1076646aa3740577fafbf3d914198b7fe8e3f7"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="28.1.1"
-PKG_SHA256="5c9402ef5886be7683260a424c02de199b45b7e15633d90e03faaf672f7041fc"
+PKG_VERSION="28.2.2"
+PKG_SHA256="07363d32256c9b9d595fdb18fccb1ab8a575ce07ae0ff9a9e16580c35f1ba926"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="01f442b84d6a669c1e335b800d4670997cd5aa93"
+export PKG_GIT_COMMIT="45873be4ae3f5488c9498b3d9f17deaddaf609f4"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/podman/gpgme/package.mk
+++ b/packages/addons/addon-depends/podman/gpgme/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpgme"
-PKG_VERSION="1.24.2"
-PKG_SHA256="e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581"
+PKG_VERSION="1.24.3"
+PKG_SHA256="bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd"
 PKG_LICENSE="gpgme"
 PKG_SITE="https://gnupg.org/software/gpgme/index.html"
 PKG_URL="https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/addon-depends/podman/netavark/package.mk
+++ b/packages/addons/addon-depends/podman/netavark/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netavark"
-PKG_VERSION="1.14.1"
-PKG_SHA256="fd4a25db0abe73e2d0d7a9958f298ace134671edc64259cbc8ea3c2907f89dd8"
+PKG_VERSION="1.15.1"
+PKG_SHA256="e81b28d4d5768d4c98a6dc2fff8432b42018e26ff891501f62af8cc577e69b1c"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/netavark"
 PKG_URL="https://github.com/containers/netavark/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.4.1"
-PKG_SHA256="502117195c06678db612313aaf42505cabeea860f8668802a0608754eb0df9f6"
+PKG_VERSION="5.5.0"
+PKG_SHA256="a4abfc72ef9a59ba80d081ea604ad2976ff967ae526e50e234edc1d2481bd9d1"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="b79bc8afe796cba51dd906270a7e1056ccdfcf9e"
+export PKG_GIT_COMMIT="0dbcb51477ee7ab8d3b47d30facf71fc38bb0c98"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="1.3.48"
-PKG_SHA256="fe77ca93cdd53023ad5c67c1a01c5a296c88e34f6761c46b3ab73e7a7abb6325"
-PKG_REV="1"
+PKG_VERSION="1.3.49"
+PKG_SHA256="4b3914aee03c982c4b3f9652b69ac183ec4183931bc5ba9eb24b6bf0033de74c"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="1.29.5"
-PKG_SHA256="17f60258af1043db93f1df3609222cdd40b4fdcccae5c60dce46c557e0796098"
-PKG_REV="1"
+PKG_VERSION="1.29.6"
+PKG_SHA256="28e7f4984a6a34fb4697448141ce2611a6510f5a4369c1669d4e766eb75cd878"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
- podman: update to 5.5.0 and addon (1)
  - netavark: update to 1.15.1
  - podman-bin: update to 5.5.0
  - containerd: update to 2.1.1
  - gpgme: update to 1.24.3
- docker: update to 28.2.2 and addon (2)
  - cli: update to 28.2.2
  - moby: update to 28.2.2
  - containerd: update to 2.1.1
- minisatip: update to 1.3.49 and addon (2)
- syncthing: update to 1.29.6 and addon (2)