### PR TITLE
flex: use flex:host stage1flex when building scan.c from scan.l

### DIFF
--- a/packages/devel/flex/package.mk
+++ b/packages/devel/flex/package.mk
@@ -9,13 +9,14 @@ PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/westes/flex"
 PKG_URL="https://github.com/westes/flex/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host m4:host autotools:host bison:host"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain flex:host"
 PKG_LONGDESC="A tool for generating programs that perform pattern-matching on text."
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared --disable-rpath --with-gnu-ld"
 
-PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_realloc_0_nonnull=yes \
+PKG_CONFIGURE_OPTS_TARGET="--disable-bootstrap \
+                           ac_cv_func_realloc_0_nonnull=yes \
                            ac_cv_func_malloc_0_nonnull=yes"
 
 post_makeinstall_host() {

--- a/packages/devel/flex/patches/flex-0001-use-flex-host-for-target-cross-compile.patch
+++ b/packages/devel/flex/patches/flex-0001-use-flex-host-for-target-cross-compile.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.am	2025-05-25 13:43:29.363027456 +0000
++++ b/src/Makefile.am	2025-05-25 13:44:38.701129436 +0000
+@@ -100,7 +100,7 @@
+ 	./stage1flex$(EXEEXT) $(AM_LFLAGS) $(LFLAGS) -o $@ $(srcdir)/scan.l
+ else
+ stage1scan.c: scan.c
+-	sed 's|^\(#line .*\)"'`printf %s $< | sed 's|[][\\\\.*]|\\\\&|g'`'"|\1"$@"|g' $< > $@
++	../../.$(HOST_NAME)/src/stage1flex$(EXEEXT) $(AM_LFLAGS) $(LFLAGS) -o $@ $(srcdir)/scan.l
+ endif
+ 
+ dist-hook: scan.l flex$(EXEEXT)


### PR DESCRIPTION
The compile logic whilst building a CROSS compiled flex could be improved. Given that we have already built flex:host and the necessary stage1flex, just use it. Using the --disable-bootstrap logic in the make file which would normally call sed, replace the sed call with the call to be previously built stage1flex. Both the patch and the update to package.mk are required.
- #10083
- #10091 
- https://github.com/westes/flex/pull/674