### PR TITLE
kodi: update to githash de5db92

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="264adc124d4770ffef0e3de5b11478077cfd4152"
-PKG_SHA256="1057f12c69dfc1397848692d6e8aa79518585e2e7a9ff3647cecab53b9a88025"
+PKG_VERSION="de5db9200b6e42972db6ebdd4b4c908f23179cac"
+PKG_SHA256="41b6ad56549b55399218a664186131bcad4d1ed354cf6831a1f0a8de32113010"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@ -1,16 +1,26 @@
-Subject: disable online check
-
----
+diff --git a/xbmc/GUIInfoManager.cpp b/xbmc/GUIInfoManager.cpp
+index e2aa9643ab89..d258e84f73d4 100644
 --- a/xbmc/GUIInfoManager.cpp
 +++ b/xbmc/GUIInfoManager.cpp
-@@ -1953,7 +1953,6 @@ const infomap system_labels[] = {
-     {"currentcontrol", SYSTEM_CURRENT_CONTROL},
-     {"currentcontrolid", SYSTEM_CURRENT_CONTROL_ID},
-     {"dvdlabel", SYSTEM_DVD_LABEL},
--    {"internetstate", SYSTEM_INTERNET_STATE},
-     {"osversioninfo", SYSTEM_OS_VERSION_INFO},
-     {"kernelversion", SYSTEM_OS_VERSION_INFO}, // old, not correct name
-     {"uptime", SYSTEM_UPTIME},
+@@ -1907,7 +1907,7 @@ constexpr std::array<InfoMap, 7> weather = {{
+ ///     <p>
+ ///   }
+ // clang-format off
+-constexpr std::array<InfoMap, 76> system_labels = {{
++constexpr std::array<InfoMap, 75> system_labels = {{
+     {"hasnetwork",              SYSTEM_ETHERNET_LINK_ACTIVE},
+     {"hasmediadvd",             SYSTEM_MEDIA_DVD},
+     {"hasmediaaudiocd",         SYSTEM_MEDIA_AUDIO_CD},
+@@ -1955,7 +1955,6 @@ constexpr std::array<InfoMap, 76> system_labels = {{
+     {"currentcontrol",          SYSTEM_CURRENT_CONTROL},
+     {"currentcontrolid",        SYSTEM_CURRENT_CONTROL_ID},
+     {"dvdlabel",                SYSTEM_DVD_LABEL},
+-    {"internetstate",           SYSTEM_INTERNET_STATE},
+     {"osversioninfo",           SYSTEM_OS_VERSION_INFO},
+     {"kernelversion",           SYSTEM_OS_VERSION_INFO}, // old, not correct name
+     {"uptime",                  SYSTEM_UPTIME},
+diff --git a/xbmc/utils/SystemInfo.cpp b/xbmc/utils/SystemInfo.cpp
+index 049d7449528d..83f08e08d1c2 100644
 --- a/xbmc/utils/SystemInfo.cpp
 +++ b/xbmc/utils/SystemInfo.cpp
 @@ -281,7 +281,6 @@ bool CSysInfoJob::DoWork()
@@ -21,7 +31,7 @@ Subject: disable online check
    m_info.videoEncoder      = GetVideoEncoder();
    m_info.cpuFrequency =
        StringUtils::Format("{:4.0f} MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
-@@ -1107,9 +1106,7 @@ int CSysInfo::GetXbmcBitness(void)
+@@ -1119,9 +1118,7 @@ int CSysInfo::GetXbmcBitness(void)
  
  bool CSysInfo::HasInternet()
  {
@@ -32,9 +42,11 @@ Subject: disable online check
  }
  
  std::string CSysInfo::GetHddSpaceInfo(int drive, bool shortText)
+diff --git a/xbmc/windows/GUIWindowSystemInfo.cpp b/xbmc/windows/GUIWindowSystemInfo.cpp
+index bf007ccfa687..b7628ae6cc51 100644
 --- a/xbmc/windows/GUIWindowSystemInfo.cpp
 +++ b/xbmc/windows/GUIWindowSystemInfo.cpp
-@@ -126,7 +126,6 @@ void CGUIWindowSystemInfo::FrameMove()
+@@ -147,7 +147,6 @@ void CGUIWindowSystemInfo::FrameMove()
      SetControlLabel(i++, "{}: {}", 13160, NETWORK_GATEWAY_ADDRESS);
      SetControlLabel(i++, "{}: {}", 13161, NETWORK_DNS1_ADDRESS);
      SetControlLabel(i++, "{}: {}", 20307, NETWORK_DNS2_ADDRESS);


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/264adc124d4770ffef0e3de5b11478077cfd4152...de5db9200b6e42972db6ebdd4b4c908f23179cac

- I got around to testing why Kodi was crashing on launch when bumping it. If I revert https://github.com/xbmc/xbmc/pull/26744 I was able to run a Kodi with 26746 and 26751. So pretty sure it is isolated to that PR. When going forward, I have had to revert the 4 PRs so as to revert 26744.

With this PR as-is with the reverts, My Kodi is running fine.


im getting the crash here

```
Using host libthread_db library "/usr/lib/libthread_db.so.1".
Core was generated by `/usr/lib/kodi/kodi.bin --standalone -fs --audio-backend=alsa+pulseaudio'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f060c542019 in ?? () from /usr/lib/libc.so.6
[Current thread is 1 (Thread 0x7f060332afc0 (LWP 120311))]

2025-06-03 22:47:30.927 T:120421   debug <general>: Initialize, updating databases... DONE
2025-06-03 22:47:30.928 T:120311   debug <general>: CDRMUtils::DrmFbGetFromBo - using modifier: INTEL_Y_TILED
2025-06-03 22:47:30.928 T:120421   debug <general>: LoadUserFonts: Updating user fonts cache...
2025-06-03 22:47:30.928 T:120421   debug <general>: LoadXMLData: Couldn't load 'special://home/media/Fonts/fontcache.xml' the file don't exists
2025-06-03 22:47:30.928 T:120421   debug <general>: LoadUserFonts: Updating user fonts cache... DONE
2025-06-03 22:47:30.942 T:120311   debug <general>: CDRMUtils::DrmFbGetFromBo - using modifier: INTEL_Y_TILED
2025-06-03 22:47:30.947 T:120385   debug <general>: CLibInputHandler::DeviceAdded - keyboard type device added: Power Button (event1)
2025-06-03 22:47:30.947 T:120385   debug <general>: CLibInputKeyboard::GetRepeat - could not get key repeat for event1 (Function not implemented)
2025-06-03 22:47:30.947 T:120385   debug <general>: CLibInputKeyboard::GetRepeat - delay: 400ms repeat: 80ms for Power Button (event1)
2025-06-03 22:47:30.958 T:120311   debug <general>: CGBMUtils - using 4 buffers
2025-06-03 22:47:30.959 T:120311   debug <general>: CDRMUtils::DrmFbGetFromBo - using modifier: INTEL_Y_TILED
2025-06-03 22:47:30.959 T:120311    info <general>: Unloaded skin
2025-06-03 22:47:30.960 T:120311    info <general>:   load skin from: /usr/share/kodi/addons/skin.estuary/ (version: 4.1.0)
2025-06-03 22:47:30.960 T:120311    info <general>:   load fonts for skin...
2025-06-03 22:47:30.960 T:120311    info <general>: Loading colors from /usr/share/kodi/addons/skin.estuary/colors/maroon.xml
2025-06-03 22:47:30.960 T:120311    info <general>: Loading skin includes from /usr/share/kodi/addons/skin.estuary/xml/Includes.xml
2025-06-03 22:47:30.973 T:120311    info <general>: LoadFontsFromFile: Loading <fontset> with name 'Default' from '/usr/share/kodi/addons/skin.estuary/xml/Font.xml'
2025-06-03 22:47:30.975 T:120311   debug <general>: LocalizeStrings: loaded 173 strings from file /usr/share/kodi/addons/skin.estuary/language/resource.language.en_gb/strings.po
2025-06-03 22:47:30.975 T:120311    info <general>: LoadTimers: Trying to load skin timers from /usr/share/kodi/addons/skin.estuary/xml/Timers.xml
``` 

to test with 26744 you will need the following patch to out patches.
```diff

Author: Rudi Heitbaum <rudi@heitbaum.com>
Date:   Tue Jun 3 12:43:26 2025 +0000

    WIP on dev: 81af28ac98 Revert "kodi: update to githash 83f8baa"

diff --cc packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
index 1f5d899d20,1f5d899d20..c8e0372d8b
--- a/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.03-disable-online-check.patch
@@@ -3,14 -3,14 +3,14 @@@ Subject: disable online chec
  ---
  --- a/xbmc/GUIInfoManager.cpp
  +++ b/xbmc/GUIInfoManager.cpp
--@@ -1953,7 +1953,6 @@ const infomap system_labels[] = {
--     {"currentcontrol", SYSTEM_CURRENT_CONTROL},
--     {"currentcontrolid", SYSTEM_CURRENT_CONTROL_ID},
--     {"dvdlabel", SYSTEM_DVD_LABEL},
---    {"internetstate", SYSTEM_INTERNET_STATE},
--     {"osversioninfo", SYSTEM_OS_VERSION_INFO},
--     {"kernelversion", SYSTEM_OS_VERSION_INFO}, // old, not correct name
--     {"uptime", SYSTEM_UPTIME},
++@@ -1955,7 +1955,6 @@ const infomap system_labels[] = {
++     {"currentcontrol",          SYSTEM_CURRENT_CONTROL},
++     {"currentcontrolid",        SYSTEM_CURRENT_CONTROL_ID},
++     {"dvdlabel",                SYSTEM_DVD_LABEL},
++-    {"internetstate",           SYSTEM_INTERNET_STATE},
++     {"osversioninfo",           SYSTEM_OS_VERSION_INFO},
++     {"kernelversion",           SYSTEM_OS_VERSION_INFO}, // old, not correct name
++     {"uptime",                  SYSTEM_UPTIME},
  --- a/xbmc/utils/SystemInfo.cpp
  +++ b/xbmc/utils/SystemInfo.cpp
  @@ -281,7 +281,6 @@ bool CSysInfoJob::DoWork()
@@@ -21,7 -21,7 +21,7 @@@
     m_info.videoEncoder      = GetVideoEncoder();
     m_info.cpuFrequency =
         StringUtils::Format("{:4.0f} MHz", CServiceBroker::GetCPUInfo()->GetCPUFrequency());
--@@ -1107,9 +1106,7 @@ int CSysInfo::GetXbmcBitness(void)
++@@ -1119,9 +1118,7 @@ int CSysInfo::GetXbmcBitness(void)
   
   bool CSysInfo::HasInternet()
   {
@@@ -34,7 -34,7 +34,7 @@@
   std::string CSysInfo::GetHddSpaceInfo(int drive, bool shortText)
  --- a/xbmc/windows/GUIWindowSystemInfo.cpp
  +++ b/xbmc/windows/GUIWindowSystemInfo.cpp
--@@ -126,7 +126,6 @@ void CGUIWindowSystemInfo::FrameMove()
++@@ -147,7 +147,6 @@ void CGUIWindowSystemInfo::FrameMove()
       SetControlLabel(i++, "{}: {}", 13160, NETWORK_GATEWAY_ADDRESS);
       SetControlLabel(i++, "{}: {}", 13161, NETWORK_DNS1_ADDRESS);
       SetControlLabel(i++, "{}: {}", 20307, NETWORK_DNS2_ADDRESS);

``` 