### PR TITLE
mesa: update to 25.1.2

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="25.1.1"
-PKG_SHA256="cf942a18b7b9e9b88524dcbf0b31fed3cde18e6d52b3375b0ab6587a14415bce"
+PKG_VERSION="25.1.2"
+PKG_SHA256="c29c93fd35119b949a589463d1feb61b4000c0daad04e8d543d7f909f119bd97"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Ann: https://lists.freedesktop.org/archives/mesa-dev/2025-June/226512.html

```
=== tested on ===
Generic.x86_64-devel-20250604225053-f3b048c
Linux nuc12 6.15.0 #1 SMP Wed Jun  4 06:18:28 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:de5db9200b6e42972db6ebdd4b4c908f23179cac). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-06-04 by GCC 15.1.0 for Linux x86 64-bit version 6.15.0 (397056)
Running on LibreELEC (heitbaum): devel-20250604225053-f3b048c 13.0, kernel: Linux x86 64-bit version 6.15.0
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0096.2025.0115.1051 01/15/2025
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.2
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.3 (d01b041c0f)
```