### PR TITLE
kodi-binary-addons: add game.shader.presets add-on

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.shader.presets/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.shader.presets/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.shader.presets"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="f32a20569bbaccf347814d048284e462e51b0678cf9b8ce12e4be72b3d48b357"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.shader.presets"
+PKG_URL="https://github.com/kodi-game/game.shader.presets/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_SECTION=""
+PKG_SHORTDESC="game.shader.presets: Shader preset support"
+PKG_LONGDESC="game.shader.presets adds libretro meta shader preset support"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Add shader presets add-on needed by recently merged https://github.com/xbmc/xbmc/pull/26435.