### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/go/package.mk
+++ b/packages/addons/addon-depends/go/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="go"
-PKG_VERSION="1.24.3"
-PKG_SHA256="4358c465e80e2124bee1969dd5e8f84d4f445a2c5a58b4b33f17bfe9e9deefed"
+PKG_VERSION="1.24.4"
+PKG_SHA256="0ffcfbfb5cf7f29c7fe5383550f1212c577c4d8cb29d1470432f76e9859bd4c0"
 PKG_LICENSE="BSD"
 PKG_SITE="https://golang.org"
 PKG_URL="https://github.com/golang/go/archive/${PKG_NAME}${PKG_VERSION}.tar.gz"

--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.7.13"
-PKG_SHA256="dcd7cde4f9c498eb496c4556e1c1b81353e2a74747e8270a42565117ea42e1f1"
+PKG_VERSION="0.8.0"
+PKG_SHA256="553ee9c63c4b3cbc9b664d5bc31d8bc4eeb345fad8809f03cbf93147a108ab32"
 PKG_LICENSE="BSD"
 PKG_SITE="https://lib.openmpt.org/libopenmpt/"
 PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"

--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="2.0.2"
-PKG_SHA256="0de288d7fe34ba133199fd8512f19cc1100196826eafcb67a33b224ec3a59737"
+PKG_VERSION="2.1"
+PKG_SHA256="95b788b39eaebab41f7e6d1c1d05ceee01a5d1225e4b6d11ed8976e96ba90b0c"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/devel/groovy/package.mk
+++ b/packages/devel/groovy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="groovy"
-PKG_VERSION="4.0.26"
-PKG_SHA256="3be6880c6de70eada2f3f5c69e1e94953e0b0c4e33c4604c1040d05dddeaed92"
+PKG_VERSION="4.0.27"
+PKG_SHA256="bc917c8bb01b2832f124a7bd63a3c72ba5e83ef7f056650dfd9a2f7944960685"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://groovy.apache.org"
 PKG_URL="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-${PKG_VERSION}.zip"

--- a/packages/devel/hwdata/package.mk
+++ b/packages/devel/hwdata/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="hwdata"
-PKG_VERSION="0.395"
-PKG_SHA256="1166f733c57afa82cfdad56e62ef044835fbc8c99ef65f033e6a5802716b5c66"
+PKG_VERSION="0.396"
+PKG_SHA256="6ed6ff6eb9d137b9669af6966974643a015cf302a39237ef84dd2efa5e20bae8"
 PKG_LICENSE="GPL-2.0"
 PKG_SITE="https://github.com/vcrhonek/hwdata"
 PKG_URL="https://github.com/vcrhonek/hwdata/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/assimp/package.mk
+++ b/packages/graphics/assimp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="assimp"
-PKG_VERSION="5.4.3"
-PKG_SHA256="66dfbaee288f2bc43172440a55d0235dfc7bf885dda6435c038e8000e79582cb"
+PKG_VERSION="6.0.1"
+PKG_SHA256="0c6ec0e601cab4700019c1e60b5cd332cc6355e63e59c11344693623c08a7d38"
 PKG_LICENSE="BSD"
 PKG_SITE="https://github.com/assimp/assimp"
 PKG_URL="https://github.com/assimp/assimp/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/lang/lua54/package.mk
+++ b/packages/lang/lua54/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lua54"
-PKG_VERSION="5.4.7"
-PKG_SHA256="9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30"
+PKG_VERSION="5.4.8"
+PKG_SHA256="4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.lua.org"
 PKG_URL="http://www.lua.org/ftp/lua-${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="25.2.3"
-PKG_SHA256="adc2968c49bcf5b7cc8bce09a785b96785cee10d577dac9eabb97f02916f7a22"
+PKG_VERSION="25.2.4"
+PKG_SHA256="ae36411645c01b17ec4a0997f3e7eccc54087391c3307f291c2edfa4a0511c2d"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.22.1"
-PKG_SHA256="6a1f89f1ab25916e255f1c2c3a4a88235a854af2eca40bb9d9bba7545b684a0a"
+PKG_VERSION="4.22.2"
+PKG_SHA256="d9ac8e224a200159e62c651cf42307dc162212ec25d04eb6800b9a7ccfbcc3c1"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/libusb/package.mk
+++ b/packages/sysutils/libusb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libusb"
-PKG_VERSION="1.0.28"
-PKG_SHA256="966bb0d231f94a474eaae2e67da5ec844d3527a1f386456394ff432580634b29"
+PKG_VERSION="1.0.29"
+PKG_SHA256="5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
 PKG_LICENSE="LGPLv2.1"
 PKG_SITE="http://libusb.info/"
 PKG_URL="https://github.com/libusb/libusb/releases/download/v${PKG_VERSION}/libusb-${PKG_VERSION}.tar.bz2"

--- a/packages/sysutils/squashfs-tools/package.mk
+++ b/packages/sysutils/squashfs-tools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squashfs-tools"
-PKG_VERSION="4.6.1"
-PKG_SHA256="94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c"
+PKG_VERSION="4.7"
+PKG_SHA256="f1605ef720aa0b23939a49ef4491f6e734333ccc4bda4324d330da647e105328"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/plougher/squashfs-tools"
 PKG_URL="https://github.com/plougher/squashfs-tools/archive/${PKG_VERSION}.tar.gz"
@@ -18,6 +18,7 @@ make_host() {
           mksquashfs \
           XZ_SUPPORT=0 \
           LZO_SUPPORT=1 \
+          LZ4_SUPPORT=0 \
           ZSTD_SUPPORT=1 \
           XATTR_SUPPORT=0 \
           XATTR_DEFAULT=0 \


### PR DESCRIPTION
- go: update to 1.24.4
- media-driver: update to 25.2.4
- samba: update to 4.22.2
- lua54: update to 5.4.8
- hwdata: update to 0.396
- squashfs-tools: update to 4.7
- assimp: update to 6.0.1
- libusb: update to 1.0.29
- groovy: update to 4.0.27
- libopenmpt: update to 0.8.0
- taglib: update to 2.1