### PR TITLE
mesa: drop deprecated options

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -30,10 +30,7 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-rusticl=false \
-                       -Dgallium-nine=false \
-                       -Dgallium-opencl=disabled \
                        -Dshader-cache=enabled \
-                       -Dshared-glapi=enabled \
                        -Dopengl=true \
                        -Dgbm=enabled \
                        -Degl=enabled \
@@ -42,8 +39,7 @@ PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dlmsensors=disabled \
                        -Dbuild-tests=false \
                        -Ddraw-use-llvm=false \
-                       -Dmicrosoft-clc=disabled \
-                       -Dosmesa=false"
+                       -Dmicrosoft-clc=disabled"
 
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr"


### PR DESCRIPTION
The following options are now deprecated:
- DEPRECATION: Option 'gallium-nine' is deprecated
  - was false and defaults to false
- DEPRECATION: Option 'gallium-opencl' is deprecated
  - was false and defaults to false
- DEPRECATION: Option 'shared-glapi' is deprecated
  - option now does nothing
- DEPRECATION: Option 'osmesa' is deprecated
  - option now does nothing
- no change at this time:
  - DEPRECATION: Option 'gallium-xa' is deprecated
    - this deprecated option has been left as-is until it is removed by upstream. this is expected in mesa 25.2 is set to true for vmware otherwise was false and defaults to false