### PR TITLE
espeak-ng: update to githash a06074c and use cmake

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -119,7 +119,7 @@
   PIPEWIRE_SUPPORT="no"
 
 # build and install eSpeak-NG support (yes / no)
-  ESPEAK_SUPPORT="no"
+  ESPEAK_SUPPORT="yes"
 
 # build and install with BluRay support (yes / no)
   KODI_BLURAY_SUPPORT="yes"

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -2,37 +2,29 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="espeak-ng"
-PKG_VERSION="1.52.0"
-PKG_SHA256="bb4338102ff3b49a81423da8a1a158b420124b055b60fa76cfb4b18677130a23"
+PKG_VERSION="a06074c8fd80f2fd3632164dc01ebf1135395e11"
+PKG_SHA256="6e5ab2c975b46ad126f74f57de9b0a543f301b42d97965710ba81105a6d75232"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/espeak-ng/espeak-ng"
-PKG_URL="https://github.com/espeak-ng/espeak-ng/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/espeak-ng/espeak-ng/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="gcc:host"
 PKG_DEPENDS_TARGET="toolchain espeak-ng:host"
 PKG_LONGDESC="eSpeak NG is an open source speech synthesizer that supports more than a hundred languages and accents"
-PKG_TOOLCHAIN="autotools"
+PKG_BUILD_FLAGS="+pic"
 
-make_host() {
-  mkdir phsource dictsource
-  (
-    cd dictsource
-    ln -s ../../dictsource/* .
-  )
-  (
-    cd phsource
-    ln -s ../../phsource/* .
-  )
-  cp -aP ../espeak-ng-data .
-  make DESTDIR=$(pwd) -j1
-}
+PKG_CMAKE_OPTS_HOST="-DBUILD_SHARED_LIBS=OFF \
+                     -DCOMPILE_INTONATIONS=ON \
+                     -DENABLE_TESTS=OFF"
 
-make_target() {
-  make src/espeak-ng src/speak-ng
-}
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=ON \
+                       -DCOMPILE_INTONATIONS=OFF \
+                       -DENABLE_TESTS=OFF"
 
-makeinstall_target() {
-  make src/espeak-ng src/speak-ng
-  make install-exec DESTDIR=${INSTALL}
+post_makeinstall_target() {
+  safe_remove ${INSTALL}/usr/share/vim
+
   mkdir -p ${INSTALL}/usr/share/espeak-ng-data
   cp -prf ${TOOLCHAIN}/share/espeak-ng-data ${INSTALL}/usr/share
+  # add symlink for backwards compatibility with old programs
+  ln -sf espeak-ng ${INSTALL}/usr/bin/espeak
 }

--- a/packages/audio/espeak-ng/patches/espeak-ng-0001-allow-build-of-intonations.patch
+++ b/packages/audio/espeak-ng/patches/espeak-ng-0001-allow-build-of-intonations.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt	2025-05-31 11:45:48.000000000 +0000
++++ b/CMakeLists.txt	2025-06-09 11:10:14.439292321 +0000
+@@ -15,7 +15,7 @@
+ include(cmake/deps.cmake)
+ include(cmake/config.cmake)
+ add_subdirectory(src)
+-if (COMPILE_INTONATIONS AND NOT CMAKE_CROSSCOMPILING)
++if (COMPILE_INTONATIONS)
+   include(cmake/data.cmake)
+ endif()
+ include(cmake/docs.cmake)
+@@ -23,7 +23,7 @@
+ include(cmake/package.cmake)
+ include(CPack)
+ 
+-if(ENABLE_TESTS AND NOT CMAKE_CROSSCOMPILING)
++if(ENABLE_TESTS)
+   add_subdirectory(tests)
+ endif()
+ 

--- a/packages/audio/espeak-ng/patches/espeak-ng-0002-find-and-link-pthread.patch
+++ b/packages/audio/espeak-ng/patches/espeak-ng-0002-find-and-link-pthread.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/deps.cmake b/cmake/deps.cmake
+index b63ced21ba89..95498cdb32d5 100644
+--- a/cmake/deps.cmake
++++ b/cmake/deps.cmake
+@@ -2,14 +2,15 @@ find_library(SONIC_LIB sonic)
+ find_path(SONIC_INC "sonic.h")
+ find_library(PCAUDIO_LIB pcaudio)
+ find_path(PCAUDIO_INC "pcaudiolib/audio.h")
+-find_library(PTHREAD_LIB pthread)
++set(THREADS_PREFER_PTHREAD_FLAG ON)
++find_package(Threads)
+ find_program(MBROLA_BIN mbrola)
+ 
+ include(FetchContent)
+ 
+-if (PTHREAD_LIB)
++if (CMAKE_USE_PTHREADS_INIT)
+   set(HAVE_PTHREAD ON)
+-endif(PTHREAD_LIB)
++endif(CMAKE_USE_PTHREADS_INIT)
+ if (MBROLA_BIN)
+   set(HAVE_MBROLA ON)
+ endif(MBROLA_BIN)
+diff --git a/src/libespeak-ng/CMakeLists.txt b/src/libespeak-ng/CMakeLists.txt
+index dd01aeb2d7c8..bb39dc281ca8 100644
+--- a/src/libespeak-ng/CMakeLists.txt
++++ b/src/libespeak-ng/CMakeLists.txt
+@@ -109,6 +109,10 @@ if (HAVE_LIBPCAUDIO AND USE_LIBPCAUDIO)
+   endif()
+ endif()
+ 
++if (HAVE_PTHREAD)
++  target_link_libraries(espeak-ng PRIVATE Threads::Threads)
++endif()
++
+ target_link_libraries(espeak-ng PRIVATE espeak-ng-config ucd)
+ if (NOT MSVC)
+   target_link_libraries(espeak-ng PRIVATE m)


### PR DESCRIPTION
- needed fix: https://github.com/espeak-ng/espeak-ng/issues/2048, so patch the PATH_MAX to 256
- Now included https://github.com/espeak-ng/espeak-ng/pull/2220

cross_compiling check fails because we use a different host name from host so patch out the check and manually set build of intonations and tests

```
$ du -sk build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/espeak-ng-9fb8ed27d5748cbaac336e525d3bcba21ec06d5c/
20620   build.LibreELEC-Generic.x86_64-13.0-devel/install_pkg/espeak-ng-9fb8ed27d5748cbaac336e525d3bcba21ec06d5c/
```

https://forum.libreelec.tv/thread/24881-libreelec-10-0-accessibility/?postID=200604#post200604