### PR TITLE
e2fsprogs: remove e2mmpstatus as it is a link to dumpe2fs

### DIFF
--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -84,6 +84,7 @@ post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/sbin/blkid
   rm -rf ${INSTALL}/usr/sbin/dumpe2fs
   rm -rf ${INSTALL}/usr/sbin/e2freefrag
+  rm -rf ${INSTALL}/usr/sbin/e2mmpstatus
   rm -rf ${INSTALL}/usr/sbin/e2undo
   rm -rf ${INSTALL}/usr/sbin/e4defrag
   rm -rf ${INSTALL}/usr/sbin/filefrag


### PR DESCRIPTION
![IMG_0618](https://github.com/user-attachments/assets/5828bd7f-abda-4d89-b4db-8292af6045c5)
