### PR TITLE
kodi: update to githash 93eeae9

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="ce89e7d9c62e800d5914d719ce5e22804d37c3b3"
-PKG_SHA256="65339cfad8efd52975d13474b088187f7afb9adc169e70c0e07b6aa52ddeb14d"
+PKG_VERSION="93eeae9b860a6f0dff4942be0e714f5d10ce2fa4"
+PKG_SHA256="9571a2d52d9c0e0b3496b66915fe756c22fe142b5d119e62fb186abad7d639b9"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/ce89e7d9c62e800d5914d719ce5e22804d37c3b3...93eeae9b860a6f0dff4942be0e714f5d10ce2fa4

```
=== tested on ===
Generic.x86_64-devel-20250611103351-e9f28f6
Linux nuc12 6.16.0-rc1 #1 SMP Wed Jun 11 08:45:41 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:93eeae9b860a6f0dff4942be0e714f5d10ce2fa4). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-06-11 by GCC 15.1.0 for Linux x86 64-bit version 6.16.0 (397312)
Running on LibreELEC (heitbaum): devel-20250611103351-e9f28f6 13.0, kernel: Linux x86 64-bit version 6.16.0-rc1
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0096.2025.0115.1051 01/15/2025
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.3
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.4 (16e8a12a4a)
```