### PR TITLE
Revert "libxml2: update to 2.14.4"

### DIFF
--- a/packages/textproc/libxml2/package.mk
+++ b/packages/textproc/libxml2/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxml2"
-PKG_VERSION="2.14.4"
-PKG_SHA256="8e20c2ef2fc7965d7851e3ab3a756c3fc8b449ba47526269a9b4d7f0480550db"
+PKG_VERSION="2.14.3"
+PKG_SHA256="9d5805e78055a4507e30944b99fb554f98142f540a092836b01d68ab344fd703"
 PKG_LICENSE="MIT"
 PKG_SITE="http://xmlsoft.org"
 PKG_URL="https://gitlab.gnome.org/GNOME/${PKG_NAME}/-/archive/v${PKG_VERSION}/${PKG_NAME}-v${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
This reverts commit 7f84ab88d699b66ca47ac350e7dd57d10e1b076e.

error with:
```
CMake Error at /build/build.LibreELEC-H3.arm-13.0-devel/toolchain/lib/cmake/libxml2-2.14.4/libxml2-export.cmake:61 (set_target_properties):
  The link interface of target "LibXml2::LibXml2" contains:

    Iconv::Iconv

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
 ```