### PR TITLE
curl: do not build docs

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -32,6 +32,7 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_DEBUG=OFF \
                        -DCURL_DISABLE_SMTP=ON \
                        -DCURL_DISABLE_GOPHER=ON \
                        -DCURL_DISABLE_MQTT=ON \
+                       -DBUILD_LIBCURL_DOCS=OFF \
                        -DENABLE_CURL_MANUAL=OFF \
                        -DENABLE_IPV6=ON \
                        -DENABLE_THREADED_RESOLVER=ON \


### PR DESCRIPTION
addresses build error by not building the documents
```
ninja: error: '/build/build.LibreELEC-AMLGX.aarch64-12.80.md/build/curl-8.14.1/.aarch64-libreelec-linux-gnu/docs/libcurl/libcurl-symbols.md', needed by 'docs/libcurl/curl_easy_cleanup.3', missing and no known rule to make it
```