### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="4a95c430381101c418e02e1ad87679237f3b59d909fa26d9fd36103d0cd36930"
+PKG_SHA256="0ac18927138cd2582e02277d365174a118b962f10084a6bef500a58de705e094"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="e6534b4eb700e592f25e7213568a02f3ce37460d"
+export PKG_GIT_COMMIT="38b7060a218775811da953650d8df7d492653f8f"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.1.1"
-PKG_SHA256="6ac779e87926ac1fe4360ffee63efd9f829b15a887e612be9a7d2f8a652674e9"
+PKG_VERSION="2.1.3"
+PKG_SHA256="f5fd43b9eefd71ddef100e7070016f9e40a1d689251bc885a2d2a87750da26b5"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="cb1076646aa3740577fafbf3d914198b7fe8e3f7"
+export PKG_GIT_COMMIT="c787fb98911740dd3ff2d0e45ce88cdf01410486"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/docker-compose/package.mk
+++ b/packages/addons/addon-depends/docker/docker-compose/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker-compose"
-PKG_VERSION="2.37.2"
+PKG_VERSION="2.37.3"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/docker/compose"
 PKG_LONGDESC="Define and run multi-container applications with Docker."
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="d2c195cf553e55d06761c192133a6a7b4d67d275c7f5ce673bbf8ecf20814061"
+    PKG_SHA256="15646d01e9291e69c9173a0d140d3ef44f912d26ffb2cbeeaf91aeb460dae59e"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-aarch64"
     ;;
   "arm")
-    PKG_SHA256="33aa26709150e835992a8af58d590e32151473f78daea549ccd70bd5f96c3bbf"
+    PKG_SHA256="2abef7f6a59d5402206f11461b69b6314a5dfdcfdd235b9acfce661d9255f2be"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-armv7"
     ;;
   "x86_64")
-    PKG_SHA256="95db7bb2ed5d5fc790a12559b9092d641637c2d0190939c282b52a7af572a8a7"
+    PKG_SHA256="522181c447d831fb23134201d9cdc5cf365f913408124c678089ea62d6a2334c"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-x86_64"
     ;;
 esac

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="28.2.2"
-PKG_SHA256="07363d32256c9b9d595fdb18fccb1ab8a575ce07ae0ff9a9e16580c35f1ba926"
+PKG_VERSION="28.3.0"
+PKG_SHA256="99fe19d2a15d3cc56b9bd5e782664a85c2a7027566a4acc5c07ec8d42666362b"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="45873be4ae3f5488c9498b3d9f17deaddaf609f4"
+export PKG_GIT_COMMIT="265f709647947fb5a1adf7e4f96f2113dcc377bd"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/moby-001-user-addon-storage-location.patch
@@ -4,8 +4,8 @@
 #
 #
 diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
---- a/cmd/dockerd/daemon_unix.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/cmd/dockerd/daemon_unix.go	2025-02-20 10:29:44.441745187 +0000
+--- a/cmd/dockerd/daemon_unix.go	2025-06-20 16:22:35.000000000 +0000
++++ b/cmd/dockerd/daemon_unix.go	2025-06-25 12:49:40.558287815 +0000
 @@ -21,7 +21,7 @@
  
  func getDefaultDaemonConfigDir() string {
@@ -16,8 +16,8 @@ diff -Naur a/cmd/dockerd/daemon_unix.go b/cmd/dockerd/daemon_unix.go
  	// NOTE: CLI uses ~/.docker while the daemon uses ~/.config/docker, because
  	// ~/.docker was not designed to store daemon configurations.
 diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
---- a/cmd/dockerd/options.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/cmd/dockerd/options.go	2025-02-20 10:29:44.441449933 +0000
+--- a/cmd/dockerd/options.go	2025-06-20 16:22:35.000000000 +0000
++++ b/cmd/dockerd/options.go	2025-06-25 12:49:40.557989909 +0000
 @@ -39,7 +39,7 @@
  	//
  	//   - DOCKER_CONFIG only affects TLS certificates, but does not change the
@@ -36,10 +36,22 @@ diff -Naur a/cmd/dockerd/options.go b/cmd/dockerd/options.go
  	//   - look at "when" (and when _not_) XDG_CONFIG_HOME should be used. Its
  	//     needed for rootless, but perhaps could be used for non-rootless(?)
  	//   - When changing  the location for TLS config, (ideally) they should
+diff -Naur a/daemon/config/config_linux_test.go b/daemon/config/config_linux_test.go
+--- a/daemon/config/config_linux_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/daemon/config/config_linux_test.go	2025-06-25 12:49:40.538939276 +0000
+@@ -377,7 +377,7 @@
+ 	}{
+ 		{
+ 			name:       "deprecated-key-path",
+-			configJSON: `{"deprecated-key-path": "/etc/docker/key.json"}`,
++			configJSON: `{"deprecated-key-path": "/storage/.kodi/userdata/addon_data/service.system.docker/config/key.json"}`,
+ 		},
+ 		{
+ 			name:       "allow-nondistributable-artifacts",
 diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/authz/authz_plugin_test.go
---- a/integration/plugin/authz/authz_plugin_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/integration/plugin/authz/authz_plugin_test.go	2025-02-20 10:29:44.406641256 +0000
-@@ -56,15 +56,15 @@
+--- a/integration/plugin/authz/authz_plugin_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/integration/plugin/authz/authz_plugin_test.go	2025-06-25 12:49:40.521643361 +0000
+@@ -57,15 +57,15 @@
  
  	ctrl = &authorizationController{}
  
@@ -59,8 +71,8 @@ diff -Naur a/integration/plugin/authz/authz_plugin_test.go b/integration/plugin/
  		ctrl = nil
  	})
 diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integration-cli/docker_cli_external_volume_driver_test.go
---- a/integration-cli/docker_cli_external_volume_driver_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/integration-cli/docker_cli_external_volume_driver_test.go	2025-02-20 10:29:44.713041018 +0000
+--- a/integration-cli/docker_cli_external_volume_driver_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/integration-cli/docker_cli_external_volume_driver_test.go	2025-06-25 12:49:40.867460226 +0000
 @@ -266,10 +266,10 @@
  		send(w, `{"Capabilities": { "Scope": "global" }}`)
  	})
@@ -75,12 +87,12 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
  	return s
  }
 @@ -277,7 +277,7 @@
- func (s *DockerExternalVolumeSuite) TearDownSuite(ctx context.Context, c *testing.T) {
+ func (s *DockerExternalVolumeSuite) TearDownSuite(ctx context.Context, t *testing.T) {
  	s.volumePlugin.Close()
  
 -	err := os.RemoveAll("/etc/docker/plugins")
 +	err := os.RemoveAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins")
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  }
  
 @@ -371,7 +371,7 @@
@@ -93,8 +105,8 @@ diff -Naur a/integration-cli/docker_cli_external_volume_driver_test.go b/integra
  	assert.NilError(c, err)
  	defer os.RemoveAll(specPath)
 diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/docker_cli_network_unix_test.go
---- a/integration-cli/docker_cli_network_unix_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/integration-cli/docker_cli_network_unix_test.go	2025-02-20 10:29:44.713475312 +0000
+--- a/integration-cli/docker_cli_network_unix_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/integration-cli/docker_cli_network_unix_test.go	2025-06-25 12:49:40.867898684 +0000
 @@ -226,14 +226,14 @@
  		}
  	})
@@ -119,13 +131,13 @@ diff -Naur a/integration-cli/docker_cli_network_unix_test.go b/integration-cli/d
  
 -	err := os.RemoveAll("/etc/docker/plugins")
 +	err := os.RemoveAll("/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins")
- 	assert.NilError(c, err)
+ 	assert.NilError(t, err)
  }
  
 diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_cli_swarm_test.go
---- a/integration-cli/docker_cli_swarm_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/integration-cli/docker_cli_swarm_test.go	2025-02-20 10:29:44.716710173 +0000
-@@ -825,14 +825,14 @@
+--- a/integration-cli/docker_cli_swarm_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/integration-cli/docker_cli_swarm_test.go	2025-06-25 12:49:40.871279027 +0000
+@@ -843,14 +843,14 @@
  		}
  	})
  
@@ -143,7 +155,7 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	err = os.WriteFile(ipamFileName, []byte(url), 0o644)
  	assert.NilError(t, err)
  }
-@@ -845,7 +845,7 @@
+@@ -863,7 +863,7 @@
  	setupRemoteGlobalNetworkPlugin(c, mux, s.server.URL, globalNetworkPlugin, globalIPAMPlugin)
  	defer func() {
  		s.server.Close()
@@ -153,9 +165,9 @@ diff -Naur a/integration-cli/docker_cli_swarm_test.go b/integration-cli/docker_c
  	}()
  
 diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remote/driver_test.go
---- a/libnetwork/drivers/remote/driver_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/libnetwork/drivers/remote/driver_test.go	2025-02-20 10:29:44.707404748 +0000
-@@ -44,7 +44,7 @@
+--- a/libnetwork/drivers/remote/driver_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/libnetwork/drivers/remote/driver_test.go	2025-06-25 12:49:40.861763019 +0000
+@@ -40,7 +40,7 @@
  }
  
  func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
@@ -165,9 +177,9 @@ diff -Naur a/libnetwork/drivers/remote/driver_test.go b/libnetwork/drivers/remot
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/remote_test.go
---- a/libnetwork/ipams/remote/remote_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/libnetwork/ipams/remote/remote_test.go	2025-02-20 10:29:44.699434031 +0000
-@@ -38,7 +38,7 @@
+--- a/libnetwork/ipams/remote/remote_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/libnetwork/ipams/remote/remote_test.go	2025-06-25 12:49:40.854121508 +0000
+@@ -35,7 +35,7 @@
  }
  
  func setupPlugin(t *testing.T, name string, mux *http.ServeMux) func() {
@@ -177,8 +189,8 @@ diff -Naur a/libnetwork/ipams/remote/remote_test.go b/libnetwork/ipams/remote/re
  		specPath = filepath.Join(os.Getenv("programdata"), "docker", "plugins")
  	}
 diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_test.go
---- a/libnetwork/libnetwork_unix_test.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/libnetwork/libnetwork_unix_test.go	2025-02-20 10:29:44.709262867 +0000
+--- a/libnetwork/libnetwork_unix_test.go	2025-06-20 16:22:35.000000000 +0000
++++ b/libnetwork/libnetwork_unix_test.go	2025-06-25 12:49:40.864001829 +0000
 @@ -2,4 +2,4 @@
  
  package libnetwork_test
@@ -186,8 +198,8 @@ diff -Naur a/libnetwork/libnetwork_unix_test.go b/libnetwork/libnetwork_unix_tes
 -var specPath = "/etc/docker/plugins"
 +var specPath = "/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins"
 diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
---- a/pkg/plugins/discovery.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/pkg/plugins/discovery.go	2025-02-20 10:29:44.412930502 +0000
+--- a/pkg/plugins/discovery.go	2025-06-20 16:22:35.000000000 +0000
++++ b/pkg/plugins/discovery.go	2025-06-25 12:49:40.525984485 +0000
 @@ -128,12 +128,12 @@
  //
  // On Unix in non-rootless mode:
@@ -204,9 +216,9 @@ diff -Naur a/pkg/plugins/discovery.go b/pkg/plugins/discovery.go
  func SpecsPaths() []string {
  	return specsPaths()
 diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
---- a/pkg/plugins/discovery_unix.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/pkg/plugins/discovery_unix.go	2025-02-20 10:29:44.412746807 +0000
-@@ -12,7 +12,7 @@
+--- a/pkg/plugins/discovery_unix.go	2025-06-20 16:22:35.000000000 +0000
++++ b/pkg/plugins/discovery_unix.go	2025-06-25 12:49:40.525803226 +0000
+@@ -13,7 +13,7 @@
  	if configHome, err := homedir.GetConfigHome(); err != nil {
  		return filepath.Join(configHome, "docker/plugins")
  	}
@@ -215,7 +227,7 @@ diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
  }
  
  func rootlessLibPluginsPath() string {
-@@ -27,5 +27,5 @@
+@@ -28,5 +28,5 @@
  	if rootless.RunningWithRootlessKit() {
  		return []string{rootlessConfigPluginsPath(), rootlessLibPluginsPath()}
  	}
@@ -223,8 +235,8 @@ diff -Naur a/pkg/plugins/discovery_unix.go b/pkg/plugins/discovery_unix.go
 +	return []string{"/storage/.kodi/userdata/addon_data/service.system.docker/config/plugins", "/usr/lib/docker/plugins"}
  }
 diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
---- a/pkg/plugins/plugins.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/pkg/plugins/plugins.go	2025-02-20 10:29:44.413216747 +0000
+--- a/pkg/plugins/plugins.go	2025-06-20 16:22:35.000000000 +0000
++++ b/pkg/plugins/plugins.go	2025-06-25 12:49:40.526271398 +0000
 @@ -4,7 +4,7 @@
  // Docker discovers plugins by looking for them in the plugin directory whenever
  // a user or container tries to use one by name. UNIX domain socket files must
@@ -235,8 +247,8 @@ diff -Naur a/pkg/plugins/plugins.go b/pkg/plugins/plugins.go
  // its name if it exists.
  //
 diff -Naur a/registry/config_unix.go b/registry/config_unix.go
---- a/registry/config_unix.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/registry/config_unix.go	2025-02-20 10:29:44.712430143 +0000
+--- a/registry/config_unix.go	2025-06-20 16:22:35.000000000 +0000
++++ b/registry/config_unix.go	2025-06-25 12:49:40.866806097 +0000
 @@ -5,7 +5,7 @@
  // defaultCertsDir is the platform-specific default directory where certificates
  // are stored. On Linux, it may be overridden through certsDir, for example, when
@@ -247,9 +259,9 @@ diff -Naur a/registry/config_unix.go b/registry/config_unix.go
  // cleanPath is used to ensure that a directory name is valid on the target
  // platform. It will be passed in something *similar* to a URL such as
 diff -Naur a/registry/search_endpoint_v1.go b/registry/search_endpoint_v1.go
---- a/registry/search_endpoint_v1.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/registry/search_endpoint_v1.go	2025-02-20 10:29:44.712695815 +0000
-@@ -54,7 +54,7 @@
+--- a/registry/search_endpoint_v1.go	2025-06-20 16:22:35.000000000 +0000
++++ b/registry/search_endpoint_v1.go	2025-06-25 12:49:40.867087851 +0000
+@@ -58,7 +58,7 @@
  		if endpoint.IsSecure {
  			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`
  			// in case that's what they need. DO NOT accept unknown CA certificates, and DO NOT fall back to HTTP.
@@ -259,9 +271,9 @@ diff -Naur a/registry/search_endpoint_v1.go b/registry/search_endpoint_v1.go
  
  		// registry is insecure and HTTPS failed, fallback to HTTP.
 diff -Naur a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go
---- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-02-19 21:53:46.000000000 +0000
-+++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-02-20 10:29:44.668972179 +0000
-@@ -578,7 +578,7 @@
+--- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-06-20 16:22:35.000000000 +0000
++++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/config/hosts.go	2025-06-25 12:49:40.820074314 +0000
+@@ -607,7 +607,7 @@
  	return filepath.Join(base, p)
  }
  

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.5.1"
-PKG_SHA256="00d02f85ad27a46e77456fef1be81865a43147544ed2487e6c4c8decd0e3748f"
+PKG_VERSION="5.5.2"
+PKG_SHA256="a2dbd8280cd92d4741f32f5a99d385d7fc6f0dd36bc9cc90a7273767e26d43d9"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="850db76dd78a0641eddb9ee19ee6f60d2c59bcfa"
+export PKG_GIT_COMMIT="e7d8226745ba07a64b7176a7f128e4ef53225a0e"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/addon-depends/system-tools-depends/dtach/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/dtach/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dtach"
-PKG_VERSION="5e3865328e4609f74bd10cb4575e429b8d1b3aa4"
-PKG_SHA256="69c6c3da78c530ec74655d6beba0d2d3e16a23ab35b3022d8af691848063cc1e"
+PKG_VERSION="b027c27b2439081064d07a86883c8e0b20a183c9"
+PKG_SHA256="2ec8db52ed99700cf80258b52e77461068abf24a2798cb91f9c0b2bc6e6ee8f4"
 PKG_LICENSE="GPL"
 PKG_SITE="http://dtach.sourceforge.net"
 PKG_URL="https://github.com/crigler/dtach/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/mmc-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mmc-utils"
-PKG_VERSION="123fd8b2ac3933be1319486fb1f32236a4a86a7c"
-PKG_SHA256="d718338740cc75c8b0b54647a0522baff1824a31d4f9ee7d0d022405d07284f6"
+PKG_VERSION="1.0"
+PKG_SHA256="39e6a89e06b53f99816f110af6743d1adc82220b26c51b0c3fd0a11ccf4206c2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html"
 PKG_URL="https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/unrar/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="unrar"
-PKG_VERSION="7.1.7"
-PKG_SHA256="e86ae4f1f33a13752146f41e961c57f12f0ee01580ac188ec8cc43da5c22ae92"
+PKG_VERSION="7.1.8"
+PKG_SHA256="9ec7765a948140758af12ed29e3e47db425df79a9c5cbb71b28769b256a7a014"
 PKG_LICENSE="free"
 PKG_SITE="https://www.rarlab.com/rar_add.htm"
 PKG_URL="https://www.rarlab.com/rar/unrarsrc-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-satip/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-satip/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-satip"
-PKG_VERSION="20240720"
-PKG_SHA256="2a9709bfb31a3745c18c867a543d708eddbf4c41af898555e4a0daa63a2199a7"
+PKG_VERSION="20250621"
+PKG_SHA256="25e91ca2cd22fdb9f445395579f39054fddab31c06982a7c5a96fa851c56067f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://vdr-projects.github.io/"
 PKG_URL="https://github.com/wirbel-at-vdr-portal/vdr-plugin-satip/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr/package.mk
+++ b/packages/addons/addon-depends/vdr/package.mk
@@ -4,8 +4,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr"
-PKG_VERSION="2.7.5"
-PKG_SHA256="e1f1c46f984dfcb4f1a00bf16010dcb863ffaaf31b87872bd90c7cf800129f99"
+PKG_VERSION="2.7.6"
+PKG_SHA256="06c8ba921277129970308fb15db1c66d7c2874fd77fcff3aa1ca77b82ccb03de"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tvdr.de"
 PKG_URL="http://git.tvdr.de/?p=vdr.git;a=snapshot;h=refs/tags/${PKG_VERSION};sf=tbz2"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/filebrowser/package.mk
+++ b/packages/addons/service/filebrowser/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="filebrowser"
-PKG_VERSION="2.33.0"
-PKG_REV="1"
+PKG_VERSION="2.33.6"
+PKG_REV="2"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://filebrowser.org"
 PKG_DEPENDS_TARGET="toolchain:host"
@@ -15,15 +15,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="0dfa1b11c783427666657a30dea27dea5c2cde28c904516993835b13bfec49e8"
+    PKG_SHA256="4f7ae16300af1936b25400e59d0cadfa0ecd2f6bfceeb5c09469db7d60c872ac"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-arm64-filebrowser.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="ac1316bbd3805e345e7263bc72d779077421ad21a0f371e0e75de41982a281d4"
+    PKG_SHA256="11af3c9fe5ef01de4cca312ef2bab46e1fb4010b1e88b05693316d8b387d31d0"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-armv7-filebrowser.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="3405b8fdecf77375fa441cbe5d0b1b2af01c79ba18a67682e37a812db598234d"
+    PKG_SHA256="fc8338841c3c172df6d6a36dd30827eec3bacbbb8f41d954451b93d9028e3bd4"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-amd64-filebrowser.tar.gz"
     ;;
 esac

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -4,7 +4,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-addon"
-PKG_VERSION="2.7.5"
+PKG_VERSION="2.7.6"
 PKG_REV="0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- filebrowser: update to 2.33.6 and addon (2)
- docker-compose: update to 2.37.3
- docker: update to 28.3.0 and addon (1)
  - cli: update to 28.3.0
  - moby: update to 28.3.0
  - containerd: update to 2.1.3
- podman: update to 5.5.2 and addon (1)
  - podman-bin: update to 5.5.2
- system-tools: update addon (2)
  - dtach: update to githash b027c27
  - unrar: update to 7.1.8
  - mmc-utils: update to 1.0
- vdr-addon: update to 2.7.6
  - vdr-plugin-satip: update to 20250621
  - vdr: update to 2.7.6