### PR TITLE
rust: update to 1.88.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="51e237e7f383840a404a5be721491a8ca4671bf9c14e62566ecadccfcc6e4291"
+    PKG_SHA256="5aa43865f2002914ce4fca8916b4403bfca62f17e779ad368f6a17553296a58b"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="661376af716de8d6abf943891bc0d8ff6b1733d97ee7da9be92820b8e11d20d1"
+    PKG_SHA256="ad1b3737e7ac3a736a95f37ddd9a5d2d19f40dfc89197d544e9ca593c09f4dc7"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="469d5dc479835adadd728bc3587f8abf1941b3dd71f9865abd3e0783ae662555"
+    PKG_SHA256="856962610ee821648cee32e3d6abac667af7bb7ea6ec6f3d184cc31e66044f6b"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="80fab79c1f57b7cd89a1e6379b2196a208352403aa7bd7f674341a172ac0697f"
+    PKG_SHA256="e9ac4ff3c87247a2195fcceddbf1bdeee5c4fd337f014d8f4c4e3ac99002021f"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="a3f6fd620fb284318e349197a50f9ecf4bccbfb21d8e55a93d7fe1bfdf9d6e92"
+    PKG_SHA256="b5e1f168fa02ad57e1ace9ac3d379a9c95f816a26f12156216521a22e192f123"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="1b57253bd32b8b292c965b3a2d992a266763158494cab8555584c09360b90f77"
+    PKG_SHA256="36d7eacf46bd5199cb433e49a9ed9c9b380d82f8a0ebc05e89b43b51c070c955"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.87.0"
-PKG_SHA256="149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76"
+PKG_VERSION="1.88.0"
+PKG_SHA256="3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -33,7 +33,7 @@ configure_host() {
   esac
 
   cat >${PKG_BUILD}/config.toml  <<END
-change-id = 138986
+change-id = 140732
 
 [llvm]
 download-ci-llvm = false

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="93c59a880632aa1c69e3ffaa1830b5b19c08341ae2cd364bf4e6d13901facfed"
+    PKG_SHA256="b841d40bb98b2718c6452ec8421a4a8df584fce8d41875bcd9b1af83f52f7d96"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="87d7dabf505b057f13feb291e253ef35d1483b61b5284df43ce0fff9a51e91cf"
+    PKG_SHA256="aef877901f8c50443476cf4e7da2668ebcfc4e2b9bb804eba9072cb821002a33"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="e8395c5c5756253b76107055e093ffbc4431af7b30aeebe72ce2684b9cb53973"
+    PKG_SHA256="b049fd57fce274d10013e2cf0e05f215f68f6580865abc52178f66ae9bf43fd8"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rustc-snapshot: update to 1.88.0
- rust-std-snapshot: update to 1.88.0
- cargo-snapshot: update to 1.88.0
- rust: update to 1.88.0
- https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/