### PR TITLE
Linux update to 6.15.4

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,8 +30,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15"
     ;;
   *)
-    PKG_VERSION="6.15.1"
-    PKG_SHA256="44f1bb84fe512e7bafe0e6dc85d38ec1c6c8fcbe97ccb51d8c19930b799f0d64"
+    PKG_VERSION="6.15.4"
+    PKG_SHA256="0eafd627b602f58d73917d00e4fc3196ba18cba67df6995a42aa74744d8efa16"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     ;;

--- a/projects/Allwinner/linux/linux.aarch64.conf
+++ b/projects/Allwinner/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.15.0 Kernel Configuration
+# Linux/arm64 6.15.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-15.1.0 (GCC) 15.1.0"
 CONFIG_CC_IS_GCC=y
@@ -1616,6 +1616,7 @@ CONFIG_VEXPRESS_CONFIG=y
 # end of ARM System Control and Management Interface Protocol
 
 CONFIG_ARM_SCPI_PROTOCOL=y
+# CONFIG_ARM_SDE_INTERFACE is not set
 # CONFIG_FIRMWARE_MEMMAP is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
@@ -4483,7 +4484,6 @@ CONFIG_DRM_DW_HDMI_CEC=y
 # CONFIG_DRM_ETNAVIV is not set
 # CONFIG_DRM_HISI_KIRIN is not set
 # CONFIG_DRM_LOGICVC is not set
-# CONFIG_DRM_APPLETBDRM is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_GM12U320 is not set
 # CONFIG_DRM_PANEL_MIPI_DBI is not set
@@ -4938,8 +4938,6 @@ CONFIG_HID_A4TECH=y
 # CONFIG_HID_ACRUX is not set
 CONFIG_HID_APPLE=y
 # CONFIG_HID_APPLEIR is not set
-# CONFIG_HID_APPLETB_BL is not set
-# CONFIG_HID_APPLETB_KBD is not set
 CONFIG_HID_ASUS=m
 CONFIG_HID_AUREAL=m
 # CONFIG_HID_BELKIN is not set

--- a/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
+++ b/projects/NXP/devices/iMX8/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.15.0 Kernel Configuration
+# Linux/arm64 6.15.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-15.1.0 (GCC) 15.1.0"
 CONFIG_CC_IS_GCC=y
@@ -1763,6 +1763,7 @@ CONFIG_GENERIC_ARCH_TOPOLOGY=y
 # end of ARM System Control and Management Interface Protocol
 
 CONFIG_ARM_SCPI_PROTOCOL=y
+# CONFIG_ARM_SDE_INTERFACE is not set
 # CONFIG_FIRMWARE_MEMMAP is not set
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
@@ -4733,7 +4734,6 @@ CONFIG_DRM_ETNAVIV_THERMAL=y
 # CONFIG_DRM_LOGICVC is not set
 # CONFIG_DRM_MXSFB is not set
 # CONFIG_DRM_IMX_LCDIF is not set
-# CONFIG_DRM_APPLETBDRM is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_BOCHS is not set
 # CONFIG_DRM_CIRRUS_QEMU is not set
@@ -5196,8 +5196,6 @@ CONFIG_HID_A4TECH=y
 # CONFIG_HID_ACRUX is not set
 CONFIG_HID_APPLE=y
 # CONFIG_HID_APPLEIR is not set
-# CONFIG_HID_APPLETB_BL is not set
-# CONFIG_HID_APPLETB_KBD is not set
 CONFIG_HID_ASUS=y
 CONFIG_HID_AUREAL=y
 # CONFIG_HID_BELKIN is not set

--- a/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
+++ b/projects/Qualcomm/devices/Dragonboard/linux/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.15.0 Kernel Configuration
+# Linux/arm64 6.15.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-15.1.0 (GCC) 15.1.0"
 CONFIG_CC_IS_GCC=y
@@ -1800,6 +1800,7 @@ CONFIG_VEXPRESS_CONFIG=y
 # end of ARM System Control and Management Interface Protocol
 
 CONFIG_ARM_SCPI_PROTOCOL=y
+# CONFIG_ARM_SDE_INTERFACE is not set
 CONFIG_DMIID=y
 # CONFIG_DMI_SYSFS is not set
 # CONFIG_ISCSI_IBFT is not set
@@ -4438,7 +4439,6 @@ CONFIG_DRM_I2C_ADV7511_CEC=y
 # CONFIG_DRM_HISI_HIBMC is not set
 # CONFIG_DRM_HISI_KIRIN is not set
 # CONFIG_DRM_LOGICVC is not set
-# CONFIG_DRM_APPLETBDRM is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_BOCHS is not set
 # CONFIG_DRM_CIRRUS_QEMU is not set
@@ -4965,8 +4965,6 @@ CONFIG_HID_A4TECH=y
 # CONFIG_HID_ACRUX is not set
 CONFIG_HID_APPLE=y
 # CONFIG_HID_APPLEIR is not set
-# CONFIG_HID_APPLETB_BL is not set
-# CONFIG_HID_APPLETB_KBD is not set
 # CONFIG_HID_ASUS is not set
 # CONFIG_HID_AUREAL is not set
 CONFIG_HID_BELKIN=y

--- a/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3328/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.15.0 Kernel Configuration
+# Linux/arm64 6.15.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-15.1.0 (GCC) 15.1.0"
 CONFIG_CC_IS_GCC=y
@@ -1663,6 +1663,7 @@ CONFIG_GENERIC_ARCH_TOPOLOGY=y
 # end of ARM System Control and Management Interface Protocol
 
 CONFIG_ARM_SCPI_PROTOCOL=y
+# CONFIG_ARM_SDE_INTERFACE is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
 CONFIG_ARM_PSCI_FW=y
@@ -4225,7 +4226,6 @@ CONFIG_DRM_DW_HDMI_CEC=y
 # CONFIG_DRM_ETNAVIV is not set
 # CONFIG_DRM_HISI_KIRIN is not set
 # CONFIG_DRM_LOGICVC is not set
-# CONFIG_DRM_APPLETBDRM is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_GM12U320 is not set
 # CONFIG_DRM_PANEL_MIPI_DBI is not set
@@ -4674,8 +4674,6 @@ CONFIG_HID_A4TECH=y
 # CONFIG_HID_ACRUX is not set
 CONFIG_HID_APPLE=y
 # CONFIG_HID_APPLEIR is not set
-# CONFIG_HID_APPLETB_BL is not set
-# CONFIG_HID_APPLETB_KBD is not set
 CONFIG_HID_ASUS=y
 CONFIG_HID_AUREAL=y
 CONFIG_HID_BELKIN=y

--- a/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
+++ b/projects/Rockchip/devices/RK3399/linux/default/linux.aarch64.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.15.0 Kernel Configuration
+# Linux/arm64 6.15.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-libreelec-linux-gnu-gcc-15.1.0 (GCC) 15.1.0"
 CONFIG_CC_IS_GCC=y
@@ -1745,6 +1745,7 @@ CONFIG_GENERIC_ARCH_TOPOLOGY=y
 # end of ARM System Control and Management Interface Protocol
 
 CONFIG_ARM_SCPI_PROTOCOL=y
+# CONFIG_ARM_SDE_INTERFACE is not set
 # CONFIG_FW_CFG_SYSFS is not set
 # CONFIG_ARM_FFA_TRANSPORT is not set
 # CONFIG_GOOGLE_FIRMWARE is not set
@@ -4875,7 +4876,6 @@ CONFIG_DRM_DW_MIPI_DSI=y
 # CONFIG_DRM_HISI_HIBMC is not set
 # CONFIG_DRM_HISI_KIRIN is not set
 # CONFIG_DRM_LOGICVC is not set
-# CONFIG_DRM_APPLETBDRM is not set
 # CONFIG_DRM_ARCPGU is not set
 # CONFIG_DRM_BOCHS is not set
 # CONFIG_DRM_CIRRUS_QEMU is not set
@@ -5417,8 +5417,6 @@ CONFIG_HID_A4TECH=y
 # CONFIG_HID_ACRUX is not set
 CONFIG_HID_APPLE=y
 # CONFIG_HID_APPLEIR is not set
-# CONFIG_HID_APPLETB_BL is not set
-# CONFIG_HID_APPLETB_KBD is not set
 CONFIG_HID_ASUS=y
 CONFIG_HID_AUREAL=y
 CONFIG_HID_BELKIN=y


### PR DESCRIPTION
### packages updated
- linux: update to 6.15.y

### 6.15.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.15.2
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.15.3
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.15.4

6.15.2 - 34 patches
6.15.3 - 780 patches
6.15.4 - 589 patches

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.15.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.15.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.15
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.15.4 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.15.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.15.4 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.15.4 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX8 (Coral Dev Board - Phanbell) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum