### PR TITLE
systemd: remove systemd-creds

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -155,6 +155,10 @@ post_makeinstall_target() {
   # adjust systemd-hwdb-update (we have read-only /etc).
   sed '/^ConditionNeedsUpdate=.*$/d' -i ${INSTALL}/usr/lib/systemd/system/systemd-hwdb-update.service
 
+  # remove systemd-creds
+  safe_remove ${INSTALL}/usr/bin/systemd-creds
+  safe_remove ${INSTALL}/usr/lib/tmpfiles.d/credstore.conf
+
   # remove nspawn
   safe_remove ${INSTALL}/usr/bin/systemd-nspawn
   safe_remove ${INSTALL}/usr/lib/systemd/system/systemd-nspawn@.service


### PR DESCRIPTION
This removes `/usr/lib/tmpfiles.d/credstore.conf` and `/usr/bin/systemd-creds`. This is expected to resolve #10179.

tmpfiles.d/credstore.conf is what is creating /etc/credstore/ and /etc/credstore.encrypted/

Remove systemd-creds because I'm expecting this will have compromised how it functions and something trying to use it should error so we may identify what that something is. My understanding is that systemd-creds is intended as a go-between for using user credentials in service files without those credentials being in plaintext. See: https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html