### PR TITLE
gettext: disable modula2 support

### DIFF
--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -21,9 +21,10 @@ PKG_CONFIGURE_OPTS_HOST="--disable-static --enable-shared \
                          --with-included-libxml \
                          --disable-native-java \
                          --disable-csharp \
+                         --disable-modula2 \
                          --without-emacs"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-rpath"
+PKG_CONFIGURE_OPTS_TARGET="--disable-rpath --disable-modula2"
 
 post_configure_target() {
   libtool_remove_rpath gettext-runtime/libasprintf/libtool


### PR DESCRIPTION
Disabled modula2 support to avoid build time errors on systems that support this language in gcc.

It seems that the build process detects the local installation, generating errors during cross-compilation
```
/bin/dash ../libtool  --tag=CC   --mode=link /home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/bin/aarch64-libreelec-linux-gnu-gcc  -march=armv8-a+crc+crypto -mabi=lp64 -Wno-psabi -mtune=cortex-a53 -mno-outline-atomics -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -no-undefined -version-info 0:0:0 -rpath /usr/lib $(libm2=`gm2 -print-file-name=libm2pim.la`; if test "$libm2" != 'libm2pim.la'; then dir=`dirname "$libm2"`; echo "-L$dir" -lm2pim; else libm2=`gm2 -print-file-name=libm2pim.so`; if test "$libm2" != 'libm2pim.so'; then dir=`dirname "$libm2"`; echo "-L$dir" -lm2pim; else libm2=`gm2 -print-file-name=m2/m2pim/libm2pim.so`; if test "$libm2" != 'm2/m2pim/libm2pim.so'; then dir=`dirname "$libm2"`; echo "-L$dir" -lm2pim; fi; fi; fi) -Wl,--as-needed -fuse-ld=gold -o libintl_m2.la -rpath /usr/lib   Libintl.lo  
libtool: link: /home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/bin/aarch64-libreelec-linux-gnu-gcc -shared  -fPIC -DPIC  .libs/Libintl.o   -L/usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64 -lm2pim  -march=armv8-a+crc+crypto -mabi=lp64 -mtune=cortex-a53 -mno-outline-atomics -O2 -Wl,--as-needed -fuse-ld=gold   -Wl,-soname -Wl,libintl_m2.so.0 -o .libs/libintl_m2.so.0.0.0
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: error: .libs/Libintl.o: incompatible target
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libm2pim.so while searching for m2pim
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: error: cannot find -lm2pim
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libgcc_s.so.1 while searching for libgcc_s.so.1
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libgcc_s.so.1 while searching for libgcc_s.so.1
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libc.so while searching for c
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libgcc_s.so.1 while searching for libgcc_s.so.1
/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/toolchain/lib/gcc/aarch64-libreelec-linux-gnu/15.1.0/../../../../aarch64-libreelec-linux-gnu/bin/ld.gold: warning: skipping incompatible /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/../../../../lib64/libgcc_s.so.1 while searching for libgcc_s.so.1
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:2388: libintl_m2.la] Error 1
make[5]: Leaving directory '/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/build/gettext-0.25/.aarch64-libreelec-linux-gnu/gettext-runtime/intl-modula2'
make[4]: *** [Makefile:2318: all] Error 2
make[4]: Leaving directory '/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/build/gettext-0.25/.aarch64-libreelec-linux-gnu/gettext-runtime/intl-modula2'
make[3]: *** [Makefile:2433: all-recursive] Error 1
make[3]: Leaving directory '/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/build/gettext-0.25/.aarch64-libreelec-linux-gnu/gettext-runtime'
make[2]: *** [Makefile:2336: all] Error 2
make[2]: Leaving directory '/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/build/gettext-0.25/.aarch64-libreelec-linux-gnu/gettext-runtime'
make[1]: *** [Makefile:414: all-recursive] Error 1
make[1]: Leaving directory '/home/ilmich-current/rockchip/LibreELEC.tv/build.LibreELEC-RK3328.aarch64-13.0-devel/build/gettext-0.25/.aarch64-libreelec-linux-gnu'
make: *** [Makefile:370: all] Error 2
```

I know that it is not advisable to compile Libreelec on unsupported systems (in this case Slackware), and I take all the risks. But in any case I think such support is superfluous anyway.