### PR TITLE
[le12] openssl: update to 3.2.5

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.2.4"
-PKG_SHA256="b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5618436a0dd2c17c3716"
+PKG_VERSION="3.2.5"
+PKG_SHA256="b36347d024a0f5bd09fefcd6af7a58bb30946080eb8ce8f7be78562190d09879"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://openssl-library.org"
 PKG_URL="https://github.com/openssl/openssl/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.openssl.org

Release notes:
- https://www.openssl.org/news/vulnerabilities.html