### PR TITLE
kodi: update to githash 943fffa

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="fc1ba2754b6201f6d532651917a446b5612ab430"
-PKG_SHA256="06c1abbdbfa7eeed1d54ba90fe932d83568862934ce05e6477f3726b9606b033"
+PKG_VERSION="943fffad41d63431bcfbddc5270a7deb0a82a259"
+PKG_SHA256="d6ee2b2afeffe0e6fbb8581a4e469d517c5c6817c36680e13040fcd7982c0088"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/fc1ba2754b6201f6d532651917a446b5612ab430...943fffad41d63431bcfbddc5270a7deb0a82a259

```
=== tested on ===
Generic.x86_64-devel-20250703122715-f2a3346
Linux nuc12 6.16.0-rc4 #1 SMP Thu Jul  3 08:58:44 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA1 (21.90.700) Git:943fffad41d63431bcfbddc5270a7deb0a82a259). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-07-03 by GCC 15.1.0 for Linux x86 64-bit version 6.16.0 (397312)
Running on LibreELEC (heitbaum): devel-20250703122715-f2a3346 13.0, kernel: Linux x86 64-bit version 6.16.0-rc4
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0096.2025.0115.1051 01/15/2025
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
GL_VERSION = OpenGL ES 3.2 Mesa 25.1.5
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.6 (2fb8f3d68c)
```