### PR TITLE
libretro-common: update to githash 5b5a830

### DIFF
--- a/packages/emulation/libretro-common/package.mk
+++ b/packages/emulation/libretro-common/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-common"
-PKG_VERSION="50c15a88eb741cbe675743a282d8cc4c89421e3f"
-PKG_SHA256="042986fad22dc37188df7a186d17a258edfe8e552353f9b509a47418e8dfa623"
+PKG_VERSION="5b5a830baa6c72452c1f1d4ac3e2fdd04bfbd267"
+PKG_SHA256="007728cbf8940cb53f867190b77080bc654b285b77e2a79c1404f78ea5e9e8b4"
 PKG_LICENSE="Public domain"
 PKG_SITE="https://github.com/libretro/libretro-common"
 PKG_URL="https://github.com/libretro/libretro-common/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/libretro/libretro-common/compare/50c15a88eb741cbe675743a282d8cc4c89421e3f...5b5a830baa6c72452c1f1d4ac3e2fdd04bfbd267
- Fixes game.libretro build since #10223 