### PR TITLE
bcm2835-utils: update to githash b7651d8

### DIFF
--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="02e3ffeee7dc8f954271fd42a3ed983567c55eb4"
-PKG_SHA256="1b519e2cb24108c6f4d7e7ef0c046f9bcc92e68c53367a61913136a1096cd2fd"
+PKG_VERSION="b7651d86d71a172b2208c67b2e360cbcb4f9d98f"
+PKG_SHA256="d96de4b95f3cd69a9f14000802e05ee364b3be7ebee45c988ff5b7ee38b0acb1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"


### PR DESCRIPTION
Log:
- https://github.com/raspberrypi/utils/compare/02e3ffeee7dc8f954271fd42a3ed983567c55eb4...b7651d86d71a172b2208c67b2e360cbcb4f9d98f