### PR TITLE
uboot_helper: RK3399: Add Radxa ROCK 4SE

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -347,7 +347,11 @@ devices = \
       'rock-4c-plus': {
         'dtb': 'rk3399-rock-4c-plus.dtb',
         'config': 'rock-4c-plus-rk3399_defconfig'
-      },      
+      },
+      'rock-4se': {
+       'dtb': 'rk3399-rock-4se.dtb',
+       'config': 'rock-4se-rk3399_defconfig'
+      },
       'rock-pi-n10': {
         'dtb': 'rk3399pro-rock-pi-n10.dtb',
         'config': 'rock-pi-n10-rk3399pro_defconfig'


### PR DESCRIPTION
Add Radxa ROCK 4SE which is officially supported by u-boot and mainline kernel.