### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asteroids/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.asteroids"
-PKG_VERSION="22.0.2-Piers"
-PKG_SHA256="3db8595fa121290fa857bf590404cd70ae910ce90c2273477baf72194e1ae2b4"
-PKG_REV="4"
+PKG_VERSION="22.0.3-Piers"
+PKG_SHA256="2cd4546b0d89439de4b808b158860f16e0e57fe6c9e4e0815a6621caae83a8dc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.asteroids"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.greynetic/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.greynetic"
-PKG_VERSION="22.0.2-Piers"
-PKG_SHA256="f8e6f772e40ad5cfb3493011fbae6062d7f3ab0c03f614842687505af2194da3"
-PKG_REV="4"
+PKG_VERSION="22.0.3-Piers"
+PKG_SHA256="3dd2f8406412a6b4afbaad5bd9cec6ed63848bcc605cef7408b8f44770b6bc37"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.greynetic"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.matrixtrails"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="cc342d201606e682fc9def894a308784b74633f981209570c87d1bd206894311"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="bee0c08851b963724d4f537ec19013233ab2e535fdab331d443d393ab622d7e2"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.matrixtrails"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.pyro/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.pyro"
-PKG_VERSION="22.0.2-Piers"
-PKG_SHA256="1a3f19ed1328c87b63be21f6d2fe068d01c338906cad280c5630011a6caab83d"
-PKG_REV="3"
+PKG_VERSION="22.0.3-Piers"
+PKG_SHA256="fbcae6128224bf76bcb3854a01e4358fac0fc85b9b754d86129cb9d1678337d1"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.pyro"

--- a/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.stars/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screensaver.stars"
-PKG_VERSION="22.0.1-Piers"
-PKG_SHA256="6a0543489dff170c2132f46da509c8ffd8d1e6265a0b07d8792e9189d573d737"
-PKG_REV="3"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="92a55f97cc03e095bc51e01265560284de5954d323b70e0920debcd7923a671c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/screensaver.stars"


### PR DESCRIPTION
- screensaver.asteroids: update 22.0.2-Piers to 22.0.3-Piers
- screensaver.greynetic: update 22.0.2-Piers to 22.0.3-Piers
- screensaver.matrixtrails: update 21.0.2-Omega to 22.0.1-Piers
- screensaver.pyro: update 22.0.2-Piers to 22.0.3-Piers
- screensaver.stars: update 22.0.1-Piers to 22.0.2-Piers