### PR TITLE
[le12.2] update security components

### DIFF
--- a/packages/devel/talloc/config/talloc-cache.txt
+++ b/packages/devel/talloc/config/talloc-cache.txt
@@ -1,0 +1,48 @@
+Checking simple C program: OK
+rpath library support: OK
+-Wl,--version-script support: OK
+Checking getconf LFS_CFLAGS: NO
+Checking for large file support without additional flags: OK
+Checking for -D_LARGE_FILES: OK
+Checking correct behavior of strtoll: NO
+Checking for working strptime: OK
+Checking for C99 vsnprintf: OK
+Checking for HAVE_SHARED_MMAP: OK
+Checking for HAVE_MREMAP: OK
+Checking for HAVE_INCOHERENT_MMAP: NO
+Checking for HAVE_SECURE_MKSTEMP: OK
+Checking for HAVE_IFACE_GETIFADDRS: OK
+Checking for kernel change notify support: OK
+Checking for Linux kernel oplocks: OK
+Checking for kernel share modes: OK
+Checking if can we convert from CP850 to UCS-2LE: OK
+Checking if can we convert from UTF-8 to UCS-2LE: OK
+Checking whether we can use Linux thread-specific credentials with 32-bit system calls: OK
+Checking whether we can use Linux thread-specific credentials: OK
+Checking whether setreuid is available: OK
+Checking whether setresuid is available: OK
+Checking whether seteuid is available: OK
+Checking whether fcntl locking is available: OK
+Checking whether fcntl lock supports open file description locks: OK
+Checking for the maximum value of the 'time_t' type: OK
+Checking whether the realpath function allows a NULL argument: OK
+Checking whether POSIX capabilities are available: OK
+Checking for ftruncate extend: OK
+vfs_fileid checking for statfs() and struct statfs.f_fsid: OK
+getcwd takes a NULL argument: OK
+Checking uname sysname type: "Linux"
+Checking uname release type: "3.0.0"
+Checking uname version type: "#1 Tue Nov 1 12:34:56 UTC 2013"
+Checking value of NSIG: "32"
+Checking value of _NSIG: "64"
+Checking value of SIGRTMAX: "64"
+Checking value of SIGRTMIN: "32"
+Checking errno of iconv for illegal multibyte sequence: "0"
+Checking for a 64-bit host to support lmdb: NO
+Checking value of GNUTLS_CIPHER_AES_128_CFB8: OK
+Checking value of GNUTLS_MAC_AES_CMAC_128: OK
+Checking whether fcntl supports flags to send direct I/O availability signals: OK
+Checking whether fcntl supports setting/geting hints: OK
+Checking for gnutls fips mode support: NO
+Checking for readlink breakage: NO
+Checking whether fcntl supports setting/getting hints: OK

--- a/packages/devel/talloc/package.mk
+++ b/packages/devel/talloc/package.mk
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="talloc"
+PKG_VERSION="2.4.3"
+PKG_SHA256="dc46c40b9f46bb34dd97fe41f548b0e8b247b77a918576733c528e83abd854dd"
+PKG_LICENSE="LGPL-3.0-or-later"
+PKG_SITE="https://talloc.samba.org/"
+PKG_URL="https://www.samba.org/ftp/talloc/talloc-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="talloc is a hierarchical, reference counted memory pool system with destructors"
+
+configure_package() {
+  PKG_WAF_VERBOSE="-v"
+
+  PKG_CONFIGURE_OPTS="--prefix=/usr \
+                      --bindir=/usr/bin \
+                      --sbindir=/usr/sbin \
+                      --sysconfdir=/etc \
+                      --libdir=/usr/lib \
+                      --libexecdir=/usr/lib \
+                      --localstatedir=/var \
+                      --cross-compile \
+                      --cross-answers=${PKG_BUILD}/cache.txt \
+                      --hostcc=gcc \
+                      --disable-python \
+                      --disable-rpath \
+                      --disable-rpath-install \
+                      --disable-rpath-private-install"
+}
+
+pre_configure_target() {
+  # talloc uses its own build directory
+  cd ${PKG_BUILD}
+    rm -rf .${TARGET_NAME}
+
+  # support 64-bit offsets and seeks on 32-bit platforms
+  if [ "${TARGET_ARCH}" = "arm" ]; then
+    export CFLAGS+=" -D_FILE_OFFSET_BITS=64 -D_OFF_T_DEFINED_ -Doff_t=off64_t -Dlseek=lseek64"
+  fi
+}
+
+configure_target() {
+  cp ${PKG_DIR}/config/talloc-cache.txt ${PKG_BUILD}/cache.txt
+    echo "Checking uname machine type: \"${TARGET_ARCH}\"" >>${PKG_BUILD}/cache.txt
+
+  PYTHON_CONFIG="${SYSROOT_PREFIX}/usr/bin/python3-config" \
+  python_LDFLAGS="" python_LIBDIR="" \
+  PYTHON=${TOOLCHAIN}/bin/python3 ./configure ${PKG_CONFIGURE_OPTS}
+}
+
+make_target() {
+  make ${PKG_SAMBA_TARGET} -j${CONCURRENCY_MAKE_LEVEL}
+}
+
+makeinstall_target() {
+  PYTHONHASHSEED=1 WAF_MAKE=1 ./buildtools/bin/waf install ${PKG_WAF_VERBOSE} --destdir=${SYSROOT_PREFIX} -j${CONCURRENCY_MAKE_LEVEL}
+}
+
+post_makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib
+    cp -PR ${PKG_BUILD}/bin/default/libtalloc.so* ${INSTALL}/usr/lib
+}

--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.9p2"
-PKG_SHA256="91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673"
+PKG_VERSION="10.0p2"
+PKG_SHA256="021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
+++ b/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
@@ -1,7 +1,7 @@
 diff -u a/configure.ac b/configure.ac
 --- a/configure.ac	2018-10-16 20:01:20.000000000 -0400
 +++ b/configure.ac	2018-12-06 04:08:42.718993760 -0500
-@@ -5185,6 +5185,19 @@
+@@ -5355,6 +5355,19 @@
  )
  
  
@@ -21,7 +21,7 @@ diff -u a/configure.ac b/configure.ac
  AC_MSG_CHECKING([if we need to convert IPv4 in IPv6-mapped addresses])
  IPV4_IN6_HACK_MSG="no"
  AC_ARG_WITH(4in6,
-@@ -5565,6 +5578,7 @@
+@@ -5754,6 +5767,7 @@
  H=`eval echo ${PRIVSEP_PATH}` ; H=`eval echo ${H}`
  I=`eval echo ${user_path}` ; I=`eval echo ${I}`
  J=`eval echo ${superuser_path}` ; J=`eval echo ${J}`
@@ -29,7 +29,7 @@ diff -u a/configure.ac b/configure.ac
  
  echo ""
  echo "OpenSSH has been configured with the following options:"
-@@ -5588,6 +5602,9 @@
+@@ -5777,6 +5791,9 @@
  if test ! -z "$superuser_path" ; then
  echo "          sshd superuser user PATH: $J"
  fi
@@ -39,14 +39,13 @@ diff -u a/configure.ac b/configure.ac
  echo "                    Manpage format: $MANTYPE"
  echo "                       PAM support: $PAM_MSG"
  echo "                   OSF SIA support: $SIA_MSG"
-Common subdirectories: a/contrib and b/contrib
 diff -u a/Makefile.in b/Makefile.in
 --- a/Makefile.in	2018-10-16 20:01:20.000000000 -0400
 +++ b/Makefile.in	2018-12-06 04:00:04.301968236 -0500
-@@ -32,8 +32,10 @@
- STRIP_OPT=@STRIP_OPT@
+@@ -33,8 +33,10 @@
  TEST_SHELL=@TEST_SHELL@
  BUILDDIR=@abs_top_builddir@
+ SK_STANDALONE=@SK_STANDALONE@
 +KEYDIR=@KEYDIR@
  
  PATHS= -DSSHDIR=\"$(sysconfdir)\" \
@@ -54,7 +53,7 @@ diff -u a/Makefile.in b/Makefile.in
  	-D_PATH_SSH_PROGRAM=\"$(SSH_PROGRAM)\" \
  	-D_PATH_SSH_ASKPASS_DEFAULT=\"$(ASKPASS_PROGRAM)\" \
  	-D_PATH_SFTP_SERVER=\"$(SFTP_SERVER)\" \
-@@ -168,11 +170,11 @@
+@@ -192,11 +194,11 @@
  	-e 's|/etc/ssh/sshd_config|$(sysconfdir)/sshd_config|g' \
  	-e 's|/usr/libexec|$(libexecdir)|g' \
  	-e 's|/etc/shosts.equiv|$(sysconfdir)/shosts.equiv|g' \
@@ -71,7 +70,6 @@ diff -u a/Makefile.in b/Makefile.in
  	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
  	-e 's|/etc/moduli|$(sysconfdir)/moduli|g' \
  	-e 's|/etc/ssh/moduli|$(sysconfdir)/moduli|g' \
-Common subdirectories: a/openbsd-compat and b/openbsd-compat
 diff -u a/pathnames.h b/pathnames.h
 --- a/pathnames.h	2018-10-16 20:01:20.000000000 -0400
 +++ b/pathnames.h	2018-12-06 04:15:01.286012398 -0500

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -77,7 +77,7 @@ configure_package() {
   PKG_SAMBA_TARGET="smbclient,client/smbclient,smbtree,nmblookup,testparm"
 
   if [ "${SAMBA_SERVER}" = "yes" ]; then
-    PKG_SAMBA_TARGET+=",nmbd,rpcd_classic,rpcd_epmapper,rpcd_winreg,samba-dcerpcd,smbpasswd,smbd/smbd"
+    PKG_SAMBA_TARGET+=",nmbd,rpcd_classic,rpcd_epmapper,rpcd_winreg,samba-dcerpcd,smbpasswd,smbd/smbd,vfs_fruit,vfs_catia,vfs_streams_xattr"
   fi
 }
 
@@ -154,6 +154,10 @@ perform_manual_install() {
       cp -PR bin/default/source3/rpc_server/rpcd_classic ${INSTALL}/usr/libexec/samba
       cp -PR bin/default/source3/rpc_server/rpcd_epmapper ${INSTALL}/usr/libexec/samba
       cp -PR bin/default/source3/rpc_server/rpcd_winreg ${INSTALL}/usr/libexec/samba
+
+    mkdir -p ${INSTALL}/usr/lib/vfs
+      cp ${PKG_BUILD}/bin/modules/vfs/* ${INSTALL}/usr/lib/vfs/
+
   fi
 }
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="8fd7092629a3596d935cd7567d934979f94272918ec3affd0cc807934ecf22ba"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="autotools:host gcc:host attr heimdal:host e2fsprogs Python3 libunwind zlib readline popt libaio connman gnutls wsdd2"
+PKG_DEPENDS_TARGET="autotools:host gcc:host heimdal:host attr connman e2fsprogs gnutls libaio libunwind popt Python3 readline talloc wsdd2 zlib"
 PKG_NEED_UNPACK="$(get_pkg_directory heimdal) $(get_pkg_directory e2fsprogs)"
 PKG_LONGDESC="A free SMB / CIFS fileserver and client."
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="8fd7092629a3596d935cd7567d934979f94272918ec3affd0cc807934ecf22ba"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain attr heimdal:host e2fsprogs Python3 libunwind zlib readline popt libaio connman gnutls wsdd2"
+PKG_DEPENDS_TARGET="autotools:host gcc:host attr heimdal:host e2fsprogs Python3 libunwind zlib readline popt libaio connman gnutls wsdd2"
 PKG_NEED_UNPACK="$(get_pkg_directory heimdal) $(get_pkg_directory e2fsprogs)"
 PKG_LONGDESC="A free SMB / CIFS fileserver and client."
 

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.19.9"
-PKG_SHA256="71ed406444714c90bb9d36c576d807b67af15449f297e91106d42b3ca2fa5549"
+PKG_VERSION="4.22.3"
+PKG_SHA256="8fd7092629a3596d935cd7567d934979f94272918ec3affd0cc807934ecf22ba"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
+++ b/packages/network/samba/patches/samba-200-4.11-fix-ASN1-bso14164.patch
@@ -40,10 +40,10 @@ diff --git a/wscript_configure_embedded_heimdal b/wscript_configure_embedded_hei
 index 8c55ae2..4fdae80 100644
 --- a/wscript_configure_embedded_heimdal
 +++ b/wscript_configure_embedded_heimdal
-@@ -6,3 +6,14 @@
+@@ -15,3 +15,14 @@
+ conf.define('HAVE_CLIENT_GSS_C_CHANNEL_BOUND_FLAG', 1)
  
- conf.define('USING_EMBEDDED_HEIMDAL', 1)
- conf.RECURSE('third_party/heimdal_build')
+ conf.define('HAVE_KRB5_INIT_CREDS_STEP', 1)
 +
 +def check_system_heimdal_binary(name):
 +    if conf.LIB_MAY_BE_BUNDLED(name):

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -9,7 +9,7 @@ PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://openssl-library.org"
 PKG_URL="https://github.com/openssl/openssl/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="autotools:host gcc:host"
 PKG_LONGDESC="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKG_TOOLCHAIN="configure"
 

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -50,6 +50,8 @@ configure_host() {
 
 makeinstall_host() {
   make install_sw
+  mkdir -p ${TOOLCHAIN}/etc/ssl
+  cp ${PKG_DIR}/cert/cacert.pem ${TOOLCHAIN}/etc/ssl/cert.pem
 }
 
 pre_configure_target() {

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.2.5"
-PKG_SHA256="b36347d024a0f5bd09fefcd6af7a58bb30946080eb8ce8f7be78562190d09879"
+PKG_VERSION="3.5.1"
+PKG_SHA256="529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://openssl-library.org"
 PKG_URL="https://github.com/openssl/openssl/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Update the security components of LE12.2
- samba
  - talloc (new dependency of samba)
- openssh
- openssl 

A further PR will be created potentially for other packages
