### PR TITLE
[le12.2] update mesa to 25.1

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -265,3 +265,11 @@
 # for a list of additional drivers see packages/linux-driver-addons
 # Space separated list is supported,
   DRIVER_ADDONS="crazycat digital_devices dvb-latest"
+
+# should reusable host tools be built:
+# Space separated list is supported,
+# list of options are:
+#   - all (for all host tools to be built)
+#   - mesa:host
+#   - save-local (saves a copy in sources/reusable/<package>
+  BUILD_REUSABLE=""

--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -273,3 +273,6 @@
 #   - mesa:host
 #   - save-local (saves a copy in sources/reusable/<package>
   BUILD_REUSABLE=""
+
+# should reusable host tools be used (yes / no)
+  USE_REUSABLE="no"

--- a/packages/graphics/mesa-reusable/package.mk
+++ b/packages/graphics/mesa-reusable/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mesa-reusable"
+PKG_LICENSE="OSS"
+PKG_SITE="http://www.mesa3d.org/"
+PKG_DEPENDS_HOST="toolchain:host"
+PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
+PKG_TOOLCHAIN="manual"
+
+MESA_VERSION=$(get_pkg_version mesa)
+PKG_VERSION="${OS_VERSION}-${MESA_VERSION}"
+PKG_SOURCE_NAME="${PKG_NAME}-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}.tar"
+PKG_URL="https://github.com/LibreELEC/mesa-reusable/releases/download/${PKG_VERSION}/${PKG_SOURCE_NAME}"
+PKG_SHA256="$(curl --fail --connect-timeout 30 --retry 3 --location --max-redirs 5 ${PKG_URL}.sha256)"
+
+unpack() {
+  mkdir -p ${TOOLCHAIN}/bin
+  tar -xf ${SOURCES}/${PKG_NAME}/${PKG_SOURCE_NAME} -C ${TOOLCHAIN}/bin
+}

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -69,8 +69,7 @@ if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
-              [ "${OPENGL_SUPPORT}" = "yes" ] &&
-              [ "${DISPLAYSERVER}" != "x11" ]; then
+              [ "${OPENGL_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" != "x11" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"
   PKG_MESON_OPTS_TARGET+=" -Dglvnd=enabled"
 else

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -30,10 +30,7 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
                        -Dgallium-rusticl=false \
-                       -Dgallium-nine=false \
-                       -Dgallium-opencl=disabled \
                        -Dshader-cache=enabled \
-                       -Dshared-glapi=enabled \
                        -Dopengl=true \
                        -Dgbm=enabled \
                        -Degl=enabled \
@@ -42,8 +39,7 @@ PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dlmsensors=disabled \
                        -Dbuild-tests=false \
                        -Ddraw-use-llvm=false \
-                       -Dmicrosoft-clc=disabled \
-                       -Dosmesa=false"
+                       -Dmicrosoft-clc=disabled"
 
 if [ "${DISPLAYSERVER}" = "x11" ]; then
   PKG_DEPENDS_TARGET+=" xorgproto libXext libXdamage libXfixes libXxf86vm libxcb libX11 libxshmfence libXrandr"

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -111,7 +111,7 @@ else
 fi
 
 if [ "${VULKAN_SUPPORT}" = "yes" ]; then
-  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools"
+  PKG_DEPENDS_TARGET+=" ${VULKAN} vulkan-tools ply:host"
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers=${VULKAN_DRIVERS_MESA// /,}"
 else
   PKG_MESON_OPTS_TARGET+=" -Dvulkan-drivers="

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="25.0.7"
-PKG_SHA256="592272df3cf01e85e7db300c449df5061092574d099da275d19e97ef0510f8a6"
+PKG_VERSION="25.1.6"
+PKG_SHA256="9f2b69eb39d2d8717d30a9868fdda3e0c0d3708ba32778bbac8ddb044538ce84"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
@@ -117,5 +117,5 @@ fi
 makeinstall_host() {
   mkdir -p "${TOOLCHAIN}/bin"
     cp -a src/compiler/clc/mesa_clc "${TOOLCHAIN}/bin"
-    cp -a src/compiler/spirv/vtn_bindgen "${TOOLCHAIN}/bin"
+    cp -a src/compiler/spirv/vtn_bindgen2 "${TOOLCHAIN}/bin"
 }

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -64,7 +64,11 @@ if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
-  PKG_DEPENDS_TARGET+=" mesa:host"
+  if [ "${USE_REUSABLE}" = "yes" ]; then
+    PKG_DEPENDS_TARGET+=" mesa-reusable"
+  else
+    PKG_DEPENDS_TARGET+=" mesa:host"
+  fi
   PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system -Dprecomp-compiler=system"
 fi
 

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -61,7 +61,7 @@ if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
   PKG_DEPENDS_TARGET+=" pycparser:host"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
   PKG_DEPENDS_TARGET+=" mesa:host"
   PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system"
 fi

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -24,7 +24,8 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dplatforms= \
                      -Dglx=disabled \
                      -Dvulkan-drivers= \
-                     -Dshared-llvm=disabled"
+                     -Dshared-llvm=disabled \
+                     -Dtools=panfrost"
 
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
@@ -62,15 +63,9 @@ if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
   PKG_DEPENDS_TARGET+=" pycparser:host"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
   PKG_DEPENDS_TARGET+=" mesa:host"
-  PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system"
-fi
-
-if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
-  PKG_DEPENDS_TARGET+=" mesa:host"
-  PKG_MESON_OPTS_HOST+=" -Dtools=panfrost"
-  PKG_MESON_OPTS_TARGET+=" -Dprecomp-compiler=system -Dmesa-clc=system"
+  PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system -Dprecomp-compiler=system"
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
@@ -124,11 +119,8 @@ else
 fi
 
 makeinstall_host() {
-  mkdir -p "${TOOLCHAIN}/bin"
-    cp -a src/compiler/clc/mesa_clc "${TOOLCHAIN}/bin"
-    cp -a src/compiler/spirv/vtn_bindgen2 "${TOOLCHAIN}/bin"
+  host_files="src/compiler/clc/mesa_clc src/compiler/spirv/vtn_bindgen2 src/panfrost/clc/panfrost_compile"
 
-    if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
-      cp -a src/panfrost/clc/panfrost_compile "${TOOLCHAIN}/bin"
-    fi
+  mkdir -p "${TOOLCHAIN}/bin"
+    cp -a ${host_files} "${TOOLCHAIN}/bin"
 }

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -23,7 +23,8 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dgallium-vdpau=disabled \
                      -Dplatforms= \
                      -Dglx=disabled \
-                     -Dvulkan-drivers="
+                     -Dvulkan-drivers= \
+                     -Dshared-llvm=disabled"
 
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -66,7 +66,9 @@ if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
   PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
+              [ "${OPENGL_SUPPORT}" = "yes" ] &&
+              [ "${DISPLAYSERVER}" != "x11" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"
   PKG_MESON_OPTS_TARGET+=" -Dglvnd=enabled"
 else

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -61,9 +61,15 @@ if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
   PKG_DEPENDS_TARGET+=" pycparser:host"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
   PKG_DEPENDS_TARGET+=" mesa:host"
   PKG_MESON_OPTS_TARGET+=" -Dmesa-clc=system"
+fi
+
+if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
+  PKG_DEPENDS_TARGET+=" mesa:host"
+  PKG_MESON_OPTS_HOST+=" -Dtools=panfrost"
+  PKG_MESON_OPTS_TARGET+=" -Dprecomp-compiler=system -Dmesa-clc=system"
 fi
 
 if listcontains "${GRAPHIC_DRIVERS}" "(nvidia|nvidia-ng)" ||
@@ -120,4 +126,8 @@ makeinstall_host() {
   mkdir -p "${TOOLCHAIN}/bin"
     cp -a src/compiler/clc/mesa_clc "${TOOLCHAIN}/bin"
     cp -a src/compiler/spirv/vtn_bindgen2 "${TOOLCHAIN}/bin"
+
+    if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
+      cp -a src/panfrost/clc/panfrost_compile "${TOOLCHAIN}/bin"
+    fi
 }

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="17.0.14"
-PKG_SHA256="0aa498daca090793d87ba24a61b01b6dfdcd00ea960611bd2dca1101333b7d88"
+PKG_VERSION="18.1.14"
+PKG_SHA256="c6f9fbbd3a27f4805f15383059f070263a5b046796f1df3cff06859838b98b90"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="17.0.6"
-PKG_SHA256="58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813"
+PKG_VERSION="18.1.8"
+PKG_SHA256="0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"

--- a/packages/python/devel/ply/package.mk
+++ b/packages/python/devel/ply/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="ply"
+PKG_VERSION="3.11"
+PKG_SHA256="00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://pypi.org/project/ply"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="Python3:host setuptools:host"
+PKG_LONGDESC="PLY is yet another implementation of lex and yacc for Python."
+PKG_TOOLCHAIN="python"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="d0c54d824e64b7313a974409541ca3a157b3ed7299865786bd0c440b0e073091"
+    PKG_SHA256="5173f84a07d4cc6b19f27eda7464999c5886232ce8e54bf61b06617635d43fb9"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="427eff597f3801987959a97a1ee5d5df57c56875a7adada41b45e72b46edfb4d"
+    PKG_SHA256="3c69ce28099974d5b2698aca4c10c88b4f2e04a89f44627373d98a76f9b9efc7"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="30ec0ad9fca443ec12c544f9ce448dacdde411a45b9042961938b650e918ccfb"
+    PKG_SHA256="f8aacf7a101eb10dc000b8bf26de90a9d0ce678d02ccf70430ed20dd31ecec6b"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="c0c579d9321da855109a2b6c7d7c9e01549db37e8490f058cfdc0012bef394cd"
+    PKG_SHA256="66cf114dcd8056a596bf169f824ff95ff1837bc065daaafdbcaa02ce92903304"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="3b9a6af550679c82cf205b665962de86d067e9ccfc392c754217519dbf2bce52"
+    PKG_SHA256="897271da9a11a6783b736f7d2a600e3a6782618ebe28cf24713986ab8f90c871"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="e41150b52d923a3bbe166c4ecc5719f56576274b0d034d764768aee279ae2063"
+    PKG_SHA256="95aece42a336f237c5bac5c5d9aca051b7f0bd3e6a64fb3c5828e6d0d3af2e8c"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.76.0"
-PKG_SHA256="9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021"
+PKG_VERSION="1.78.0"
+PKG_SHA256="ff544823a5cb27f2738128577f1e7e00ee8f4c83f2a348781ae4fc355e91d5a9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -33,7 +33,7 @@ configure_host() {
   esac
 
   cat > ${PKG_BUILD}/config.toml <<END
-changelog-seen = 2
+change-id = 102579
 
 [target.${TARGET_NAME}]
 llvm-config = "${TOOLCHAIN}/bin/llvm-config"

--- a/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
@@ -2,7 +2,7 @@
   "arch": "x86_64",
   "cpu": "x86-64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a299b5053d2771c24e3d5787caa0317ea729618700acacf2eeb95e345a92529c"
+    PKG_SHA256="e0450bef5537e6b0bb82872e9f837c3b3f6397cc8eba6f53211481c82426e1ce"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="f398547fd5ad0e2f5904ace4eddaf74c615d0a75221b36ed2667fbb9a6324714"
+    PKG_SHA256="8e42581140e56ad55a67e2e8a3b562b86fa7571bbc394c0df8696f0276a8faf3"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="9fadfcf71bc6a0ddfd026b9624163faf1c5689dd4a1f7cc1f857167ade4aa6eb"
+    PKG_SHA256="3994971e5923716d54e4b574ce238f04c4e20cda03990670f7cc3f87d36e5499"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
Draft. 

- So far tested on Generic build. 
- Will need some commits squashed.
- Includes the minimal bumps to llvm, rust subsequently needs to be bumped to a minimum 1.78 to be compiled with llvm18.
- Will need to test Mesa-reusable (but expect it to work correctly) as it can/should be used by GHA actions CU/CD
