### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.fishbmc/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.fishbmc"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="d7433e4e88e29f1dd3524d2d0b660ce529852561f14f479f4b83a9c5ac436ffc"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="088dfae6dbae1611daa6858bda11d0dd7b6dcfd23f741f5d7afa40b5d690d5ca"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.fishbmc"

--- a/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.goom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.goom"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="f87356122f91ea40d096d559d1180571e701e39867448768d14d6c2ba3b2e264"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="ac3e56b6441315be6f2add90ada2e656f03bbead999bc86fefff423a0cd56a77"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.goom"

--- a/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.matrix/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.matrix"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="b1d1f3da5470d657e70c4b914a77445fe1d0a0ba35007fc402982a8b1b4cf9b0"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="f5f6d7488f6ea2ef8c4fd6e88213e8fe3c882fd5820a917f6df6a3a358a83429"
+PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.matrix"
 PKG_URL="https://github.com/xbmc/visualization.matrix/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.shadertoy"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="30a5081365cea1dbdf49ccbb059076d4c7abc28604a58749fcd0d025e2faa760"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="a7e162c2828f4cee6998e3434ab2043398679f8311bd032b347566aa21ad8872"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.spectrum/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.spectrum"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="7b6635789d226ee4cd4e17d54d57e880731d0762835802835d0d5ac4f0084b99"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="68bfc627e0af2ae8a822450bd6757567fef193cef2891ea0f6bb4784ffac4138"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.spectrum"

--- a/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.starburst/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.starburst"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="a3f70985fee6b1014e7e7599431e646f36bd3870ead78bbc8936151b805e4241"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="2086ab7e34896ebc5aa7256dd08865f15bd00615ebc0d8d5da19cf989c2946b0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.starburst"

--- a/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.waveform/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.waveform"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="fe6d2f3990ea5f2ea2d4a0a905f451b1c2c7f1300529d8957b5d93a97421f415"
-PKG_REV="2"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="f09a656c8a36c6b6197424b7b821f27b308b450ca2ee1ae91e5f4cd44f32024b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.waveform"


### PR DESCRIPTION
- visualization.fishbmc: update 21.0.2-Omega to 22.0.1-Piers
- visualization.goom: update 21.0.2-Omega to 22.0.1-Piers
- visualization.matrix: update 21.0.2-Omega to 22.0.1-Piers
- visualization.shadertoy: update 21.0.2-Omega to 22.0.1-Piers
- visualization.spectrum: update 21.0.2-Omega to 22.0.1-Piers
- visualization.starburst: update 21.0.2-Omega to 22.0.1-Piers
- visualization.waveform: update 21.0.2-Omega to 22.0.1-Piers