### PR TITLE
[le12.2] backport docker changes from master

### DIFF
--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -29,13 +29,7 @@ RUN apt-get install -y \
     && ln -s /usr/lib/go-1.22/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  apt-get update; \
-  dpkg --add-architecture amd64; \
-  apt-get install -y libc6:amd64 qemu-user-binfmt --no-install-recommends; \
+  apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \
  fi
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     wget bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.22-go git openssh-client rsync \
+      golang-1.22-go git openssh-client rsync upx-ucl \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.22 /usr/lib/go \
     && ln -s /usr/lib/go-1.22/bin/go /usr/bin/go \

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -18,8 +18,8 @@ RUN useradd docker -U -G sudo -m -s /bin/bash \
 RUN apt-get update
 
 RUN apt-get install -y \
-    wget bash bc gcc-13 cpp-13 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
-      unzip diffutils lzop make file g++-13 xfonts-utils xsltproc default-jre-headless python3 \
+    wget bash bc gcc-14 cpp-14 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
+      unzip diffutils lzop make file g++-14 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-1.23-go git openssh-client rsync \
     --no-install-recommends \
@@ -33,10 +33,10 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
-    --slave /usr/bin/cpp cpp /usr/bin/cpp-13 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
+    --slave /usr/bin/cpp cpp /usr/bin/cpp-14 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-14
 RUN update-alternatives --config gcc
 
 USER docker

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -28,13 +28,7 @@ RUN apt-get install -y \
     && ln -s /usr/lib/go-1.23/bin/gofmt /usr/bin/gofmt
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble main restricted universe multiverse' > /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-security main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ noble-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/amd64.list; \
-  apt-get update; \
-  dpkg --add-architecture amd64; \
-  apt-get install -y libc6:amd64 qemu-user-binfmt --no-install-recommends; \
+  apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \
  fi
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/tools/docker/noble/Dockerfile
+++ b/tools/docker/noble/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y \
     wget bash bc gcc-14 cpp-14 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-14 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.23-go git openssh-client rsync \
+      golang-1.23-go git openssh-client rsync upx-ucl \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.23 /usr/lib/go \
     && ln -s /usr/lib/go-1.23/bin/go /usr/bin/go \


### PR DESCRIPTION
- tools/docker/jammy/Dockerfile: add upx-ucl to allow binary compression
 of mesa:host tools
- tools/docker/noble/Dockerfile: add upx-ucl to allow binary compression of mesa:host tools
- tools/docker/noble: update to gcc-14
- dockerfiles: update packages for aarch64 to amd64 crosscompiles

- also needed is https://github.com/LibreELEC/mesa-reusable/pull/2