### PR TITLE
[le 12.2] connman: update to 1.45

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="connman"
-PKG_VERSION="1.44"
-PKG_SHA256="d751da9858a6e3dfe70d6c98e71ea4f5896e1c92c5e1b17f10d055eaeae0e452"
+PKG_VERSION="1.45"
+PKG_SHA256="5dfc192e4ad619fa373fb1204ec3456dc349984738bb1dae895b6f3815172130"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- backport of #10277 
- https://git.kernel.org/pub/scm/network/connman/connman.git/commit/?id=e410e40bc61e5573c2a592bfaebc0fb283ec0fab
- https://git.kernel.org/pub/scm/network/connman/connman.git/log/

ver 1.45:
- Fix issue with setting MFP optional for PSK.
- Fix issue with comparison in timezone checking.
- Fix issue with dnsproxy and empty lookup.