### PR TITLE
tools/docker/jammy/Dockerfile: add upx-ucl to allow binary compression of mesa:host tools

### DIFF
--- a/tools/docker/jammy/Dockerfile
+++ b/tools/docker/jammy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
     curl bash bc gcc-12 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
       unzip diffutils lzop make file g++-12 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
-      golang-1.22-go git openssh-client rsync \
+      golang-1.22-go git openssh-client rsync upx-ucl \
     --no-install-recommends \
     && ln -s /usr/lib/go-1.22 /usr/lib/go \
     && ln -s /usr/lib/go-1.22/bin/go /usr/bin/go \


### PR DESCRIPTION
- Forward port of #10269 7f837287d77f79ff0edd676dbe05e2478ebb125d