### PR TITLE
systemd: add AliExpress G60S Pro Plus remote to 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -1,3 +1,7 @@
+ # Ali Express G60S Pro Plus remote
+ evdev:input:b0003v1915p1001e0201*
+  KEYBOARD_KEY_c0041=enter
+
 # alfawise z1 remote
 evdev:input:b0005v2B54p1603e*
  KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
[As reported in the forums](https://forum.libreelec.tv/thread/26261-fix-for-xiaomi-bluetooth-remote-with-nonworking-button/?postID=201316#post201316), adds the evdev mapping for a AliExpress remote that might be quite popular, not sure. 

[This is the remote.](https://fr.aliexpress.com/item/1005008114628409.html?src=google&pdp_npi=4%40dis!EUR!8.58!4.39!!!!!%40!12000043842202536!ppc!!!&src=google&albch=shopping&acnt=248-630-5778&isdl=y&slnk=&plac=&mtctp=&albbt=Google_7_shopping&aff_platform=google&aff_short_key=UneMJZVf&gclsrc=aw.ds&&albagn=888888&&ds_e_adid=&ds_e_matchtype=&ds_e_device=c&ds_e_network=x&ds_e_product_group_id=&ds_e_product_id=fr1005008114628409&ds_e_product_merchant_id=107857240&ds_e_product_country=FR&ds_e_product_language=fr&ds_e_product_channel=online&ds_e_product_store_id=&ds_url_v=2&albcp=19000710609&albag=&isSmbAutoCall=false&needSmbHouyi=false&gad_source=1&gad_campaignid=17725339642&gbraid=0AAAAACWaBwfX5iIRM36NVK7EIWyZmHHOb&gclid=CjwKCAjwqKzEBhANEiwAeQaPVceueUG9TDUB9i3QSnSJkV0WquaKjWI-EtLmYa4-G3BsiyQ9rMLI2hoCMIMQAvD_BwE)

I personally got it [from Amazon](https://www.amazon.com/Remote-Control-Bluetooth-Computer-Projector/dp/B0C3M5KGPW).