### PR TITLE
libxkbcommon: update to 1.11.0

### DIFF
--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.10.0"
-PKG_SHA256="0427585a4d6ca17c9fc1ac4b539bf303348e9080af70c5ea402503bc370a9631"
+PKG_VERSION="1.11.0"
+PKG_SHA256="78a6b14f16e9a55025978c252e53ce9e16a02bfdb929550b9a0db5af87db7e02"
 PKG_LICENSE="MIT"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
This finally adds a lot of missing keysyms like the long awaited XKB_KEY_XF86OK for the OK button on remotes.

This is in preparation for the Kodi PR https://github.com/xbmc/xbmc/pull/26039