### PR TITLE
readline: build as a shared library instead of static

### DIFF
--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -13,13 +13,10 @@ PKG_LONGDESC="The GNU Readline library provides a set of functions for use by ap
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CONFIGURE_OPTS_TARGET="bash_cv_wcwidth_broken=no \
-                           --disable-shared \
-                           --enable-static \
+                           --enable-shared \
+                           --disable-static \
                            --with-curses"
 
 post_makeinstall_target() {
-  # fix static library
-  sed -i 's/-lreadline/-lreadline -lncursesw/' ${SYSROOT_PREFIX}/usr/lib/pkgconfig/readline.pc
-
   rm -rf ${INSTALL}/usr/share/readline
 }


### PR DESCRIPTION
This reduces image size by almost 500k (300k compressed)

Runtime tested on RPi5

```
$ ./squashfscmp.sh static shared
NEW FILE       Delta: 15           shared: 15            static: n/a          /usr/lib/libhistory.so -> libhistory.so.8
NEW FILE       Delta: 16           shared: 16            static: n/a          /usr/lib/libreadline.so -> libreadline.so.8
NEW FILE       Delta: 17           shared: 17            static: n/a          /usr/lib/libhistory.so.8 -> libhistory.so.8.3
NEW FILE       Delta: 18           shared: 18            static: n/a          /usr/lib/libreadline.so.8 -> libreadline.so.8.3
NEW FILE       Delta: 68,216       shared: 68,216        static: n/a          /usr/lib/libhistory.so.8.3
NEW FILE       Delta: 421,240      shared: 421,240       static: n/a          /usr/lib/libreadline.so.8.3
SIZE CHANGE    Delta: -583,408     shared: 69,232        static: 652,640      /usr/lib/python3.13/lib-dynload/readline.so
SIZE CHANGE    Delta: -512,608     shared: 133,288       static: 645,896      /usr/bin/smbclient
SIZE CHANGE    Delta: -283,912     shared: 299,808       static: 583,720      /usr/bin/connmanctl
SIZE CHANGE    Delta: -283,904     shared: 431,520       static: 715,424      /usr/bin/iwctl
SIZE CHANGE    Delta: -218,296     shared: 705,072       static: 923,368      /usr/bin/bluetoothctl
SIZE CHANGE    Delta: -11          shared: 78,380        static: 78,391       /usr/lib/python3.13/_sysconfigdata__linux_aarch64-linux-gnu.pyc
SIZE CHANGE    Delta: -11          shared: 177,205       static: 177,216      /usr/lib/python3.13/config-3.13-aarch64-linux-gnu/Makefile
SIZE CHANGE    Delta: 228,976      shared: 296,552       static: 67,576       /usr/lib/libreplace-private-samba.so
SIZE CHANGE    Delta: 228,984      shared: 296,704       static: 67,720       /usr/lib/libwbclient.so
SIZE CHANGE    Delta: 229,048      shared: 296,552       static: 67,504       /usr/lib/libsocket-blocking-private-samba.so
SIZE CHANGE    Delta: 229,048      shared: 296,552       static: 67,504       /usr/lib/libutil-setid-private-samba.so
TOTAL CHANGE   Delta: -476,572 (less) in shared (kernel 6.12.41) compared with static (kernel 6.12.41) [minimum delta: 0, files below threshhold: 0]

SYSTEM         Delta: -299,008     shared: 152,674,304   static: 152,973,312  (less in shared)
KERNEL         Delta: 18           shared: 11,676,058    static: 11,676,040   (more in shared)
```