### PR TITLE
rust: update to 1.89.0

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -99,7 +99,9 @@ pre_configure_host() {
 }
 
 post_make_host() {
-  ninja ${NINJA_OPTS} llvm-config llvm-objcopy llvm-tblgen
+  ninja ${NINJA_OPTS} llc llvm-ar llvm-config llvm-cov llvm-dis llvm-nm llvm-objcopy llvm-objdump \
+                      llvm-profdata llvm-readobj llvm-size llvm-strip \
+                      llvm-tblgen
 
   if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
     ninja ${NINJA_OPTS} llvm-as llvm-link llvm-spirv opt
@@ -108,8 +110,18 @@ post_make_host() {
 
 post_makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
+    cp -a bin/llc ${TOOLCHAIN}/bin
+    cp -a bin/llvm-ar ${TOOLCHAIN}/bin
     cp -a bin/llvm-config ${TOOLCHAIN}/bin
+    cp -a bin/llvm-cov ${TOOLCHAIN}/bin
+    cp -a bin/llvm-dis ${TOOLCHAIN}/bin
+    cp -a bin/llvm-nm ${TOOLCHAIN}/bin
     cp -a bin/llvm-objcopy ${TOOLCHAIN}/bin
+    cp -a bin/llvm-objdump ${TOOLCHAIN}/bin
+    cp -a bin/llvm-profdata ${TOOLCHAIN}/bin
+    cp -a bin/llvm-readobj ${TOOLCHAIN}/bin
+    cp -a bin/llvm-size ${TOOLCHAIN}/bin
+    cp -a bin/llvm-strip ${TOOLCHAIN}/bin
     cp -a bin/llvm-tblgen ${TOOLCHAIN}/bin
 
   if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="5aa43865f2002914ce4fca8916b4403bfca62f17e779ad368f6a17553296a58b"
+    PKG_SHA256="f9df3ee6d55a2387459b843477743fa386c3c0f126bd0be01691ee49309681b8"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="ad1b3737e7ac3a736a95f37ddd9a5d2d19f40dfc89197d544e9ca593c09f4dc7"
+    PKG_SHA256="92cfcd64ebb62b486cadafec936290e028e1993122ab2add2f9b9a8e397c9c7f"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="856962610ee821648cee32e3d6abac667af7bb7ea6ec6f3d184cc31e66044f6b"
+    PKG_SHA256="99fc10be2aeedf2c23a484f217bfa76458494495a0eee33e280d3616bb08282d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="e9ac4ff3c87247a2195fcceddbf1bdeee5c4fd337f014d8f4c4e3ac99002021f"
+    PKG_SHA256="abea0955dded88c68d731524ab9d29b162fae23bf5805b9f1dec063cba37c2aa"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="b5e1f168fa02ad57e1ace9ac3d379a9c95f816a26f12156216521a22e192f123"
+    PKG_SHA256="5b3cbcf6b161dce4ac4e316440924b3133d1306592b4ab4d7bfc4429a609199e"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="36d7eacf46bd5199cb433e49a9ed9c9b380d82f8a0ebc05e89b43b51c070c955"
+    PKG_SHA256="2719470dcd78b3f97d78b978c8f85a1a58d84ff11b62558294621c01bca34d49"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.88.0"
-PKG_SHA256="3a97544434848ae3d193d1d6bc83d6f24cb85c261ad95f955fde47ec64cfcfbe"
+PKG_VERSION="1.89.0"
+PKG_SHA256="2576f9f440dd99b0151bd28f59aa0ac6102d5c4f3ed4ef8a810c8dd05057250d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="b841d40bb98b2718c6452ec8421a4a8df584fce8d41875bcd9b1af83f52f7d96"
+    PKG_SHA256="16ed8d8c7628a481c8501e7cd1022a123269b297bdedbb7f211f37a15e937e0e"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="aef877901f8c50443476cf4e7da2668ebcfc4e2b9bb804eba9072cb821002a33"
+    PKG_SHA256="c9e6c54f9b72edb75a34cda22baec8c962ad233e58c11a4a58c7c2646c4731f9"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="b049fd57fce274d10013e2cf0e05f215f68f6580865abc52178f66ae9bf43fd8"
+    PKG_SHA256="b42c254e1349df86bd40bc28fdf386172a1a46f2eeabe3c7a08a75cf1fb60e27"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rustc-snapshot: update to 1.89.0
- rust-std-snapshot: update to 1.89.0
- cargo-snapshot: update to 1.89.0
- rust: update to 1.89.0
- llvm: add llc and llvm-... as required by rust-1.89.0