### PR TITLE
llvm: include llvm- and obj on all target llvm builds to support rust

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -99,33 +99,25 @@ pre_configure_host() {
 }
 
 post_make_host() {
-  ninja ${NINJA_OPTS} llc llvm-ar llvm-config llvm-cov llvm-dis llvm-nm llvm-objcopy llvm-objdump \
+  ninja ${NINJA_OPTS} llc llvm-ar llvm-as llvm-config llvm-cov llvm-dis \
+                      llvm-link llvm-nm llvm-objcopy llvm-objdump \
                       llvm-profdata llvm-readobj llvm-size llvm-strip \
-                      llvm-tblgen
+                      llvm-tblgen opt
 
   if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
-    ninja ${NINJA_OPTS} llvm-as llvm-link llvm-spirv opt
+    ninja ${NINJA_OPTS} llvm-spirv
   fi
 }
 
 post_makeinstall_host() {
   mkdir -p ${TOOLCHAIN}/bin
-    cp -a bin/llc ${TOOLCHAIN}/bin
-    cp -a bin/llvm-ar ${TOOLCHAIN}/bin
-    cp -a bin/llvm-config ${TOOLCHAIN}/bin
-    cp -a bin/llvm-cov ${TOOLCHAIN}/bin
-    cp -a bin/llvm-dis ${TOOLCHAIN}/bin
-    cp -a bin/llvm-nm ${TOOLCHAIN}/bin
-    cp -a bin/llvm-objcopy ${TOOLCHAIN}/bin
-    cp -a bin/llvm-objdump ${TOOLCHAIN}/bin
-    cp -a bin/llvm-profdata ${TOOLCHAIN}/bin
-    cp -a bin/llvm-readobj ${TOOLCHAIN}/bin
-    cp -a bin/llvm-size ${TOOLCHAIN}/bin
-    cp -a bin/llvm-strip ${TOOLCHAIN}/bin
-    cp -a bin/llvm-tblgen ${TOOLCHAIN}/bin
+    cp -a bin/{llc,llvm-ar,llvm-as,llvm-config,llvm-cov,llvm-dis} "${TOOLCHAIN}/bin"
+    cp -a bin/{llvm-link,llvm-nm,llvm-objcopy,llvm-objdump} "${TOOLCHAIN}/bin"
+    cp -a bin/{llvm-profdata,llvm-readobj,llvm-size,llvm-strip} "${TOOLCHAIN}/bin"
+    cp -a bin/{llvm-tblgen,opt} "${TOOLCHAIN}/bin"
 
   if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
-    cp -a bin/{llvm-as,llvm-link,llvm-spirv,opt} "${TOOLCHAIN}/bin"
+    cp -a bin/llvm-spirv "${TOOLCHAIN}/bin"
   fi
 }
 


### PR DESCRIPTION
- fixes aarch64 and arm rust target builds