### PR TITLE
[le12.2] firmware-imx: update to 8.28-994fa14

### DIFF
--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="firmware-imx"
-PKG_VERSION="8.27-5af0ceb"
-PKG_SHA256="61f925e606ab020b1a36f3f7f7e459c6847f5b9dbc79421f9ef86e8fc124eb2f"
+PKG_VERSION="8.28-994fa14"
+PKG_SHA256="55996f340e87825685a00cd309901189066ec9545ee607734f942c3cde4d69dc"
 PKG_ARCH="aarch64 arm"
 PKG_LICENSE="other"
 PKG_SITE="http://www.freescale.com"


### PR DESCRIPTION
release notes:
- https://docs.nxp.com/bundle/RN00210/page/topics/overview.html
- https://www.nxp.com/docs/en/user-guide/UG10163.pdf
- Backport #10341 