### PR TITLE
screensaver: allow build with EGL on gbm

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.asterwave/package.mk
@@ -20,3 +20,7 @@ PKG_ADDON_TYPE="xbmc.ui.screensaver"
 if [ "${OPENGL}" = "no" ]; then
   exit 0
 fi
+
+if [ "${DISPLAYSERVER}" = "no" ]; then
+  PKG_CMAKE_OPTS_TARGET="-DCORE_PLATFORM_NAME=gbm"
+fi

--- a/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/screensaver.matrixtrails/package.mk
@@ -21,3 +21,7 @@ PKG_ADDON_TYPE="xbmc.ui.screensaver"
 if [ "${OPENGL}" = "no" ]; then
   exit 0
 fi
+
+if [ "${DISPLAYSERVER}" = "no" ]; then
+  PKG_CMAKE_OPTS_TARGET="-DCORE_PLATFORM_NAME=gbm"
+fi


### PR DESCRIPTION
- needs https://github.com/xbmc/screensaver.matrixtrails/pull/87
- needs https://github.com/xbmc/screensaver.asterwave/pull/78
- ref https://github.com/SpartanJ/SOIL2/commit/8eba88632323f6d65e5e68a2830a9ef60dd09d91 
- ref https://github.com/SpartanJ/SOIL2/issues/74 
- fixes #10306
- Required changes for addons included in #10349