### PR TITLE
libprojectM: allow build with EGL on gbm

### DIFF
--- a/packages/graphics/libprojectM/package.mk
+++ b/packages/graphics/libprojectM/package.mk
@@ -39,7 +39,10 @@ fi
 pre_configure_target() {
   ./autogen.sh
 
-  if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  if [ "${DISPLAYSERVER}" = "no" -a "${OPENGL_SUPPORT}" = "yes" ]; then
+    export CFLAGS+=" -DSOIL_EGL"
+    export GL_LIBS="-lOpenGL"
+  elif [ "${OPENGLES_SUPPORT}" = "yes" ]; then
     export CFLAGS+=" -DSOIL_GLES2"
   fi
 }

--- a/packages/graphics/libprojectM/patches/0002-Allow-to-build-without-X11-on-Linux-and-BSD.patch
+++ b/packages/graphics/libprojectM/patches/0002-Allow-to-build-without-X11-on-Linux-and-BSD.patch
@@ -1,0 +1,58 @@
+From 8eba88632323f6d65e5e68a2830a9ef60dd09d91 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mart=C3=ADn=20Lucas=20Golini?= <spartanj@gmail.com>
+Date: Sun, 10 Aug 2025 11:52:46 -0300
+Subject: [PATCH] Allow to build without X11 on Linux and BSD. Added flags:
+ `SOIL_EGL` flag to indicate the build have access to an EGL context.
+ `SOIL_NO_X11` flag to force disable using X11 features.
+
+---
+ src/SOIL2/SOIL2.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/src/libprojectM/Renderer/SOIL2/SOIL2.c b/src/libprojectM/Renderer/SOIL2/SOIL2.c
+index 42f111a..d220e85 100644
+--- a/src/libprojectM/Renderer/SOIL2/SOIL2.c
++++ b/src/libprojectM/Renderer/SOIL2/SOIL2.c
+@@ -29,7 +29,11 @@
+ 	#endif
+ #elif defined( __ANDROID__ ) || defined( ANDROID )
+ 	#define SOIL_PLATFORM_ANDROID
+-#elif ( defined ( linux ) || defined( __linux__ ) || defined( __FreeBSD__ ) || defined(__OpenBSD__) || defined( __NetBSD__ ) || defined( __DragonFly__ ) || defined( __SVR4 ) )
++#elif !defined( SOIL_GLES2 ) && !defined( SOIL_GLES1 ) && !defined( SOIL_NO_X11 ) && \
++	!defined( SOIL_EGL ) &&                                                          \
++	( defined( linux ) || defined( __linux__ ) || defined( __FreeBSD__ ) ||          \
++	  defined( __OpenBSD__ ) || defined( __NetBSD__ ) || defined( __DragonFly__ ) || \
++	  defined( __SVR4 ) )
+ 	#define SOIL_X11_PLATFORM
+ #endif
+ 
+@@ -37,8 +41,9 @@
+ 	#define SOIL_GLES2
+ #endif
+ 
+-#if ( defined( SOIL_GLES2 ) || defined( SOIL_GLES1 ) ) && !defined( SOIL_NO_EGL ) && !defined( SOIL_PLATFORM_IOS )
+-	#include <EGL/egl.h>
++#if ( defined( SOIL_GLES2 ) || defined( SOIL_GLES1 ) || defined( SOIL_EGL ) ) && \
++	!defined( SOIL_NO_EGL ) && !defined( SOIL_PLATFORM_IOS )
++#include <EGL/egl.h>
+ #endif
+ 
+ #if defined( SOIL_GLES2 )
+@@ -216,7 +221,7 @@
+ 
+ #if defined( SOIL_PLATFORM_IOS )
+ 	func = dlsym( RTLD_DEFAULT, proc );
+-#elif defined( SOIL_GLES2 ) || defined( SOIL_GLES1 )
++#elif defined( SOIL_GLES2 ) || defined( SOIL_GLES1 ) || defined( SOIL_EGL )
+ 	#ifndef SOIL_NO_EGL
+ 		func = eglGetProcAddress( proc );
+ 	#else
+@@ -2973,7 +2978,7 @@
+ 				ext_addr = (P_SOIL_GLGENERATEMIPMAPPROC)SOIL_GL_GetProcAddress("glGenerateMipmapEXT");
+ 			}
+ 
+-			#elif defined( SOIL_GLES2 )
++			#elif defined( SOIL_GLES2 ) || defined( SOIL_EGL )
+ 				ext_addr = 	&glGenerateMipmap;
+ 			#else /** SOIL_GLES1 */
+ 				ext_addr = &glGenerateMipmapOES;

--- a/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.projectm/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="visualization.projectm"
-PKG_VERSION="21.0.1-Omega"
-PKG_SHA256="71e99eb4ba79df21afa17a058b77905f56daa2417a94b1b7cf557efa2b48a64a"
-PKG_REV="4"
+PKG_VERSION="22f1ff11f883cc9cfd6a243371d96e7963a71e2d"
+PKG_SHA256="02ae1c54d83c7a1f96c5de6b23e149ea4866f16fb8200a10b1e33c3e55917258"
+PKG_REV="5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/visualization.projectm"
 PKG_URL="https://github.com/xbmc/visualization.projectm/archive/${PKG_VERSION}.tar.gz"
@@ -16,6 +16,10 @@ PKG_LONGDESC="visualization.projectm"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.player.musicviz"
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi
 
 pre_configure_target() {
   export LDFLAGS=$(echo ${LDFLAGS} | sed -e "s|-Wl,--as-needed||")


### PR DESCRIPTION
- fixes #10306
- Attached patch enabled the EGL in SOIL2
- ref https://github.com/SpartanJ/SOIL2/commit/8eba88632323f6d65e5e68a2830a9ef60dd09d91 
- ref https://github.com/SpartanJ/SOIL2/issues/74

Includes the following commits:
- visualization.projectm: update to githash 22f1ff1 and addon (5)
- libprojectM: allow build with EGL on gbm

~~there is an additional build issue - as below - with pthread to be fixed.~~

~~[build.LibreELEC-Generic.x86_64-13.0-devel-libprojectM_target-678.log](https://github.com/user-attachments/files/21737495/build.LibreELEC-Generic.x86_64-13.0-devel-libprojectM_target-678.log)~~
