### PR TITLE
game.shader.presets: update to 22.1.0-Piers

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.shader.presets/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.shader.presets/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.shader.presets"
-PKG_VERSION="22.0.1-Piers"
-PKG_SHA256="f32a20569bbaccf347814d048284e462e51b0678cf9b8ce12e4be72b3d48b357"
-PKG_REV="2"
+PKG_VERSION="22.1.0-Piers"
+PKG_SHA256="1e0efe8aaadb9e6eebbdcf9a7b80495477153bb7671aec66ff3d77edb5e74f55"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/kodi-game/game.shader.presets"


### PR DESCRIPTION
This fixes the build error with current kodi master:
```
/home/hias/libreelec/libreelec-master/build.LibreELEC-RPi5.aarch64-13.0-devel/build/game.shader.presets-22.0.1-Piers/src/addon.h:44:8: error: conflicting return type specified for 'virtual void CShaderPreset::ShaderPresetWrite(preset_file, const video_shader&)'
   44 |   void ShaderPresetWrite(preset_file file, const video_shader &shader) override;
      |        ^~~~~~~~~~~~~~~~~
In file included from /home/hias/libreelec/libreelec-master/build.LibreELEC-RPi5.aarch64-13.0-devel/build/game.shader.presets-22.0.1-Piers/src/addon.h:23: 
/home/hias/libreelec/libreelec-master/build.LibreELEC-RPi5.aarch64-13.0-devel/toolchain/aarch64-libreelec-linux-gnu/sysroot/usr/include/kodi/addon-instance/ShaderPreset.h:164:16: note: overridden function is 'virtual bool kodi::addon::CInstanceShaderPreset::ShaderPresetWrite(preset_file, const video_shader&)'
  164 |   virtual bool ShaderPresetWrite(preset_file file, const video_shader& shader) { return false; }
      |                ^~~~~~~~~~~~~~~~~

```