### PR TITLE
[le12.2] scripts/get_archive: allow fallback to curl if wget is missing

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -21,21 +21,31 @@ build_msg "CLR_GET" "GET" "${1} (archive)" "indent"
 pkg_lock_status "GETPKG" "${PKG_NAME}" "unpack" "downloading package..."
 
 PACKAGE_MIRROR="${DISTRO_MIRROR}/${PKG_NAME}/${PKG_SOURCE_NAME}"
-[ "${VERBOSE}" != "yes" ] && WGET_OPT=-q
-WGET_CMD="wget --output-file=- --timeout=30 --tries=3 --no-check-certificate -c ${WGET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
+if command -v wget >/dev/null; then
+  [ "${VERBOSE}" != "yes" ] && GET_OPT=-q
+  GET_CMD="wget --output-file=- --timeout=30 --tries=3 --no-check-certificate -c ${GET_OPT} --progress=bar:force --show-progress -O ${PACKAGE}"
+else
+  # if wget is not available use curl
+  [ "${VERBOSE}" != "yes" ] && GET_OPT="--silent --show-error"
+  GET_CMD="curl ${GET_OPT} --fail --connect-timeout 30 --retry 3 --continue-at - --location --max-redirs 5 --output ${PACKAGE}"
+fi
 
 # unset LD_LIBRARY_PATH to stop wget from using toolchain/lib and loading libssl.so/libcrypto.so instead of host libraries
 unset LD_LIBRARY_PATH
 
 rm -f "${STAMP_URL}" "${STAMP_SHA}"
 
-NBWGET=10
+NBGET=10
 NBCHKS=2
-while [ ${NBWGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
+while [ ${NBGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
     rm -f "${PACKAGE}"
-    [[ "${url}" =~ ^[fF][tT][pP]:* ]] && WGET_FTP=--passive-ftp || WGET_FTP=
-    if ${WGET_CMD} ${WGET_FTP} "${url}"; then
+    if command -v wget >/dev/null; then
+      [[ "${url}" =~ ^[fF][tT][pP]:* ]] && GET_FTP=--passive-ftp || GET_FTP=
+    else
+      GET_FTP=
+    fi
+    if ${GET_CMD} ${GET_FTP} "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
       [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
@@ -49,10 +59,10 @@ while [ ${NBWGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
       fi
     fi
   done
-  NBWGET=$((NBWGET - 1))
+  NBGET=$((NBGET - 1))
 done
 
-if [ ${NBWGET} -eq 0 -o ${NBCHKS} -eq 0 ]; then
+if [ ${NBGET} -eq 0 -o ${NBCHKS} -eq 0 ]; then
   die "\nCannot get ${1} sources : ${PKG_URL}\nTry later!"
 else
   build_msg "CLR_INFO" "INFO" "Calculated checksum: ${CALC_SHA256}"


### PR DESCRIPTION
le13 has migrated to using curl instead of wget. this change allows for curl to be used when preparing package get on dev host, but still defaults to wget as is the standard in le12.x