### PR TITLE
pastekodi: include arch and version info

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -72,7 +72,7 @@ else
 fi
 
 (
-  echo "${LOG_TYPE} log output for: $(lsb_release)"
+  echo "${LOG_TYPE} log output for: $(lsb_release) ${DISTRO_ARCH} ${VERSION_ID}"
 
   if [ "${SYSTEM_ARCH}" = "x86_64" ]; then
     if [ -d "/sys/firmware/efi" ]; then


### PR DESCRIPTION
Currently it's very hard to tell from the logs if a user runs eg a Generic or a Generic-legacy image and if it's from a LE12, LE12.2 or LE13 nightly.

Add this important info in addition to the PRETTY_NAME info.