### PR TITLE
iwlwifi-firmware: update to githash 042ba27

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="e1616ba80b84271dd61266047be57be906688e27"
-PKG_SHA256="58d13bc4f8c5212b01afb1c7d4d2e929082a044d069525b4368269fd4f1db6a8"
+PKG_VERSION="042ba27c927df44e8413a3a86f4c19ffb8f4babd"
+PKG_SHA256="b1afaa0893c46d2eeea962c8cc6210355408357ee8704ca5a8b27ce35b073d62"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- supports Linux 6.16