### PR TITLE
mesa: add patch with mesa MR 36870

### DIFF
--- a/packages/graphics/mesa/patches/001-mr36870-gallium-extra-samplers.patch
+++ b/packages/graphics/mesa/patches/001-mr36870-gallium-extra-samplers.patch
@@ -1,0 +1,112 @@
+From e10e533b39b0820efbd215080992cffe1acc0f45 Mon Sep 17 00:00:00 2001
+From: Robert Mader <robert.mader@collabora.com>
+Date: Wed, 20 Aug 2025 10:18:13 +0200
+Subject: [PATCH] gallium: Set and count all extra samplers
+
+After the commit mentioned below the `extra` variable only holds the
+last added extra sampler. For 3-plane formats this results in one extra
+sampler being leaked.
+
+Add the bits for each extra sampler instead.
+
+Fixes: abcd02a07db (gallium: Properly handle non-contiguous used sampler view indexes)
+Signed-off-by: Robert Mader <robert.mader@collabora.com>
+---
+ src/mesa/state_tracker/st_atom_texture.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/mesa/state_tracker/st_atom_texture.c b/src/mesa/state_tracker/st_atom_texture.c
+index 8cfd54779cbee..7626a1da0e8fd 100644
+--- a/src/mesa/state_tracker/st_atom_texture.c
++++ b/src/mesa/state_tracker/st_atom_texture.c
+@@ -187,6 +187,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_NV12:
+          if (stObj->pt->format == PIPE_FORMAT_R8_G8B8_420_UNORM)
+@@ -199,6 +200,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_NV21:
+          if (stObj->pt->format == PIPE_FORMAT_R8_B8G8_420_UNORM)
+@@ -211,6 +213,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_P010:
+       case PIPE_FORMAT_P012:
+@@ -222,6 +225,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_IYUV:
+          if (stObj->pt->format == PIPE_FORMAT_R8_G8_B8_420_UNORM ||
+@@ -234,9 +238,11 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_Y10X6_U10X6_V10X6_420_UNORM:
+       case PIPE_FORMAT_Y10X6_U10X6_V10X6_422_UNORM:
+@@ -252,9 +258,11 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_YUYV:
+       case PIPE_FORMAT_YVYU:
+@@ -270,6 +278,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_UYVY:
+       case PIPE_FORMAT_VYUY:
+@@ -285,6 +294,7 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       case PIPE_FORMAT_Y210:
+       case PIPE_FORMAT_Y212:
+@@ -296,14 +306,12 @@ st_get_sampler_views(struct st_context *st,
+          extra = u_bit_scan(&free_slots);
+          sampler_views[extra] =
+                pipe->create_sampler_view(pipe, stObj->pt->next, &tmpl);
++         (*extra_sampler_views) |= 1 << extra;
+          break;
+       default:
+          break;
+       }
+ 
+-      if (extra)
+-         (*extra_sampler_views) |= 1 << extra;
+-
+       num_textures = MAX2(num_textures, extra + 1);
+    }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
This fixes a huge memory leak when using EGL rendering

See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/36870

Issue was initially reported on forums: https://forum.libreelec.tv/thread/29918-rpi4-prime-breaks-system-on-12-2/?postID=201675#post201675

Runtime tested on RPi5