### PR TITLE
[le12.2] gdk-pixbuf: add upstream patch file for v2.43.2 release

### DIFF
--- a/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
+++ b/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
@@ -1,0 +1,27 @@
+commit 101805761797283449bc3d02df1efc43c8be3b8a
+Author: correctmost <136447-correctmost@users.noreply.gitlab.gnome.org>
+Date:   Mon Jun 16 01:21:00 2025 -0400
+
+    Add a GDK_PIXBUF_VERSION_2_44 macro to fix -Wundef warnings
+
+diff --git a/gdk-pixbuf/gdk-pixbuf-macros.h b/gdk-pixbuf/gdk-pixbuf-macros.h
+index 335285f5c..f831a308a 100644
+--- a/gdk-pixbuf/gdk-pixbuf-macros.h
++++ b/gdk-pixbuf/gdk-pixbuf-macros.h
+@@ -258,6 +258,16 @@
+  */
+ #define GDK_PIXBUF_VERSION_2_40 (G_ENCODE_VERSION (2, 40))
+ 
++/**
++ * GDK_PIXBUF_VERSION_2_44:
++ *
++ * A macro that evaluates to the 2.44 version of GdkPixbuf,
++ * in a format that can be used by the C pre-processor.
++ *
++ * Since: 2.44
++ */
++#define GDK_PIXBUF_VERSION_2_44 (G_ENCODE_VERSION (2, 44))
++
+ #ifndef __GTK_DOC_IGNORE__
+ #if (GDK_PIXBUF_MINOR % 2)
+ #define GDK_PIXBUF_VERSION_CUR_STABLE (G_ENCODE_VERSION (GDK_PIXBUF_MAJOR, GDK_PIXBUF_MINOR + 1))


### PR DESCRIPTION
### Background :
Lakka has trying to port LibreELEC 12.2 into Lakka-v6.1 now.
https://github.com/libretro/Lakka-LibreELEC/tree/Lakka-v6.1
https://github.com/libretro/Lakka-LibreELEC/pull/2097
And, Lakka supports Wayland.x86_64.

### About this pull request :
Lakka found the build problem on the swaybg package. ([Lakka-v6_1-swaybg-buildfail-Wayland-x86_64.log](https://github.com/user-attachments/files/21948336/Lakka-v6_1-swaybg-buildfail-Wayland-x86_64.log))
This problem is occured on LibreELEC 12.2 too. ([LE12_2-swaybg-buildlog.txt](https://github.com/user-attachments/files/21948343/LE12_2-swaybg-buildlog.txt))

This problem is caused by gdk-pixbuf package v2.43.2.
v2.43.2 is not contained GDK_PIXBUF_VERSION_2_44 macro in source file.
So upstream gdk-pixbuf prepared update.
https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/491d005d116ecc49350366b8c2920ae4d865b7dd

This pull request is gdk-pixbuf's update.
This problem is fixed by this pull request. 
[LE12_2-swaybg-buildlog-gdk-pixbuf-patched.txt](https://github.com/user-attachments/files/21948389/LE12_2-swaybg-buildlog-gdk-pixbuf-patched.txt)

### Note :
The gdk-pixbuf has update version v2.43.3.
But v2.43.3 needs meson v1.5 or later.
So patch file is better than version bump for LibreELEC 12.2 I think.

Please let me know if something wrong.

Thanks
ASAI, Shigeaki