### PR TITLE
Shellcheck changes

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -311,7 +311,7 @@ check_is_compatible() {
 }
 
 update_file() {
-  if [ -f "$UPDATE_DIR/$2" -a -f "$3" ]; then
+  if [ -f "$UPDATE_DIR/$2" ] && [ -f "$3" ]; then
     mount -o remount,rw /flash
 
     rm -f "$3"
@@ -334,7 +334,7 @@ update_file() {
 update_partition() {
   local result
 
-  if [ -f "$UPDATE_DIR/$2" -a -b "$3" ]; then
+  if [ -f "$UPDATE_DIR/$2" ] && [ -b "$3" ]; then
     StartProgress spinner "Updating $1... "
       result="$(dd if="$UPDATE_DIR/$2" of="$3" 2>&1)"
       StopProgress "done"
@@ -406,7 +406,7 @@ load_splash() {
         done
       fi
 
-      if [ -n "$SPLASHIMAGE" -a -f "$SPLASHIMAGE" ]; then
+      if [ -n "$SPLASHIMAGE" ] && [ -f "$SPLASHIMAGE" ]; then
         ply-image $SPLASHIMAGE > /dev/null 2>&1
       fi
 
@@ -468,7 +468,7 @@ force_fsck() {
 }
 
 check_disks() {
-  if [ "$RUN_FSCK" = "yes" -a -n "$RUN_FSCK_DISKS" ]; then
+  if [ "$RUN_FSCK" = "yes" ] && [ -n "$RUN_FSCK_DISKS" ]; then
     progress "Checking disk(s): $RUN_FSCK_DISKS"
     echo "Checking disk(s): $RUN_FSCK_DISKS" >/dev/kmsg
     for i in 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0; do
@@ -571,7 +571,7 @@ mount_storage() {
 
   if [ -n "$disk" ]; then
     if [ -n "$OVERLAY" ]; then
-      OVERLAY_DIR=$(cat /sys/class/net/eth0/address | tr -d :)
+      OVERLAY_DIR=$(tr -d : < /sys/class/net/eth0/address)
 
       mount_part "$disk" "/storage" "rw,noatime"
       mkdir -p /storage/$OVERLAY_DIR
@@ -602,7 +602,7 @@ mount_storage() {
 update_bootmenu() {
   local crnt_default
 
-  if [ -n "$SYSLINUX_DEFAULT" -a -f /flash/syslinux.cfg ]; then
+  if [ -n "$SYSLINUX_DEFAULT" ] && [ -f /flash/syslinux.cfg ]; then
     if grep -q "^LABEL $SYSLINUX_DEFAULT\$" /flash/syslinux.cfg; then
       crnt_default="$(awk '/^DEFAULT/ {print $2}' /flash/syslinux.cfg)"
       if [ ! "$crnt_default" = "$SYSLINUX_DEFAULT" ]; then
@@ -617,7 +617,7 @@ update_bootmenu() {
     fi
   fi
 
-  if [ -n "$GRUB_DEFAULT" -a -f /flash/EFI/BOOT/grub.cfg ]; then
+  if [ -n "$GRUB_DEFAULT" ] && [ -f /flash/EFI/BOOT/grub.cfg ]; then
     if grep -q "^menuentry \"$GRUB_DEFAULT\"" /flash/EFI/BOOT/grub.cfg; then
       crnt_default="$(awk '/^set default/ {print substr($2,9,19)}' /flash/EFI/BOOT/grub.cfg)"
       if [ ! "$crnt_default" = "\"$GRUB_DEFAULT\"" ]; then
@@ -663,7 +663,7 @@ do_cleanup() {
       umount $UPDATE_ROOT/.tmp/mnt
     fi
 
-    [ -n $LOOP ] && losetup -d $LOOP &>/dev/null
+    [ -n "$LOOP" ] && losetup -d $LOOP &>/dev/null
   fi
 
   [ -f "$UPDATE_TAR" ] && rm -f "$UPDATE_TAR" &>/dev/null
@@ -812,7 +812,7 @@ check_update() {
     return 0
   fi
 
-  if [ ! -f "$UPDATE_DIR/$UPDATE_KERNEL" -o ! -f "$UPDATE_DIR/$UPDATE_SYSTEM" ]; then
+  if [ ! -f "$UPDATE_DIR/$UPDATE_KERNEL" ] || [ ! -f "$UPDATE_DIR/$UPDATE_SYSTEM" ]; then
     echo "Missing (source) ${UPDATE_KERNEL} or ${UPDATE_SYSTEM}!"
     do_cleanup
     StartProgress countdown "Normal startup in 30s... " 30 "NOW"
@@ -821,9 +821,9 @@ check_update() {
 
   # check md5 sums if .nocheck doesn't exist
   if [ ! -f "$UPDATE_ROOT/.nocheck" ]; then
-    if [ -f "$UPDATE_DIR/${UPDATE_KERNEL}.md5" -a -f "$UPDATE_DIR/${UPDATE_SYSTEM}.md5" ]; then
+    if [ -f "$UPDATE_DIR/${UPDATE_KERNEL}.md5" ] && [ -f "$UPDATE_DIR/${UPDATE_SYSTEM}.md5" ]; then
       # *.md5 size-check
-      if [ ! -s "$UPDATE_DIR/${UPDATE_KERNEL}.md5" -o ! -s "$UPDATE_DIR/${UPDATE_SYSTEM}.md5" ]; then
+      if [ ! -s "$UPDATE_DIR/${UPDATE_KERNEL}.md5" ] || [ ! -s "$UPDATE_DIR/${UPDATE_SYSTEM}.md5" ]; then
         echo "Zero-sized .md5 file!"
         MD5_FAILED="1"
       else
@@ -932,7 +932,7 @@ prepare_sysroot() {
   mount --move /flash /sysroot/flash
   mount --move /storage /sysroot/storage
 
-  if [ ! -d "/sysroot/usr/lib/kernel-overlays/base/lib/modules/$(uname -r)/" -a -f "/sysroot/usr/lib/systemd/systemd" ]; then
+  if [ ! -d "/sysroot/usr/lib/kernel-overlays/base/lib/modules/$(uname -r)/" ] && [ -f "/sysroot/usr/lib/systemd/systemd" ]; then
     echo ""
     echo "NEVER TOUCH boot= in syslinux.conf / cmdline.txt!"
     echo "If you don't know what you are doing,"
@@ -1082,8 +1082,8 @@ done
 BOOT_STEP=final
 
 # log if booting from usb / removable storage
-STORAGE=$(cat /proc/mounts | grep " /sysroot/storage " | awk '{print $1}' | awk -F '/' '{print $3}')
-FLASH=$(cat /proc/mounts | grep " /sysroot/flash " | awk '{print $1}' | awk -F '/' '{print $3}')
+STORAGE=$(grep " /sysroot/storage " /proc/mounts | awk '{print $1}' | awk -F '/' '{print $3}')
+FLASH=$(grep " /sysroot/flash " /proc/mounts | awk '{print $1}' | awk -F '/' '{print $3}')
 for i in $STORAGE $FLASH ; do
   if [ -n "$i" ]; then
     removable="/sys/class/block/*/$i/../removable"

--- a/scripts/autoreconf
+++ b/scripts/autoreconf
@@ -8,8 +8,7 @@
 
 RECONF_DIR="${3}"
 
-if [ ! -f "${RECONF_DIR}/configure.in" \
-  -a ! -f "${RECONF_DIR}/configure.ac" ]; then
+if [ ! -f "${RECONF_DIR}/configure.in" ] && [ ! -f "${RECONF_DIR}/configure.ac" ]; then
   die "configure.in or configure.ac not found"
 fi
 

--- a/scripts/autoremove
+++ b/scripts/autoremove
@@ -5,7 +5,7 @@
 
 . config/options "${1}"
 
-if [ -d "${PKG_BUILD}" -a "${PKG_SECTION}" != "virtual" ]; then
+if [ -d "${PKG_BUILD}" ] && [ "${PKG_SECTION}" != "virtual" ]; then
   print_color CLR_AUTOREMOVE "AUTOREMOVE ${PKG_BUILD}"
   echo
   rm -r "${PKG_BUILD}"

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -97,7 +97,7 @@ perl_map=(
 ### PROJECT SPECIFIC REQUIREMENTS ###
 # Extend build scripts to look for distro/project/device checkdep scripts before adding further checks here
 # Native aarch64 on debian host needs to support rkbin (Rockchip) and aml_encrypt_* (Amlogic)
-if [ "$(uname -m)" = "aarch64" ] && [ "${PROJECT}" = "Rockchip" -o "${PROJECT}" = "Amlogic" ]; then
+if [ "$(uname -m)" = "aarch64" ] && { [ "${PROJECT}" = "Rockchip" ] || [ "${PROJECT}" = "Amlogic" ]; }; then
   dep_map[qemu-x86_64]=qemu-user-binfmt
   file_map[/usr/x86_64-linux-gnu/lib/ld-linux-x86-64.so.2]="libc6-amd64-cross"
   file_map[/usr/x86_64-linux-gnu/lib/libc.so.6]="libc6-amd64-cross"

--- a/scripts/extract
+++ b/scripts/extract
@@ -10,7 +10,7 @@ if [ -z "${2}" ]; then
   die "usage: ${0} package_name target_dir"
 fi
 
-[ -z "${PKG_URL}" -o -z "${PKG_SOURCE_NAME}" ] && die "${PKG_NAME}: PKG_URL or PKG_SOURCE_NAME undefined"
+{ [ -z "${PKG_URL}" ] || [ -z "${PKG_SOURCE_NAME}" ]; } && die "${PKG_NAME}: PKG_URL or PKG_SOURCE_NAME undefined"
 [ ! -d "${SOURCES}/${1}" ] && die "${PKG_NAME}: ${SOURCES}/${1} not found"
 [ ! -d "${2}" ] && die "${PKG_NAME}: target ${2} not found"
 
@@ -20,7 +20,7 @@ else
   FULL_SOURCE_PATH="${SOURCES}/${1}/${PKG_SOURCE_NAME}"
 fi
 
-if [ ! -f "${FULL_SOURCE_PATH}" -a ! -d "${FULL_SOURCE_PATH}" ]; then
+if [ ! -f "${FULL_SOURCE_PATH}" ] && [ ! -d "${FULL_SOURCE_PATH}" ]; then
   echo "error: File ${PKG_SOURCE_NAME} doesn't exist for package ${1}"
   echo "Have you called scripts/extract before scripts/get?"
   die

--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 _get_file_already_downloaded() {
-  [ ! -f "${PACKAGE}" -o ! -f "${STAMP_URL}" -o ! -f "${STAMP_SHA}" ] && return 1
-  [ -n "${PKG_SHA256}" -a "$(cat ${STAMP_SHA} 2>/dev/null)" != "${PKG_SHA256}" ] && return 1
+  { [ ! -f "${PACKAGE}" ] || [ ! -f "${STAMP_URL}" ] || [ ! -f "${STAMP_SHA}" ]; } && return 1
+  { [ -n "${PKG_SHA256}" ] && [ "$(cat ${STAMP_SHA} 2>/dev/null)" != "${PKG_SHA256}" ]; } && return 1
   return 0
 }
 
@@ -32,13 +32,13 @@ rm -f "${STAMP_URL}" "${STAMP_SHA}"
 
 NBGET=10
 NBCHKS=2
-while [ ${NBGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
+while [ ${NBGET} -gt 0 ] && [ ${NBCHKS} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
     rm -f "${PACKAGE}"
     if ${GET_CMD} "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
 
-      [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" = "${CALC_SHA256}" ] && break 2
+      { [ -z "${PKG_SHA256}" ] || [ "${PKG_SHA256}" = "${CALC_SHA256}" ]; } && break 2
 
       if [ "${CHANGE_HASH}" = "yes" ]; then
         sed -e "s|^PKG_SHA256=.*|PKG_SHA256=\"${CALC_SHA256}\"|" -i "${PKG_DIR}/package.mk"
@@ -52,7 +52,7 @@ while [ ${NBGET} -gt 0 -a ${NBCHKS} -gt 0 ]; do
   NBGET=$((NBGET - 1))
 done
 
-if [ ${NBGET} -eq 0 -o ${NBCHKS} -eq 0 ]; then
+if [ ${NBGET} -eq 0 ] || [ ${NBCHKS} -eq 0 ]; then
   die "\nCannot get ${1} sources : ${PKG_URL}\nTry later!"
 else
   build_msg "CLR_INFO" "INFO" "Calculated checksum: ${CALC_SHA256}"

--- a/scripts/image
+++ b/scripts/image
@@ -11,7 +11,7 @@ unset _CACHE_PACKAGE_LOCAL _CACHE_PACKAGE_GLOBAL _DEBUG_DEPENDS_LIST _DEBUG_PACK
 . config/show_config
 
 # Validate UBOOT_SYSTEM if it is specified
-if [ "${BOOTLOADER}" = "u-boot" -a -n "${DEVICE}" ]; then
+if [ "${BOOTLOADER}" = "u-boot" ] && [ -n "${DEVICE}" ]; then
   if [ -z "${UBOOT_SYSTEM}" ]; then
     ${SCRIPTS}/uboot_helper ${PROJECT} ${DEVICE} >/dev/null
   else
@@ -206,7 +206,7 @@ if [ -d "${PROJECT_DIR}/${PROJECT}/filesystem" ]; then
 fi
 
 # Copy DEVICE related files to filesystem
-if [ -n "${DEVICE}" -a -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem" ]; then
+if [ -n "${DEVICE}" ] && [ -d "${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem" ]; then
   cp -PR --remove-destination ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/* ${INSTALL}
   # Install device specific systemd services
   for service in ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/filesystem/usr/lib/systemd/system/*.service; do
@@ -272,7 +272,7 @@ rm -rf ${FAKEROOT_SCRIPT}
 # Set permissions
 chmod 0644 ${TARGET_IMG}/${IMAGE_NAME}.system
 
-if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
+if [ "${1}" = "release" ] || [ "${1}" = "mkimage" ] || [ "${1}" = "noobs" ]; then
 
   RELEASE_DIR="target/${IMAGE_NAME}"
 
@@ -341,9 +341,10 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
     UUID_SYSTEM="$(date '+%d%m')-$(date '+%M%S')"
     UUID_STORAGE="$(uuidgen)"
 
-    DEVICE_BOARDS=
-    if [ "${BOOTLOADER}" = "u-boot" -a -z "${UBOOT_SYSTEM}" -a -n "${DEVICE}" ]; then
+    if [ "${BOOTLOADER}" = "u-boot" ] && [ -z "${UBOOT_SYSTEM}" ] && [ -n "${DEVICE}" ]; then
       DEVICE_BOARDS=$(${SCRIPTS}/uboot_helper "${PROJECT}" "${DEVICE}")
+    else
+      DEVICE_BOARDS=
     fi
 
     if [ -n "${DEVICE_BOARDS}" ]; then
@@ -502,6 +503,6 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
   fi
 fi
 
-if [ -n "$(ls -1 ${BUILD}/qa_checks/ 2>/dev/null)" ]; then
+if [ -d "${BUILD}/qa_checks" ] && [ -n "$(ls -1 ${BUILD}/qa_checks/)" ]; then
   log_qa_check "qa_issues" "QA issues present, please fix!\n$(find ${BUILD}/qa_checks/* -type f ! -name qa_issues)\n"
 fi

--- a/scripts/makefile_helper
+++ b/scripts/makefile_helper
@@ -10,7 +10,7 @@ set -e
 BUILD_ROOT=$(PROJECT= DEVICE= ARCH= . config/options "" && echo "${BUILD_ROOT}")
 BUILD_BASE=$(PROJECT= DEVICE= ARCH= . config/options "" && echo "${BUILD_BASE}")
 
-if [ -z "${BUILD_BASE}" -o -z "${BUILD_ROOT}" ]; then
+if [ -z "${BUILD_BASE}" ] || [ -z "${BUILD_ROOT}" ]; then
   # make sure variables are set before running an rm
   echo "error: ${0}: both BUILD_BASE and BUILD_ROOT must be set when running \"[clean|distclean]\"; aborting"
   exit 1

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -39,7 +39,7 @@ mkdir -p ${BUILD}/build
 # Perform a wildcard match on the package to ensure old versions are cleaned too
 PKG_DEEPHASH=
 for i in ${BUILD}/build/${PKG_NAME}-*; do
-  if [ -d ${i} -a -f "${i}/.libreelec-unpack" ]; then
+  if [ -d ${i} ] && [ -f "${i}/.libreelec-unpack" ]; then
     . "${i}/.libreelec-unpack"
     if [ "${STAMP_PKG_NAME}" = "${PKG_NAME}" ]; then
       [ -z "${PKG_DEEPHASH}" ] && PKG_DEEPHASH=$(calculate_stamp)
@@ -50,7 +50,7 @@ for i in ${BUILD}/build/${PKG_NAME}-*; do
   fi
 done
 
-if [ -d "${PKG_BUILD}" -a ! -f "${STAMP}" ]; then
+if [ -d "${PKG_BUILD}" ] && [ ! -f "${STAMP}" ]; then
   # stale pkg build dir
   ${SCRIPTS}/clean "${PKG_NAME}"
 fi
@@ -62,7 +62,7 @@ fi
 
 pkg_lock_status "ACTIVE" "${PKG_NAME}" "unpack"
 
-if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists_opt unpack; then
+if { [ -d "${SOURCES}/${PKG_NAME}" ] || [ -d "${PKG_DIR}/sources" ]; } || pkg_call_exists_opt unpack; then
   pkg_call_finish
   build_msg "CLR_UNPACK" "UNPACK" "${PKG_NAME}" "indent"
 
@@ -205,10 +205,10 @@ if [ -d "${SOURCES}/${PKG_NAME}" -o -d "${PKG_DIR}/sources" ] || pkg_call_exists
     for config in $(find "${PKG_BUILD}" -name config.guess | sed 's/config.guess//'); do
       build_msg "CLR_FIXCONFIG" "FIXCONFIG" "${config}"
 
-      [ -f "${config}/config.guess" -a -f ${TOOLCHAIN}/configtools/config.guess ] &&
-        cp -f ${TOOLCHAIN}/configtools/config.guess ${config}
-      [ -f "${config}/config.sub" -a -f ${TOOLCHAIN}/configtools/config.sub ] &&
-        cp -f ${TOOLCHAIN}/configtools/config.sub ${config}
+      { [ -f "${config}/config.guess" ] && [ -f "${TOOLCHAIN}/configtools/config.guess" ]; } && \
+        cp -f "${TOOLCHAIN}/configtools/config.guess" "${config}"
+      { [ -f "${config}/config.sub" ] && [ -f "${TOOLCHAIN}/configtools/config.sub" ]; } && \
+        cp -f "${TOOLCHAIN}/configtools/config.sub" "${config}"
     done
   fi
 fi
@@ -220,7 +220,7 @@ if [ "${PKG_SECTION}" != "virtual" ]; then
 
   PKG_DEEPHASH=$(calculate_stamp)
   for i in PKG_NAME PKG_DEEPHASH; do
-    echo "STAMP_${i}=\"${!i}\"" >>${STAMP}
+    echo "STAMP_${i}=\"${!i}\"" >>"${STAMP}"
   done
 fi
 


### PR DESCRIPTION
These are shellcheck suggested changes to various scripts. Most of the changes are to replace `-a` and `-o` with `&&` and `||` in tests, so that the test conditions can fail early if a condition is false instead of continuing to test.

The use of `{    }` in some places is command grouping, and is used to accommodate the above for something like `[ test1] && [ test2 -a test3 ]` -> `[ test1 ] && { [test2] && [test3] ; }`

Some other misc stuff like use of `cat` too.