### PR TITLE
llvm: update to 21.1.y

### DIFF
--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="20.1.5"
-PKG_SHA256="83048509774d865dab7631c887b0673753f59f337256bb56829ea32f30d7584b"
+PKG_VERSION="21.1.0"
+PKG_SHA256="4f7019a06c731daebbc18080db338964002493ead4cfb440fef95d120c50a170"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="20.1.8"
-PKG_SHA256="6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d"
+PKG_VERSION="21.1.2"
+PKG_SHA256="1a417d1c8faf8d93e73fec1cbb76d393ed3218974c2283c7bac9672d3d47c54b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="f9df3ee6d55a2387459b843477743fa386c3c0f126bd0be01691ee49309681b8"
+    PKG_SHA256="bd8d1da6fe88ea7e29338f24277c22156267447adbfc47d690467ad32d02c2a7"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="92cfcd64ebb62b486cadafec936290e028e1993122ab2add2f9b9a8e397c9c7f"
+    PKG_SHA256="f556cb4aecf8faa51bd3ca888eaccd85015aa8ada7a82c6b0554690e23246e57"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="99fc10be2aeedf2c23a484f217bfa76458494495a0eee33e280d3616bb08282d"
+    PKG_SHA256="9853db03d68578a30972e2755c89c66aec035fec641cf8f3a7117c81eec2578d"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="abea0955dded88c68d731524ab9d29b162fae23bf5805b9f1dec063cba37c2aa"
+    PKG_SHA256="4952abb7d9d3ed7cea4f7ea44dcb23dc67631fae4ac44a5f059b90a4b5e9223f"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="5b3cbcf6b161dce4ac4e316440924b3133d1306592b4ab4d7bfc4429a609199e"
+    PKG_SHA256="a839d314309c6ce1d00f2005311a5d9d17d5ce1351d8ad1d09c0e78f716d4741"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="2719470dcd78b3f97d78b978c8f85a1a58d84ff11b62558294621c01bca34d49"
+    PKG_SHA256="663f4ab7945b392d5e5294dec1b050a66820a20e86f084ec37eeb0f2f7ff5569"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.89.0"
-PKG_SHA256="2576f9f440dd99b0151bd28f59aa0ac6102d5c4f3ed4ef8a810c8dd05057250d"
+PKG_VERSION="1.90.0"
+PKG_SHA256="799a9f9cba4ed5351e071048bcf6b5560755d9009648def33a407dd4961f9b7e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -33,7 +33,7 @@ configure_host() {
   esac
 
   cat >${PKG_BUILD}/config.toml  <<END
-change-id = 142379
+change-id = 144675
 
 [llvm]
 download-ci-llvm = false

--- a/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
@@ -8,7 +8,6 @@
   "features": "+outline-atomics",
   "has-rpath": true,
   "has-thread-local": true,
-  "is-builtin": false,
   "llvm-target": "aarch64-unknown-linux-gnu",
   "max-atomic-width": 128,
   "os": "linux",

--- a/packages/rust/rust/targets/arm-libreelec-linux-gnueabihf.json
+++ b/packages/rust/rust/targets/arm-libreelec-linux-gnueabihf.json
@@ -9,7 +9,6 @@
   "features": "+strict-align,+v6,+vfp2,-d32",
   "has-rpath": true,
   "has-thread-local": true,
-  "is-builtin": false,
   "llvm-floatabi": "hard",
   "llvm-target": "arm-unknown-linux-gnueabihf",
   "max-atomic-width": 64,

--- a/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
@@ -8,7 +8,6 @@
   "executables": true,
   "has-rpath": true,
   "has-thread-local": true,
-  "is-builtin": false,
   "llvm-target": "x86_64-unknown-linux-gnu",
   "max-atomic-width": 64,
   "os": "linux",

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="16ed8d8c7628a481c8501e7cd1022a123269b297bdedbb7f211f37a15e937e0e"
+    PKG_SHA256="4e1a9987a11d7d91f0d5afbf5333feb62f44172e4a31f33ce7246549003217f2"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="c9e6c54f9b72edb75a34cda22baec8c962ad233e58c11a4a58c7c2646c4731f9"
+    PKG_SHA256="e3c1fbdd69e3071cdd10a41184fe2e4213caf898b5cabceb891b22b50711a794"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="b42c254e1349df86bd40bc28fdf386172a1a46f2eeabe3c7a08a75cf1fb60e27"
+    PKG_SHA256="48c2a42de9e92fcae8c24568f5fe40d5734696a6f80e83cc6d46eef1a78f13c9"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
~~Required rust-1.90.0 (18th September 2025) before this can be merged.~~
- llvm: update to 21.1.1
- spirv-llvm-translator: update to 21.1.0
- spirv-tools: update to githash 925b0bd
- spirv-headers: update to githash 1de2e41
- rust: update to 1.90.0
  - rustc-snapshot: update to 1.90.0
  - rust-std-snapshot: update to 1.90.0
  - cargo-snapshot: update to 1.90.0