### PR TITLE
[le12.2] llvm: update to 19.1.7

### DIFF
--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="18.1.15"
-PKG_SHA256="e737d537b1c2339f4d91cd8aa26f377180ddccf5b67cd575e62481c37255bc48"
+PKG_VERSION="19.1.10"
+PKG_SHA256="c829a6090b7ea9cdebaa5d3dbad0972f75bccb46d09b2fe02db17afd7cf4eff2"
 PKG_LICENSE="LLVM"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="18.1.8"
-PKG_SHA256="0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
+PKG_VERSION="19.1.7"
+PKG_SHA256="82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"
@@ -28,7 +28,6 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_ENABLE_SPHINX=OFF \
                        -DLLVM_ENABLE_OCAMLDOC=OFF \
                        -DLLVM_ENABLE_BINDINGS=OFF \
-                       -DLLVM_ENABLE_TERMINFO=OFF \
                        -DLLVM_ENABLE_ASSERTIONS=OFF \
                        -DLLVM_ENABLE_WERROR=OFF \
                        -DLLVM_ENABLE_ZLIB=OFF \

--- a/packages/lang/llvm/patches/llvm-14.0.0-force-disable-cmakelist-options.patch
+++ b/packages/lang/llvm/patches/llvm-14.0.0-force-disable-cmakelist-options.patch
@@ -1,14 +1,5 @@
 --- a/llvm/CMakeLists.txt	2022-04-02 06:26:04.688530539 +0000
 +++ b/llvm/CMakeLists.txt	2022-04-02 06:44:00.015717360 +0000
-@@ -396,7 +396,7 @@
- set(LLVM_TARGET_ARCH "host"
-   CACHE STRING "Set target to use for LLVM JIT or use \"host\" for automatic detection.")
- 
--option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." ON)
-+option(LLVM_ENABLE_TERMINFO "Use terminfo database if available." OFF)
- 
- set(LLVM_ENABLE_LIBXML2 "ON" CACHE STRING "Use libxml2 if available. Can be ON, OFF, or FORCE_ON")
- 
 @@ -616,7 +616,7 @@
  
  option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default


### PR DESCRIPTION
This fixes issue identified by rust build https://github.com/librespot-org/librespot/issues/1553. Would normally not be included in stable release, but as it is only supporting rust and mesa, may be appropriate for LE12.2.
- llvm: update to 19.1.7
- spirv-llvm-translator: update to 19.1.10