### PR TITLE
systemd: fix 70-local-keyboard.hwdb indentation

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -1,12 +1,12 @@
- # Ali Express G60S Pro Plus remote
- evdev:input:b0003v1915p1001e0201*
-  KEYBOARD_KEY_c0041=enter
+# ali express g60s pro plus remote
+evdev:input:b0003v1915p1001e0201*
+ KEYBOARD_KEY_c0041=enter
 
 # alfawise z1 remote
 evdev:input:b0005v2B54p1603e*
  KEYBOARD_KEY_c0041=enter
 
-# auvipal g9f
+# auvipal g9f remote
 evdev:input:b0005v045Ep0041*
  KEYBOARD_KEY_c0041=enter
  KEYBOARD_KEY_70071=l
@@ -118,7 +118,7 @@ evdev:input:b0005v2717p32B9e4A4C*
 evdev:input:b0005v0416p0300*
  KEYBOARD_KEY_c0041=enter
 
-# zidoo v10
+# zidoo v10 remote
 evdev:input:b0005v2B54p1600*
  KEYBOARD_KEY_c0041=enter
 


### PR DESCRIPTION
Fix the indentation problem. Also lowercase names and append some `remote`(s) for content ~ocd~ alignment.