### PR TITLE
linux: update to 6.16.4

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -30,8 +30,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"
     ;;
   *)
-    PKG_VERSION="6.16.3"
-    PKG_SHA256="80439ba055c12f541abf44b8fc3c9b825a8f42fc25ce67462ec7e556c5790b85"
+    PKG_VERSION="6.16.4"
+    PKG_SHA256="d6a5e3c71a10b533a756251387cc8bf48bbd5c76d842ba5e957d8b1c316ab622"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;

--- a/projects/Rockchip/patches/linux/default/linux-1001-v4l2-rockchip.patch
+++ b/projects/Rockchip/patches/linux/default/linux-1001-v4l2-rockchip.patch
@@ -392,9 +392,9 @@ index 8de6fd2e8eef..002b1a600f93 100644
 -#define RK3288_ACLK_MAX_FREQ (400 * 1000 * 1000)
 +#define RK3288_ACLK_MAX_FREQ (600 * 1000 * 1000)
 +#define RK3399_ACLK_MAX_FREQ (400 * 1000 * 1000)
- #define RK3588_ACLK_MAX_FREQ (300 * 1000 * 1000)
  
  #define ROCKCHIP_VPU981_MIN_SIZE 64
+ 
 @@ -346,13 +347,20 @@ static int rk3066_vpu_hw_init(struct hantro_dev *vpu)
  	return 0;
  }


### PR DESCRIPTION
### packages updated
- linux: update to 6.16.4

### 6.16.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.16.4

6.16.4 - 457 patches

### errors / fixes / issues / regressions / todo
- done

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.16.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.16.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.16
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.16.4 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.16.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.16 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.16 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX8 (Coral Dev Board - Phanbell) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum