### PR TITLE
zstd: configure target build

### DIFF
--- a/packages/compress/zstd/package.mk
+++ b/packages/compress/zstd/package.mk
@@ -33,3 +33,9 @@ configure_host() {
         -DZSTD_BUILD_TESTS=OFF \
         ${PKG_CMAKE_SCRIPT%/*}
 }
+
+PKG_CMAKE_OPTS_TARGET="-DZSTD_LEGACY_SUPPORT=0 \
+                       -DBUILD_SHARED_LIBS=ON \
+                       -DZSTD_BUILD_STATIC=OFF \
+                       -DZSTD_BUILD_PROGRAMS=OFF \
+                       -DZSTD_BUILD_TESTS=OFF"


### PR DESCRIPTION
This configures the zstd:target build. Disables the CLI utilities. Disables the ability to read zstd compressed files that used a version older than 0.8 to compress. Skips building the static library.