### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="172dca437abb36485275a8d43550db90b6878bcc676fc0b73a67a57a15026cff"
+PKG_SHA256="420f9caf3ba09229cd98f7f8325fb9969d0746cccf4bdc3c56dfe2621bb07803"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="980b85681696fbd95927fd8ded8f6d91bdca95b0"
+export PKG_GIT_COMMIT="d8eb465f86cfceeb57f8582e373d41a558d35503"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="28.3.3"
-PKG_SHA256="3727c8963ab4bcff12291e99e4d4a6b9a29ace5236fd245717bbff648f15f8cd"
+PKG_VERSION="28.4.0"
+PKG_SHA256="4aa0776ef3c040204cada69f3d4d7b89a3cef85e07cbe098c05cdcb000ea7e30"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="bea959c7b793b32a893820b97c4eadc7c87fabb0"
+export PKG_GIT_COMMIT="249d679a6baf8a32bb6d72d6ac5cc7ab9c90b4ea"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/podman/netavark/package.mk
+++ b/packages/addons/addon-depends/podman/netavark/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="netavark"
-PKG_VERSION="1.15.2"
-PKG_SHA256="84325e03aa0a2818aef9fb57b62cda8e9472584744d91ce5e5b191098f9e6d6a"
+PKG_VERSION="1.16.1"
+PKG_SHA256="e655fcd882fe891bcc8328ddcfff3745831c8b1013ae59f012d37ce87175b0b3"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/containers/netavark"
 PKG_URL="https://github.com/containers/netavark/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/podman-bin/package.mk
+++ b/packages/addons/addon-depends/podman/podman-bin/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman-bin"
-PKG_VERSION="5.5.2"
-PKG_SHA256="a2dbd8280cd92d4741f32f5a99d385d7fc6f0dd36bc9cc90a7273767e26d43d9"
+PKG_VERSION="5.6.1"
+PKG_SHA256="e4fccc003dac77bae9127968c93388b6bf59d6b9ef8ffbdda21696613f729f3c"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io/"
 PKG_URL="https://github.com/containers/podman/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Podman: A tool for managing OCI containers and pods."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containers/podman
-export PKG_GIT_COMMIT="e7d8226745ba07a64b7176a7f128e4ef53225a0e"
+export PKG_GIT_COMMIT="1e2b2315150b2ffa0971596fb5da8cd83f3ce0e1"
 
 PKG_PODMAN_BUILDTAGS="exclude_graphdriver_devicemapper \
                       exclude_graphdriver_btrfs \

--- a/packages/addons/addon-depends/runc/package.mk
+++ b/packages/addons/addon-depends/runc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="runc"
-PKG_VERSION="1.3.0"
-PKG_SHA256="3262492ce42bea0919ee1a2d000b6f303fd14877295bc38d094876b55fdd448b"
+PKG_VERSION="1.3.1"
+PKG_SHA256="ab204e8ceed9eef4a8b21f69c658f30f9c2d610185141395263f71adda1ad73a"
 PKG_LICENSE="APL"
 PKG_SITE="https://github.com/opencontainers/runc"
 PKG_URL="https://github.com/opencontainers/runc/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A CLI tool for spawning and running containers according to the OC
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/opencontainers/runc/releases
-export PKG_GIT_COMMIT="4ca628d1d4c974f92d24daccb901aa078aad748e"
+export PKG_GIT_COMMIT="e6457afc48eff1ce22dece664932395026a7105e"
 
 pre_make_target() {
   go_configure

--- a/packages/addons/addon-depends/system-tools-depends/dool/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/dool/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dool"
-PKG_VERSION="1.3.4"
-PKG_SHA256="286a5c4f5677ea04752f310360244b25d5e35cac8a2137144ba047276ed41f38"
+PKG_VERSION="1.3.8"
+PKG_SHA256="efd8b0889542783cd56b11d08e9b571bfbeaad7a21d9d3c586b1e22ae14be1cd"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/scottchiefbaker/dool"
 PKG_URL="https://github.com/scottchiefbaker/dool/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/evtest/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/evtest/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="evtest"
-PKG_VERSION="3fe3ce98d81ae8b00156933ddb86b92a874cba6a" # HEAD 07/04/2025
-PKG_SHA256="ed9eace5cde4ce8d2c5bcfd10a700d2d0bbf843c1ed9359701db0305adb897ac"
+PKG_VERSION="1.36"
+PKG_SHA256="3b9a66c92e48b0cd13b689530b5729c031bc1bcbfe9d19c258f9245e2f8d2a0f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://gitlab.freedesktop.org/libevdev/evtest/"
-PKG_URL="https://gitlab.freedesktop.org/libevdev/evtest/-/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://gitlab.freedesktop.org/libevdev/evtest/-/archive/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libxml2"
 PKG_LONGDESC="A simple tool for input event debugging."
 PKG_TOOLCHAIN="autotools"

--- a/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/stress-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="stress-ng"
-PKG_VERSION="0.19.03"
-PKG_SHA256="a5ddd9914a4aa0c4708035a475772cb7a6989f28829e608ad790d64849610ae6"
+PKG_VERSION="0.19.04"
+PKG_SHA256="3761ae901b2a81dcdb3f5363b8d98f288c03ae320a697b6d7ffef01a48845f05"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/ColinIanKing/stress-ng"
 PKG_URL="https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="2.0.27"
-PKG_SHA256="589c5f4c9f74464504b79748cd92337549d1f9179802dd291104b84898aceddc"
-PKG_REV="8"
+PKG_VERSION="2.0.28"
+PKG_SHA256="2181dfd5768080ac8d41c7b1bb7302f1edd8e15cee83b921e4eb8757867fe794"
+PKG_REV="9"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/podman/package.mk
+++ b/packages/addons/service/podman/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="podman"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://podman.io"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="2.0.6"
-PKG_SHA256="e17ea11091a8c9d29b99a09f93005f66a199ef4843a2be277c14361edef5953a"
-PKG_REV="6"
+PKG_VERSION="2.0.7"
+PKG_SHA256="6e0f66fa17402e7a4395658732af719e3c25c17ca436eb473912dfb0f4340a0d"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- syncthing: update to 2.0.7 and addon (7)
- minisatip: update to 2.0.28 and addon (9)
- docker: update to 28.4.0 and addon (5)
  - cli: update to 28.4.0
  - moby: update to 28.4.0
  - runc: update to 1.3.1
- podman: update to 5.6.1 and addon (2)
  - runc: update to 1.3.1
  - podman-bin: update to 5.6.1
  - netavark: update to 1.16.1
- system-tools: update addon (8)
  - stress-ng: update to 0.19.04
  - evtest: update to 1.36
  - dool: update to 1.3.8
