### PR TITLE
oscam: update to 11886, include missing shared library and addon (1)

### DIFF
--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11881"
-PKG_SHA256="0e9393a443510ea06faf418aa3c6431bbd12617a40f5de1c023218c4419e9006"
-PKG_REV="0"
+PKG_VERSION="11886"
+PKG_SHA256="3a6d5080dd3a8d91f0ccea2baf00e4a496bb45d6dc16737aceefa49e6cfbc073"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"
@@ -74,6 +74,7 @@ addon() {
     cp -P ${PKG_BUILD}/.${TARGET_NAME}/oscam ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P ${PKG_BUILD}/.${TARGET_NAME}/utils/list_smargo ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -L $(get_install_dir pcsc-lite)/usr/lib/libpcsclite.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -L $(get_install_dir pcsc-lite)/usr/lib/libpcsclite_real.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/oscam
 }

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/service/pcscd/source/bin/pcscd.start
+++ b/packages/addons/service/pcscd/source/bin/pcscd.start
@@ -16,4 +16,4 @@ if [ ! -f "$ADDON_HOME/config/reader.conf" ]; then
   cp $ADDON_DIR/config/reader.conf $ADDON_HOME/config/reader.conf
 fi
 
-exec pcscd.bin --foreground -c $ADDON_HOME/config/reader.conf
+exec pcscd.bin --foreground -c $ADDON_HOME/config/reader.conf --disable-polkit


### PR DESCRIPTION
- Fixes #9342 
- oscam: update to 11886, include missing shared library and addon (1)
- pcscd: do not use polkit and addon (1)