### PR TITLE
[le12.2] oscam: fix RPATH on libpcsclite and addon (2)

### DIFF
--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="oscam"
 PKG_VERSION="11886"
 PKG_SHA256="3a6d5080dd3a8d91f0ccea2baf00e4a496bb45d6dc16737aceefa49e6cfbc073"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"
@@ -77,4 +77,5 @@ addon() {
     cp -L $(get_install_dir pcsc-lite)/usr/lib/libpcsclite_real.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/oscam
+  patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/libpcsclite.so.1
 }


### PR DESCRIPTION
- backport of #10471 
- fixes https://github.com/LibreELEC/LibreELEC.tv/commit/38c127fb384598872837b07c26064200b3064a05#commitcomment-165428638