### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/chrome-libXfixes/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/chrome-libXfixes/package.mk
@@ -9,10 +9,6 @@ PKG_URL=""
 PKG_DEPENDS_UNPACK+=" libXfixes"
 PKG_BUILD_FLAGS="-sysroot"
 
-PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_TARGET} \
-                           --disable-static \
-                           --enable-shared"
-
 unpack() {
   mkdir -p ${PKG_BUILD}
   tar --strip-components=1 -xf ${SOURCES}/${PKG_NAME:7}/${PKG_NAME:7}-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="11.4.5"
-PKG_SHA256="0f052eb4ab01d8bae98ba971c954becb32be57d7250f18af343b1d27892e03fa"
+PKG_VERSION="11.5.0"
+PKG_SHA256="2d30ba45c4c8ec4de661a1002b4f88d0841ff1a3087f34629275f5436d722109"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nfs-utils"
-PKG_VERSION="2.8.3"
-PKG_SHA256="11e7c5847a8423a72931c865bd9296e7fd56ff270a795a849183900961711725"
+PKG_VERSION="2.8.4"
+PKG_SHA256="11c4cc598a434d7d340bad3e072a373ba1dcc2c49f855d44b202222b78ecdbf5"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.linux-nfs.org/"
 PKG_URL="https://www.kernel.org/pub/linux/utils/nfs-utils/${PKG_VERSION}/nfs-utils-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- harfbuzz: update to 11.5.0
- chrome-libXfixes: use meson
  - fixes chrome build since https://github.com/LibreELEC/LibreELEC.tv/commit/4ba33341f6577d81d6cc5126c65e51c7046ed415
- nfs-utils: update to 2.8.4