### PR TITLE
fix ldacBT patch

### DIFF
--- a/packages/audio/ldacBT/patches/ldacBT-1-build-with-cmake-4.0.0.patch
+++ b/packages/audio/ldacBT/patches/ldacBT-1-build-with-cmake-4.0.0.patch
@@ -17,6 +17,6 @@ index 7739887..ecbf6da 100644
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.0)
 +cmake_minimum_required(VERSION 3.0...3.10)
- project(libldac
-         LANGUAGES C
-         VERSION 2.0.2.3)
+ project(libldac C)
+ 
+ set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
fix ldacBT patch
fixes build failure when compiling with pipewire