### PR TITLE
openssl: update to 3.5.3

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.5.2"
-PKG_SHA256="c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec"
+PKG_VERSION="3.5.3"
+PKG_SHA256="c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://openssl-library.org"
 PKG_URL="https://github.com/openssl/openssl/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.openssl.org

Release notes:
- https://www.openssl.org/news/vulnerabilities.html