### PR TITLE
[le12.2] Addon updates 

### DIFF
--- a/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
+++ b/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librelp"
-PKG_VERSION="1.11.0"
-PKG_SHA256="7719b5f31e07cbb9872289ad32b787c613b5355d407982a0a2c4d69938457fd6"
+PKG_VERSION="1.12.0"
+PKG_SHA256="e2e53a9812d06f95d0a311bbfafba78704835de6d7f0ea0fd9c0d94e8eae496a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.rsyslog.com/category/librelp/"
 PKG_URL="https://download.rsyslog.com/librelp/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/asio/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/asio/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="asio"
-PKG_VERSION="1.34.2"
-PKG_SHA256="688869a4447bd564bcee3d43137d52d972112cb05c7ec4665945affdd01eea75"
+PKG_VERSION="1.36.0"
+PKG_SHA256="bcc4e7143352e4556d22cbfd0f072f352bfa87bd6f454fe8d7b1d55cdc8f8695"
 PKG_LICENSE="BSL"
 PKG_SITE="http://think-async.com/Asio"
 PKG_URL="https://github.com/chriskohlhoff/asio/archive/asio-${PKG_VERSION//./-}.zip"

--- a/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/snapcast/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapcast"
-PKG_VERSION="8b7ac6986f2b37efba8087c05e35248649489d9e"
-PKG_SHA256="e09760bcfd09ca25041dd1f259862493d7c97426183b9f42d72d0fa2835b8be3"
+PKG_VERSION="0.33.0"
+PKG_SHA256="5da21ab4a609550308be389d6af628628a89b6beb1d6e996ad2e4960e8e36d1d"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/badaix/snapcast"
-PKG_URL="https://github.com/badaix/snapcast/archive/${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/badaix/snapcast/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain aixlog alsa-lib asio avahi flac libvorbis popl pulseaudio boost opus"
 PKG_LONGDESC="Synchronous multi-room audio player."
 PKG_BUILD_FLAGS="-sysroot"

--- a/packages/addons/service/filebrowser/package.mk
+++ b/packages/addons/service/filebrowser/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="filebrowser"
-PKG_VERSION="2.42.5"
-PKG_REV="1"
+PKG_VERSION="2.43.0"
+PKG_REV="2"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://filebrowser.org"
 PKG_DEPENDS_TARGET="toolchain:host"
@@ -15,15 +15,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="3c66d6a615b0fd2507db0f8d2f3576f57fef74c7765ecbac4b769d926f0ac047"
+    PKG_SHA256="8d854adca14cf8f9dfdc5f49d564ab5521e99ea940aba10baae74ac327ada962"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-arm64-filebrowser.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="a89e497c2b34b443b5533e98042a911d4434cb55111df0034fa1c0170fd5fa34"
+    PKG_SHA256="fcbc31922f587e5a12bd0c914ccdee5242362ecbda026fd6ca214b097b322ef8"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-armv7-filebrowser.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="d8fc2b2c3d5b9e4b45d3e021251a897f2743213239cf1319d9dc9d660a22190e"
+    PKG_SHA256="62fd00aeb80861c4156989df5977f9d2eb012956266a73c24b0ad774a5804e1c"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-amd64-filebrowser.tar.gz"
     ;;
 esac

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="2.0.30"
-PKG_SHA256="77436891d9698a016c4cd7e236e4a07552670f333e7b5dd9c24642852e3728a8"
-PKG_REV="4"
+PKG_VERSION="2.0.34"
+PKG_SHA256="0d887945eecbe46df9464df9bd67ef47b3c57bec9cc0174974f73b743c50a9f8"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="rsyslog"
 PKG_VERSION="8.2508.0"
 PKG_SHA256="c89b1e74d36d0ca4a95b74a1abe36ed0b1faac8b7c8be471a8415cfa776206fd"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/rsyslog"

--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapclient"
-PKG_VERSION="0.31.0"
-PKG_REV="0"
+PKG_VERSION="0.33.0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="snapserver"
-PKG_VERSION="0.31.0"
-PKG_REV="0"
+PKG_VERSION="0.33.0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_DEPENDS_TARGET="toolchain nqptp shairport-sync snapcast"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="2.0.8"
-PKG_SHA256="ad583925c0934fcfe9976e544093203d7ced483bd5bad80cd02a3c93a04dfb8b"
-PKG_REV="6"
+PKG_VERSION="2.0.9"
+PKG_SHA256="803ea5e50c0cdb465b03245a75715d3a9c69f929876d0956ef07c6f3a25dee69"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"


### PR DESCRIPTION
- backport of #10517 
- minisatip: update to 2.0.34 and addon (5)
- snapserver: update to 0.33.0 and addon (1)
- snapclient: update to 0.33.0 and addon (1)
  - snapcast: update to 0.33.0
  - asio: update to 1.36.0
- syncthing: update to 2.0.9 and addon (7)
- filebrowser: update to 2.43.0 and addon (2)
- rsyslog: update addon (2)
  - librelp: update to 1.12.0