### PR TITLE
[le12.2] iwd: update to 3.10

### DIFF
--- a/packages/network/iwd/package.mk
+++ b/packages/network/iwd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwd"
-PKG_VERSION="3.9"
-PKG_SHA256="0cd7dc9b32b9d6809a4a5e5d063b5c5fd279f5ad3a0bf03d7799da66df5cad45"
+PKG_VERSION="3.10"
+PKG_SHA256="640bff22540e1714f71772a83123aff6f810b7eb9d7d6df1e10fb2695beb5115"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.kernel.org/cgit/network/wireless/iwd.git/about/"
 PKG_URL="https://www.kernel.org/pub/linux/network/wireless/iwd-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- backport of #10520
- log:
- https://git.kernel.org/pub/scm/network/wireless/iwd.git/log/