### PR TITLE
linux: update to 6.16.9

### DIFF
--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="iwlwifi-firmware"
-PKG_VERSION="042ba27c927df44e8413a3a86f4c19ffb8f4babd"
-PKG_SHA256="b1afaa0893c46d2eeea962c8cc6210355408357ee8704ca5a8b27ce35b073d62"
+PKG_VERSION="8f70df657bf3f509254fbe01e9c1c782f326a31b"
+PKG_SHA256="f0a9e7181820a522735601197ead8117547be95ac3063f1aa41f4c732569e443"
 PKG_LICENSE="Free-to-use"
 PKG_SITE="https://github.com/LibreELEC/iwlwifi-firmware"
 PKG_URL="https://github.com/LibreELEC/iwlwifi-firmware/archive/${PKG_VERSION}.tar.gz"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,8 +37,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rockchip rtlwifi/6.17"
     ;;
   *)
-    PKG_VERSION="6.16.7"
-    PKG_SHA256="5be3daa1f9427b1bdb34c4894d9c1adfac38cff674376fe0611a3065729a1a81"
+    PKG_VERSION="6.16.9"
+    PKG_SHA256="7ac8c8a3cf05476375deaaa85dfcee095a826ffe557b437f43774fc3b64ce58d"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     case ${DEVICE} in


### PR DESCRIPTION
### packages updated
- linux: update to 6.16.9
- iwlwifi-firmware: update to githash 8f70df6

### 6.16.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.16.8
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.16.9

6.16.8 - 189 patches
6.16.9 - 149 patches

### errors / fixes / issues / regressions / todo
- done

### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.16.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.16.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.16
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.16.9 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.16.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.16 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.16 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX8 (Coral Dev Board - Phanbell) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum