### PR TITLE
fix error in 90-alsa-restore.rules udev rule

### DIFF
--- a/packages/audio/alsa-utils/udev.d/90-alsa-restore.rules
+++ b/packages/audio/alsa-utils/udev.d/90-alsa-restore.rules
@@ -2,4 +2,4 @@
 # Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
 
 # When a sound device is detected, restore the volume settings
-  KERNEL=="controlC[0-9]*",  NAME="snd/%k", ACTION=="add", RUN+="soundconfig %k"
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="controlC*", RUN+="soundconfig %k"

--- a/packages/audio/rpi-cirrus-config/udev.d/90-alsa-restore.rules
+++ b/packages/audio/rpi-cirrus-config/udev.d/90-alsa-restore.rules
@@ -2,7 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 # When a sound device is detected, restore the volume settings
-SUBSYSTEM=="sound", KERNEL=="controlC*", NAME="snd/%k", ACTION=="add", GOTO="alsa_restore_go"
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="controlC*", GOTO="alsa_restore_go"
 GOTO="alsa_restore_end"
 
 LABEL="alsa_restore_go"


### PR DESCRIPTION
Our downstream udev rule has been carrying a meaningless `NAME="snd/%k"` action since forever that just results in an error message being logged to the journal - see also #10532

```
/usr/lib/udev/rules.d/90-alsa-restore.rules:5 NAME="snd/%k": Only network interfaces can be renamed, ignoring.
```

Drop that and also add the `SUBSYSTEM=="sound"` check like in the upstream alsa-tools udev rule