### PR TITLE
systemd: remove provision.conf from tmpfiles.d

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -159,6 +159,7 @@ post_makeinstall_target() {
   # remove systemd-creds
   safe_remove ${INSTALL}/usr/bin/systemd-creds
   safe_remove ${INSTALL}/usr/lib/tmpfiles.d/credstore.conf
+  safe_remove ${INSTALL}/usr/lib/tmpfiles.d/provision.conf
 
   # remove nspawn
   safe_remove ${INSTALL}/usr/bin/systemd-nspawn


### PR DESCRIPTION
provision.conf sets up files from systemd credentials which is quite useless in LE as we've dropped those.

This fixes the "/root" related error messages from systemd-tmpfiles in the journal.

see also https://github.com/LibreELEC/LibreELEC.tv/issues/10532#issuecomment-3352194572