### PR TITLE
bluez: fix bluetooth.service unit

### DIFF
--- a/packages/network/bluez/system.d/bluetooth.service
+++ b/packages/network/bluez/system.d/bluetooth.service
@@ -6,6 +6,8 @@ Requires=bluetooth-defaults.service
 ConditionPathExists=/storage/.cache/services/bluez.conf
 
 [Service]
+Type=dbus
+BusName=org.bluez
 NotifyAccess=main
 EnvironmentFile=/storage/.cache/services/bluez.conf
 EnvironmentFile=-/run/libreelec/debug/bluez.conf
@@ -19,3 +21,4 @@ StartLimitInterval=0
 
 [Install]
 WantedBy=bluetooth.target
+Alias=dbus-org.bluez.service


### PR DESCRIPTION
Align our bluetooth.service unit with upstream:

Specify the correct dbus service type, add bus name and add the alias so pulseaudio stops complaining about the missing dbus-org.bluez.service

See #10532