### PR TITLE
fix pcsc protocol in oscam addon

### DIFF
--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -10,7 +10,7 @@ PKG_URL="https://pcsclite.apdu.fr/files/pcsc-lite-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain libusb polkit"
 PKG_LONGDESC="Middleware to access a smart card using SCard API (PC/SC)."
 
-PKG_MESON_OPTS_TARGET="-Ddefault_library=static \
+PKG_MESON_OPTS_TARGET="-Ddefault_library=both \
                        -Dlibudev=false \
                        -Dlibusb=true \
                        -Dpolkit=true \

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -71,7 +71,12 @@ makeinstall_target() {
 }
 
 addon() {
-  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+  mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
     cp -P ${PKG_BUILD}/.${TARGET_NAME}/oscam ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
     cp -P ${PKG_BUILD}/.${TARGET_NAME}/utils/list_smargo ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -L $(get_install_dir pcsc-lite)/usr/lib/libpcsclite.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -L $(get_install_dir pcsc-lite)/usr/lib/libpcsclite_real.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/oscam
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/libpcsclite.so.1
 }

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -23,7 +23,7 @@ PKG_ADDON_TYPE="xbmc.service"
 addon() {
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/{bin,lib.private}
     cp -Pa $(get_install_dir pcsc-lite)/usr/sbin/pcscd ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/pcscd.bin
-    patchelf --add-rpath '$ORIGIN/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/pcscd.bin
+    patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/pcscd.bin
     cp -L $(get_install_dir polkit)/usr/lib/libpolkit-gobject-1.so.0 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   cp -a $(get_install_dir ccid)/storage/.kodi/addons/${PKG_ADDON_ID}/drivers ${ADDON_BUILD}/${PKG_ADDON_ID}

--- a/packages/addons/service/pcscd/source/bin/pcscd.start
+++ b/packages/addons/service/pcscd/source/bin/pcscd.start
@@ -16,4 +16,4 @@ if [ ! -f "$ADDON_HOME/config/reader.conf" ]; then
   cp $ADDON_DIR/config/reader.conf $ADDON_HOME/config/reader.conf
 fi
 
-exec pcscd.bin --foreground -c $ADDON_HOME/config/reader.conf
+exec pcscd.bin --foreground -c $ADDON_HOME/config/reader.conf --disable-polkit


### PR DESCRIPTION
pcsc plugin for communication with pcscd service in oscam service was failing due to missing shared library. This PR brings changes from libreelec-12.2 branch into libreelec-12.0