### PR TITLE
package: Add new package nftables

### DIFF
--- a/packages/network/connman/package.mk
+++ b/packages/network/connman/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="5dfc192e4ad619fa373fb1204ec3456dc349984738bb1dae895b6f3815172130"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.connman.net"
 PKG_URL="https://git.kernel.org/pub/scm/network/connman/connman.git/snapshot/connman-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="autotools:host gcc:host dbus glib iptables iwd readline"
+PKG_DEPENDS_TARGET="autotools:host gcc:host dbus glib iptables iwd readline nftables"
 PKG_LONGDESC="A modular network connection manager."
 PKG_TOOLCHAIN="autotools"
 

--- a/packages/network/nftables/package.mk
+++ b/packages/network/nftables/package.mk
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="nftables"
+PKG_VERSION="1.1.5"
+PKG_SHA256="1daf10f322e14fd90a017538aaf2c034d7cc1eb1cc418ded47445d714ea168d4"
+PKG_LICENSE="GPL"
+PKG_SITE="https://netfilter.org/projects/${PKG_NAME}"
+PKG_URL="https://netfilter.org/projects/${PKG_NAME}/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="autotools:host gcc:host libnftnl readline"
+PKG_LONGDESC="A userspace library providing a low-level netlink programming interface (API) to the in-kernel nf_tables subsystem."
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared --without-cli --with-mini-gmp --enable-static"


### PR DESCRIPTION

This adds nftables to the base image making it as a dependency of conman (iptables is the same).

tested by compiling the image from scratch: PROJECT=Rockchip DEVICE=RK3588 ARCH=aarch64 UBOOT_SYSTEM=rock-5b make image