### PR TITLE
[le12.2] linux (RPi): update to 6.12.51

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;
   raspberrypi)
-    PKG_VERSION="407877aa2199efc0ed52e3cfd33999839a6f03cc" # 6.12.48
-    PKG_SHA256="6046959be3a9cd5f96211cad4e1d497cb73a7ac30827fb680f61ea047fb37c43"
+    PKG_VERSION="4661a42dd38af6e6205795732bc272f0bf983a8d" # 6.12.49
+    PKG_SHA256="08dac877bcdccfeea68ca009f1981bdb900d24b1f30157d77fc091b51f37b186"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;
   raspberrypi)
-    PKG_VERSION="359f37f0faefb712add32a39f98751aea67d5c1f" # 6.12.47
-    PKG_SHA256="85c882310e7c74657855b25bba700b5a856327a31547fe49f5758951984c92d9"
+    PKG_VERSION="407877aa2199efc0ed52e3cfd33999839a6f03cc" # 6.12.48
+    PKG_SHA256="6046959be3a9cd5f96211cad4e1d497cb73a7ac30827fb680f61ea047fb37c43"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;
   raspberrypi)
-    PKG_VERSION="31470f8f63f4413879fb34ba8f766655ae57cd17" # 6.12.50
-    PKG_SHA256="8dc0734519d6574c8d3a12223b13a0fefdd2183a28f2550d619e2ece3e513fe5"
+    PKG_VERSION="c70638a3d1114b74cae89c0a9ff332dd4ff67d32" # 6.12.51
+    PKG_SHA256="dfa113952fcf93c48d809d36a6ac2a64938153207962deb5c7c0e8b9595146ac"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;
   raspberrypi)
-    PKG_VERSION="4661a42dd38af6e6205795732bc272f0bf983a8d" # 6.12.49
-    PKG_SHA256="08dac877bcdccfeea68ca009f1981bdb900d24b1f30157d77fc091b51f37b186"
+    PKG_VERSION="905d3e0276a657fb797f48d13c63a2577b1d2a56" # 6.12.49
+    PKG_SHA256="9a9b7b7a70e7295b187f62789b4977a13c35fad9c3598ac6affcb894a576f796"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rtlwifi/6.17"
     ;;
   raspberrypi)
-    PKG_VERSION="905d3e0276a657fb797f48d13c63a2577b1d2a56" # 6.12.49
-    PKG_SHA256="9a9b7b7a70e7295b187f62789b4977a13c35fad9c3598ac6affcb894a576f796"
+    PKG_VERSION="31470f8f63f4413879fb34ba8f766655ae57cd17" # 6.12.50
+    PKG_SHA256="8dc0734519d6574c8d3a12223b13a0fefdd2183a28f2550d619e2ece3e513fe5"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.17"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="2164519657c18e2f06b50993245a57eeff13ec12"
-PKG_SHA256="750d0372323b9f15c7cda03c14f77cad560c7fb77f6bd66ee7721c9781fa2b51"
+PKG_VERSION="24a4ec1a23edc2932dbaa2a34568901a68772c49"
+PKG_SHA256="41389d528d8e576a08fe1810d0157401d52ab8701cc6246bff192ac4b3665cf8"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="8fb396f650f38f98f42db0ed936abb59d2c331cf"
-PKG_SHA256="0bbfec15d5250a885a3882e57409b73e76f127b6b7eaadbd5a19af990f604afd"
+PKG_VERSION="430834f34b690d6f1a5232056b34a70fa0a39946"
+PKG_SHA256="9a74b02c4fb59e4136bdfb30f9da83794836767c17828e264bf46afc9be817b5"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="f45ed2371426add9a315809aeeaa6dc5c5694c6e"
-PKG_SHA256="943bd6384dd2437310741466fa2d22ba9b3e89de100ec9fa593896981281b4ac"
+PKG_VERSION="8fb396f650f38f98f42db0ed936abb59d2c331cf"
+PKG_SHA256="0bbfec15d5250a885a3882e57409b73e76f127b6b7eaadbd5a19af990f604afd"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="430834f34b690d6f1a5232056b34a70fa0a39946"
-PKG_SHA256="9a74b02c4fb59e4136bdfb30f9da83794836767c17828e264bf46afc9be817b5"
+PKG_VERSION="b818b44bd5bad848410ff56ed4c95868a3679786"
+PKG_SHA256="7a1491bdf00323ebf990613c463da79497586d0adf79c93fb36ec6b39f6c7df6"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/tools/rpi-eeprom/package.mk
+++ b/packages/tools/rpi-eeprom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rpi-eeprom"
-PKG_VERSION="b818b44bd5bad848410ff56ed4c95868a3679786"
-PKG_SHA256="7a1491bdf00323ebf990613c463da79497586d0adf79c93fb36ec6b39f6c7df6"
+PKG_VERSION="2164519657c18e2f06b50993245a57eeff13ec12"
+PKG_SHA256="750d0372323b9f15c7cda03c14f77cad560c7fb77f6bd66ee7721c9781fa2b51"
 PKG_LICENSE="BSD-3/custom"
 PKG_SITE="https://github.com/raspberrypi/rpi-eeprom"
 PKG_URL="https://github.com/raspberrypi/rpi-eeprom/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Backport of #10556

Runtime tested on RPi5