### PR TITLE
[le12.2] wireless-regdb: update to 2025.10.07

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2025.07.10"
-PKG_SHA256="a8340bcdcd1b5db6c79149879d122b170f3bb075381718d4f429ad831a6fa28d"
+PKG_VERSION="2025.10.07"
+PKG_SHA256="d4c872a44154604c869f5851f7d21d818d492835d370af7f58de8847973801c3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://git.kernel.org/pub/scm/linux/kernel/git/wens/wireless-regdb.git
- Backport #10560 