### PR TITLE
linux (Allwinner): phy_driver_register and phy_driver_unregister no longer exported

### DIFF
--- a/projects/Allwinner/patches/linux/0015-net-phy-Add-support-for-AC200-EPHY.patch
+++ b/projects/Allwinner/patches/linux/0015-net-phy-Add-support-for-AC200-EPHY.patch
@@ -240,7 +240,7 @@ index 000000000000..0464c9a20365
 +	if (ret)
 +		return ret;
 +
-+	ret = phy_driver_register(priv->ephy, THIS_MODULE);
++	ret = phy_drivers_register(priv->ephy, 1, THIS_MODULE);
 +	if (ret) {
 +		dev_err(dev, "Unable to register phy\n");
 +		return ret;
@@ -253,7 +253,7 @@ index 000000000000..0464c9a20365
 +{
 +	struct ac200_ephy_dev *priv = platform_get_drvdata(pdev);
 +
-+	phy_driver_unregister(priv->ephy);
++	phy_drivers_unregister(priv->ephy, 1);
 +
 +	regmap_write(priv->regmap, AC200_EPHY_CTL, AC200_EPHY_SHUTDOWN);
 +	regmap_write(priv->regmap, AC200_SYS_EPHY_CTL1, 0);


### PR DESCRIPTION
… in 6.18 use phy_drivers_ instead. This patch is applicable for 6.17 too.