### PR TITLE
[le12.2] samba: update to 4.22.5

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.22.4"
-PKG_SHA256="a41a828848abdf5e942c900ca178597e18aab7b61d3c06a9b5ba43661988010b"
+PKG_VERSION="4.22.5"
+PKG_SHA256="d8566a15d3dbfc0b777d1e8fbb2eee988a024ca9c786dcac65dd10347307400d"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.22.5.html