### PR TITLE
nasm: fix dirs dependency

### DIFF
--- a/packages/lang/nasm/patches/nasm-152-dirs-dep.patch
+++ b/packages/lang/nasm/patches/nasm-152-dirs-dep.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile.in b/Makefile.in
+index 64e0cb2d8be1..eb2adcd7e7c5 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -224,7 +224,7 @@ ZLIBOBJ = \
+ 
+ LIBOBJ    = $(LIBOBJ_W) $(LIBOBJ_NW) $(ZLIB)
+ ALLOBJ_W  = $(NASM) $(LIBOBJ_W)
+-ALLOBJ    = $(PROGOBJ) $(LIBOBJ)
++ALLOBJ    = $(PROGOBJ) $(LIBOBJ) $(LIBOBJ_DIS)
+ SUBDIRS  = stdlib nasmlib include config output asm disasm x86 \
+ 	   common zlib macros misc
+ XSUBDIRS = nsis win test doc editors
+@@ -262,7 +262,7 @@ ndisasm$(X): $(NDISASM) $(MANIFEST) $(DISLIB) $(NASMLIB)
+ 		$(DISLIB) $(NASMLIB) $(LIBS)
+ 
+ # Make sure we have subdirectories set up...
+-$(LIBOBJ) $(LIBOBJ_DIS): $(DIRS)
++$(ALLOBJ): $(DIRS)
+ 
+ #-- Begin Generated File Rules --#
+ 


### PR DESCRIPTION
- https://github.com/netwide-assembler/nasm/issues/152
- fixes #10574

In testing on highload systems the nasm 3.01 build hasnt failed. PRed it into the codebase - so that GHA CI (which regularly fails with this can test it further.)