### PR TITLE
Add Support for mupen64plus-nx

### DIFF
--- a/packages/emulation/libretro-mupen64plus-nx/package.mk
+++ b/packages/emulation/libretro-mupen64plus-nx/package.mk
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-mupen64plus-nx"
+PKG_VERSION="222acbd3f98391458a047874d0372fe78e14fe94"
+PKG_SHA256="9e55fa83f2313f9b80a369d77457ec216e5774ef2d486083ad8661aa94a4dbd1"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/mupen64plus-libretro-nx"
+PKG_URL="https://github.com/kodi-game/mupen64plus-libretro-nx/archive/${PKG_VERSION}.tar.gz"
+PKG_BRANCH="develop"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Improved mupen64plus libretro core reimplementation"
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="mupen64plus_next_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="MUPEN64PLUS-NS_LIB"
+
+if build_with_debug; then
+  PKG_MAKE_OPTS_TARGET+=" DEBUG=1"
+fi
+
+PLATFORM=""
+
+case "${DEVICE}" in
+  RPi)
+    #mupen64plus-nx auto detects rpi4 for gles3 but not rpi5
+    case "${DEVICE:-${PROJECT}}" in
+      RPi)  PLATFORM="rpi" ;;
+      RPi2) PLATFORM="rpi2" ;;
+      RPi4) PLATFORM="rpi4_64" ;;
+      RPi5) PLATFORM="rpi5_64" ;;
+    esac
+    ;;
+  Generic|*)
+    # Tested only with "Generic"
+    PLATFORM="unix"
+    PKG_MAKE_OPTS_TARGET+=" HAVE_THR_AL=1 HAVE_PARALLEL_RDP=1 LLE=1 HAVE_PARALLEL_RSP=1"
+    ;;
+esac
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  PKG_MAKE_OPTS_TARGET+=" GL_LIB=-lOpenGL"
+fi
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  PLATFORM+="-mesa"
+  PKG_MAKE_OPTS_TARGET+=" FORCE_GLES3=1"
+fi
+
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${VULKAN}"
+fi
+
+if [ -n "${PLATFORM}" ]; then
+  PKG_MAKE_OPTS_TARGET+=" platform=${PLATFORM}"
+fi
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" > ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/emulation/libretro-mupen64plus-nx/patches/0001-Enable-all-options.patch
+++ b/packages/emulation/libretro-mupen64plus-nx/patches/0001-Enable-all-options.patch
@@ -1,0 +1,141 @@
+From 40fdde51fa7aa07dbde07ca9e3c5254aa4ce158a Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Tue, 2 Sep 2025 23:55:00 -0700
+Subject: [PATCH 1/4] Enable all options
+
+---
+ libretro/libretro_core_options.h | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+
+diff --git a/libretro/libretro_core_options.h b/libretro/libretro_core_options.h
+index fb39aa98e..f89a088ad 100644
+--- a/libretro/libretro_core_options.h
++++ b/libretro/libretro_core_options.h
+@@ -46,20 +46,16 @@ struct retro_core_option_v2_category option_cats_us[] = {
+       "GLideN64",
+       "Configure GLideN64 Options."
+    },
+-#ifdef HAVE_PARALLEL_RDP
+    {
+       "parallel_rdp",
+       "ParaLLEl-RDP",
+       "Configure ParaLLEl-RDP Options."
+    },
+-#endif // HAVE_PARALLEL_RDP
+-#ifdef HAVE_THR_AL
+    {
+       "angrylion",
+       "Angrylion",
+       "Configure Angrylion Options."
+    },
+-#endif // HAVE_THR_AL
+    { NULL, NULL, NULL },
+ };
+ 
+@@ -72,12 +68,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         NULL,
+         NULL,
+         {
+-#ifdef HAVE_THR_AL
+             {"angrylion", "Angrylion"},
+-#endif
+-#ifdef HAVE_PARALLEL_RDP
+             {"parallel", "ParaLLEl-RDP"},
+-#endif
+             {"gliden64", "GLideN64"},
+             { NULL, NULL },
+         },
+@@ -260,7 +252,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         },
+         "False"
+     },
+-#ifndef HAVE_OPENGLES2
+     {
+         CORE_NAME "-MultiSampling",
+         "MSAA level",
+@@ -278,7 +269,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         },
+         "0"
+     },
+-#endif
+     {
+         CORE_NAME "-FXAA",
+         "FXAA",
+@@ -349,10 +339,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         {
+             {"Off", NULL},
+             {"Sync", NULL},
+-#ifndef HAVE_OPENGLES2
+             {"Async", "DoubleBuffer"},
+             {"TripleBuffer", "TripleBuffer"},
+-#endif // HAVE_OPENGLES2
+             { NULL, NULL },
+         },
+ #ifndef HAVE_OPENGLES2
+@@ -512,7 +500,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         "True"
+ #endif
+     },
+-#if !defined(VC) && !defined(HAVE_OPENGLES)
+     {
+         CORE_NAME "-EnableN64DepthCompare",
+         "N64 Depth Compare",
+@@ -541,7 +528,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         },
+         "True"
+     },
+-#endif
+     {
+         CORE_NAME "-EnableTextureCache",
+         "Cache Textures",
+@@ -1022,7 +1008,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         },
+         "late"
+     },
+-#ifdef HAVE_PARALLEL_RDP
+     {
+         CORE_NAME "-parallel-rdp-synchronous",
+         "(ParaLLEl-RDP) Synchronous RDP",
+@@ -1244,8 +1229,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+             { NULL, NULL },
+         }
+     },
+-#endif
+-#ifdef HAVE_THR_AL
+     {
+         CORE_NAME "-angrylion-vioverlay",
+         "VI Overlay",
+@@ -1371,7 +1354,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         },
+         "disabled"
+     },
+-#endif
+     {
+         CORE_NAME "-cpucore",
+         "CPU Core",
+@@ -1382,9 +1364,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         {
+             {"pure_interpreter", "Pure Interpreter"},
+             {"cached_interpreter", "Cached Interpreter"},
+-#ifdef DYNAREC
+             {"dynamic_recompiler", "Dynarec"},
+-#endif
+             { NULL, NULL },
+         },
+ #ifdef DYNAREC
+@@ -1401,12 +1381,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+         NULL,
+         NULL,
+         {
+-#ifdef HAVE_LLE
+             {"cxd4", "CXD4"},
+-#endif
+-#ifdef HAVE_PARALLEL_RSP
+             {"parallel", "ParaLLEl"},
+-#endif
+             {"hle", "HLE"},
+             { NULL, NULL },
+         },
+-- 
+2.43.0
+

--- a/packages/emulation/libretro-mupen64plus-nx/patches/0002-Working-Defaults.patch
+++ b/packages/emulation/libretro-mupen64plus-nx/patches/0002-Working-Defaults.patch
@@ -1,0 +1,34 @@
+From 5411bf5f6e6269eea2880d1c70753db8d6258b61 Mon Sep 17 00:00:00 2001
+From: Zoe Gidiere <duplexsys@protonmail.com>
+Date: Fri, 17 Oct 2025 13:35:37 -0600
+Subject: [PATCH] [PATCH 2/4] Working Defaults
+
+---
+ libretro/libretro_core_options.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libretro/libretro_core_options.h b/libretro/libretro_core_options.h
+index f89a088..6d76653 100644
+--- a/libretro/libretro_core_options.h
++++ b/libretro/libretro_core_options.h
+@@ -73,7 +73,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+             {"gliden64", "GLideN64"},
+             { NULL, NULL },
+         },
+-        "gliden64"
++        "angrylion"
+     },
+     {
+         CORE_NAME "-43screensize",
+@@ -1386,7 +1386,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+             {"hle", "HLE"},
+             { NULL, NULL },
+         },
+-        "hle"
++        "cxd4"
+     },
+     {
+         CORE_NAME "-FrameDuping",
+-- 
+2.45.0
+

--- a/packages/emulation/libretro-mupen64plus-nx/patches/0003-Fix-compiler-error-with-GCC-15.patch
+++ b/packages/emulation/libretro-mupen64plus-nx/patches/0003-Fix-compiler-error-with-GCC-15.patch
@@ -1,0 +1,33 @@
+From dc1d9f87b89df718bd4f697cdd56b76571bff291 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Wed, 3 Sep 2025 15:08:31 -0700
+Subject: [PATCH 3/4] Fix compiler error with GCC 15
+
+Error was:
+
+  In file included from GLideN64/src/GLideNHQ/TxHiResCache.h:31,
+                   from GLideN64/src/GLideNHQ/TxFilter.h:29,
+                   from GLideN64/src/GLideNHQ/TxFilterExport.cpp:28:
+  GLideN64/src/GLideNHQ/TxHiResLoader.h:31:9: error: 'uint32_t' does not name a type
+     31 |         uint32_t checkFileName(char* ident, char* fname, uint32_t* pChksum, uint32_t* pPalchksum, uint32_t* pFmt, uint32_t* pSiz) const;
+        |         ^~~~~~~~
+---
+ GLideN64/src/GLideNHQ/TxHiResLoader.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/GLideN64/src/GLideNHQ/TxHiResLoader.h b/GLideN64/src/GLideNHQ/TxHiResLoader.h
+index 4c1365123..9dcec1412 100644
+--- a/GLideN64/src/GLideNHQ/TxHiResLoader.h
++++ b/GLideN64/src/GLideNHQ/TxHiResLoader.h
+@@ -18,6 +18,8 @@
+ #include "TxImage.h"
+ #include "TxReSample.h"
+ 
++#include <stdint.h>
++
+ #ifdef _WIN32
+ #define FULLFNAME_CHARTYPE wchar_t
+ #else
+-- 
+2.43.0
+

--- a/packages/emulation/libretro-mupen64plus-nx/patches/0004-Fix-compiler-error-on-Windows.patch
+++ b/packages/emulation/libretro-mupen64plus-nx/patches/0004-Fix-compiler-error-on-Windows.patch
@@ -1,0 +1,32 @@
+From e3598f579ef60c80bab2ff55796e3f268807146e Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Wed, 3 Sep 2025 16:59:04 -0700
+Subject: [PATCH 4/4] Fix compiler error on Windows
+
+Error was:
+
+  libretro/libretro.c:469:17: error: implicit declaration of function 'rand_s'; did you mean 'rand'? [-Wimplicit-function-declaration]
+    469 |                 rand_s(&reg_id);
+        |                 ^~~~~~
+        |                 rand
+---
+ libretro/libretro.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libretro/libretro.c b/libretro/libretro.c
+index c4f570f3b..b8b016484 100644
+--- a/libretro/libretro.c
++++ b/libretro/libretro.c
+@@ -19,6 +19,9 @@
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+ 
+ #include <stdio.h>
++#ifdef __MINGW32__
++#define _CRT_RAND_S
++#endif
+ #include <stdlib.h>
+ #include <string.h>
+ #include <compat/strl.h>
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus-nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus-nx/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.mupen64plus-nx"
+PKG_VERSION="914c98d9db4c5ec9d2fd51ab3f2ec4ec9d17ae3f"
+PKG_SHA256="a9713229540e69ef9c0e6cc310380ec511077383ffecc40a78ae97c06ef7d20d"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/kodi-game/game.libretro.mupen64plus-nx"
+PKG_URL="https://github.com/kodi-game/game.libretro.mupen64plus-nx/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-mupen64plus-nx"
+PKG_DEPENDS_UNPACK="libretro-mupen64plus-nx"
+PKG_SECTION=""
+PKG_LONGDESC="Mupen64Plus-Next is N64 emulation library for the libretro API, based on Mupen64Plus"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
This PR adds valuable support for N64 games when using Kodi's retro player.

While Kodi does not have OpenGL support for the libretro api, mupen64plus-nx supports the angrylion software render, which does not need OpenGL.

The patches were taken from [game.libretro.mupen64plus-nx](https://github.com/kodi-game/game.libretro.mupen64plus-nx), however an additional patch is needed to set the rsp plugin setting away from hle as default which disables angrylion, and causes Kodi to crash. This PR is marked draft while I PR the change to the game.libretro.mupen64plus-nx repo. But you can easily change  `mupen64plus-rsp-plugin` in the settings.xml to fix this for now. 

This has been tested working on A Raspberry Pi 5 running LibreELEC 12.2.0

Feedback welcome :)!