### PR TITLE
Revert "pcre2: update to 10.47"

### DIFF
--- a/packages/devel/pcre2/package.mk
+++ b/packages/devel/pcre2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcre2"
-PKG_VERSION="10.47"
-PKG_SHA256="47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7"
+PKG_VERSION="10.46"
+PKG_SHA256="15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f"
 PKG_LICENSE="BSD"
 PKG_SITE="http://www.pcre.org/"
 PKG_URL="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PKG_VERSION}/pcre2-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
This reverts commit f87014cfc2295ae4b0dcccb789711841f0e00323.

build errors of

CMake Error at cmake/modules/FindPCRE2.cmake:129 (add_library):
  add_library cannot create ALIAS target "kodi::PCRE2" because target
  "PCRE2::8BIT" is itself an ALIAS.