### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="22.0.4-Piers"
-PKG_SHA256="bf73f524e7f53332a473799e719eebc7cb51352a26cd2d6ea68a86338d17c767"
-PKG_REV="2"
+PKG_VERSION="22.0.5-Piers"
+PKG_SHA256="a52e85286fe1d06138248ad61fcb8278ad650a1539534329bbdc4b624947d7e3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/peripheral.joystick"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.xarcade/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.xarcade"
-PKG_VERSION="22.0.1-Piers"
-PKG_SHA256="c88574779fdce588adf509b5f543b12bdc25e7b023c9d7dc6169cd2473b2f25e"
-PKG_REV="3"
+PKG_VERSION="22.0.2-Piers"
+PKG_SHA256="fe004117b8d2c953e438962b878a5b11d9c772867391863f92dd7c2c827d3ca1"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/peripheral.xarcade"


### PR DESCRIPTION
- peripheral.joystick: update 22.0.4-Piers to 22.0.5-Piers
- peripheral.xarcade: update 22.0.1-Piers to 22.0.2-Piers