### PR TITLE
game.libretro: Update to v22.2.3-Piers

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="22.2.0-Piers"
-PKG_SHA256="258d10c79ffa13cd0bad229a23704b60e24186665ee42e789be0b4c6578d69fd"
-PKG_REV="2"
+PKG_VERSION="22.2.3-Piers"
+PKG_SHA256="4c721762d47a1ef0f30877f2a5bd6fe93a9f0500b49e888b98bc8c248e0b6268"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro"


### PR DESCRIPTION
## Description

As title says, this updates game.libretro to v22.2.3-Piers.

Companion to https://github.com/LibreELEC/LibreELEC.tv/pull/10636.

Changes include a runtime fix, a build fix, and some translation updates.