### PR TITLE
texturecache.py: update to githash 0a334fb and update repo

### DIFF
--- a/packages/tools/texturecache.py/package.mk
+++ b/packages/tools/texturecache.py/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="texturecache.py"
-PKG_VERSION="2.5.4"
-PKG_SHA256="0717c2e62dc3f809e8754be2c83d2c7d0f92188741eb425d5377c1d326d25276"
+PKG_VERSION="0a334fb997cb5242958aef4eb28da68423850eb8"
+PKG_SHA256="bdeda226c43f7fb71b1c3d4c070463da12da7efd28e050e9d3aa2b6da25e3a92"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/MilhouseVH/texturecache.py"
-PKG_URL="https://github.com/MilhouseVH/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/xbmc/texturecache.py"
+PKG_URL="https://github.com/xbmc/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"
 PKG_LONGDESC="The Swiss Army knife for Kodi"
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
- fixes #10644 