### PR TITLE
texturecache.py: update to 2.5.6

### DIFF
--- a/packages/tools/texturecache.py/package.mk
+++ b/packages/tools/texturecache.py/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="texturecache.py"
-PKG_VERSION="2.4.6"
-PKG_SHA256="0e28ccf1dfeacb0509c4372fe77b8b4cd8f1ab8511acc5802fd01dff41743f96"
+PKG_VERSION="2.5.6"
+PKG_SHA256="75a6e78c1f7371dfc273a7ae851445e1be38cc427b99e2a5d7f347f146fe10ef"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/texturecache"
 PKG_URL="https://github.com/xbmc/texturecache/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
The latest version is 2.5.6, not 2.4.6 - thanks @mglae for spotting that!