### PR TITLE
libcap: add missing HOST_LDFLAGS for target build

### DIFF
--- a/packages/devel/libcap/package.mk
+++ b/packages/devel/libcap/package.mk
@@ -28,6 +28,7 @@ make_host() {
        RANLIB=${RANLIB} \
        CFLAGS="${HOST_CFLAGS}" \
        BUILD_CFLAGS="${HOST_CFLAGS} -I${PKG_BUILD}/libcap/include" \
+       BUILD_LDFLAGS="${HOST_LDFLAGS}" \
        PAM_CAP=no \
        lib=/lib \
        USE_GPERF=no \
@@ -42,6 +43,7 @@ make_target() {
        CFLAGS="${TARGET_CFLAGS}" \
        BUILD_CC=${HOST_CC} \
        BUILD_CFLAGS="${HOST_CFLAGS} -I${PKG_BUILD}/libcap/include" \
+       BUILD_LDFLAGS="${HOST_LDFLAGS}" \
        PAM_CAP=no \
        lib=/lib \
        USE_GPERF=no \


### PR DESCRIPTION
Build on Ubuntu 25.10 (Questing Quokka) identified that the BUILD_LDFLAGS were not being provided to the _makenames recipe. Add BUILD_LDFLAGS so that a host compile of _makenames can be done for a :target build.

Ref: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=c3ddf45d9afaab85d3b7db0dc7bfd1aafb8fde50

    make: Entering directory '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/libcap-2.77/.x86_64-libreelec-linux-gnu/libcap'
    sed -e 's,@prefix@,/usr,' \
            -e 's,@exec_prefix@,,' \
            -e 's,@libdir@,//lib,' \
            -e 's,@includedir@,/usr/include,' \
            -e 's,@VERSION@,2.77,' \
            -e 's,@deps@,,' \
            libcap.pc.in >libcap.pc
    => making cap_names.list.h from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/libcap-2.77/.x86_64-libreelec-linux-gnu/libcap/../libcap/include/uapi/linux/capability.h
    grep -E '^#define\s+CAP_([^\s]+)\s+[0-9]+\s*$' include/uapi/linux/capability.h | sed -e 's/^#define\s\+/{"/' -e 's/\s*$/},/' -e 's/\s\+/",/' -e 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' > cap_names.list.h
    /home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/host-gcc -O2 -Wall -pipe -I/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/include -Wno-format-security -I/home/docker/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/libcap-2.77/libcap/include -Dlinux -Wall -Wwrite-strings -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wshadow -Wunreachable-code  -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/libcap-2.77/.x86_64-libreelec-linux-gnu/libcap/../libcap/include/uapi -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/libcap-2.77/.x86_64-libreelec-linux-gnu/libcap/../libcap/include _makenames.c -o _makenames -Wl,--as-needed -fuse-ld=gold -fPIC
    collect2: fatal error: cannot find 'ld'
    compilation terminated.
    make: *** [Makefile:83: _makenames] Error 1