### PR TITLE
nextpvr: Rework FFmpeg options

### DIFF
--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="nextpvr"
 PKG_VERSION="7.0.4"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"
 PKG_SITE="https://nextpvr.com"

--- a/packages/addons/service/nextpvr/source/addon.py
+++ b/packages/addons/service/nextpvr/source/addon.py
@@ -24,9 +24,6 @@ LS = xbmcaddon.Addon().getLocalizedString
 SCANTABLES = ['atsc', 'dvb-c', 'dvb-s', 'dvb-t']
 GENERIC_URL = 'https://nextpvr.com/stable/linux/NPVR.zip'
 
-FFMPEG_PARMS = ( '-y [ANALYZE_DURATION] [SEEK] -i [SOURCE] -map_metadata -1 -threads [THREADS] -ignore_unknown -map 0:v:0? [PREFERRED_LANGUAGE] -map 0:a:[AUDIO_STREAM] -map -0:s '
-                '-vcodec @PRESET@ -acodec aac -ac 2 -c:s copy -hls_time [SEGMENT_DURATION] -start_number 0 -hls_list_size [SEGMENT_COUNT] -y [TARGET]')
-
 class Controller():
 
     def __init__(self):
@@ -182,32 +179,6 @@ class Controller():
         self.doSessionRequest5('session.logout')
         self.showMessage(LS(30017))
 
-    def transcodeHLS(self):
-        base = os.path.join(xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile')), 'config/config.xml')
-        tree = ET.parse(base)
-        parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
-        tree = ET.parse(base, parser=parser)
-        root = tree.getroot()
-        parent = root.find("WebServer")
-        child = parent.find('TranscodeHLS')
-        preset = xbmcaddon.Addon().getSetting('preset')
-        if preset  == 'default':
-            parms = 'default'
-        else:
-            if (preset != "copy"):
-                preset = "libx264 -preset " + preset + ' -crf 26'
-            parms = FFMPEG_PARMS.replace('@PRESET@', preset)
-
-        if child.text != parms:
-            child.text = parms
-            tree.write(base, encoding='utf-8')
-            if child.text == 'default':
-                self.showMessage(LS(30018))
-            else:
-                self.showMessage(LS(30019))
-        else:
-            self.showMessage(LS(30020))
-
     def resetWebCredentials(self):
         rewrite = False
         base = os.path.join(xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile')), 'config/config.xml')
@@ -227,7 +198,6 @@ class Controller():
         if rewrite:
             tree.write(base, encoding='utf-8')
             self.showMessage(LS(30046))
-
 
 if __name__ == '__main__':
     option = Controller()

--- a/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
+++ b/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
@@ -72,6 +72,9 @@ unzip ${NEXTPVR_FILE} -d ${ADDON_DIR}/nextpvr-bin >/dev/null
 if [ "$(uname -m)" != "x86_64" ] && [ $(grep -c  RPi5 /etc/os-release) -eq 0 ] && \
    [ $(grep -c  RK3588 /etc/os-release) -eq 0 ] && [ $(grep -c  S928 /proc/cpuinfo) -eq 0 ]; then
   sed -i 's/<TranscodeHLS>default<\/TranscodeHLS>/<TranscodeHLS>-y [ANALYZE_DURATION] [SEEK] -i [SOURCE] -map_metadata -1 -threads [THREADS] -ignore_unknown -map 0:v:0? [PREFERRED_LANGUAGE] -map 0:a:[AUDIO_STREAM] -map -0:s -vcodec copy -acodec aac -ac 2 -c:s copy -hls_time [SEGMENT_DURATION] -start_number 0 -hls_list_size [SEGMENT_COUNT] -y [TARGET]<\/TranscodeHLS>/' ${ADDON_DIR}/nextpvr-bin/data/Config-master-dont-edit.xml
+  sed -i 's/<default>default</<default>copy</' ${ADDON_DIR}/resources/settings.xml
+else:
+  sed -i 's/<level type="ffmpeg">3</<level type="ffmpeg">2</' ${ADDON_DIR}/resources/settings.xml
 fi
 
 sed -i 's/<RecordingDirectory>C:\\Users\\Public\\Videos\\<\/RecordingDirectory>/<RecordingDirectory>\/storage\/tvshows\/<\/RecordingDirectory>/' ${ADDON_DIR}/nextpvr-bin/data/Config-master-dont-edit.xml

--- a/packages/addons/service/nextpvr/source/default.py
+++ b/packages/addons/service/nextpvr/source/default.py
@@ -3,14 +3,66 @@
 
 import xbmc
 import xbmcaddon
+import xbmcvfs
+import xbmcgui
+import os
+import xml.etree.ElementTree as ET
+
+ADDON_NAME = xbmcaddon.Addon().getAddonInfo('name')
+
+FFMPEG_PARMS = ( '-y [ANALYZE_DURATION] [SEEK] -i [SOURCE] -map_metadata -1 -threads [THREADS] -ignore_unknown -map 0:v:0? [PREFERRED_LANGUAGE] -map 0:a:[AUDIO_STREAM] -map -0:s '
+                '-vcodec @PRESET@ -acodec aac -ac 2 -c:s copy -hls_time [SEGMENT_DURATION] -start_number 0 -hls_list_size [SEGMENT_COUNT] -y [TARGET]')
+
+LS = xbmcaddon.Addon().getLocalizedString
+
+preset = None
+crf = None
 
 class Monitor(xbmc.Monitor):
 
    def __init__(self, *args, **kwargs):
+      global preset
       xbmc.Monitor.__init__(self)
+      preset = xbmcaddon.Addon().getSetting('preset')
+      crf = xbmcaddon.Addon().getSetting('crf')
 
    def onSettingsChanged(self):
-      pass
+      newpreset = xbmcaddon.Addon().getSetting('preset')
+      newcrf = xbmcaddon.Addon().getSetting('preset')
+      if crf != newcrf or preset != newpreset:
+         self.transcodeHLS()
+
+   def transcodeHLS(self):
+      base = os.path.join(xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile')), 'config/config.xml')
+      tree = ET.parse(base)
+      parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+      tree = ET.parse(base, parser=parser)
+      root = tree.getroot()
+      parent = root.find("WebServer")
+      child = parent.find('TranscodeHLS')
+      preset = xbmcaddon.Addon().getSetting('preset')
+      if preset  == 'default':
+         parms = 'default'
+      else:
+         if preset != "copy":
+               crf = xbmcaddon.Addon().getSetting('crf')
+               preset = "libx264 -preset " + preset + ' -crf ' + crf
+         parms = FFMPEG_PARMS.replace('@PRESET@', preset)
+
+      if child.text != parms:
+         child.text = parms
+         tree.write(base, encoding='utf-8')
+         if child.text == 'default':
+               self.showMessage(LS(30018))
+         else:
+               self.showMessage(LS(30019))
+      else:
+         self.showMessage(LS(30020))
+
+   def showMessage(self, message):
+      xbmc.log(message, xbmc.LOGDEBUG)
+      xbmcgui.Dialog().notification(ADDON_NAME, message, xbmcgui.NOTIFICATION_INFO)
+
 
 if __name__ == "__main__":
    Monitor().waitForAbort()

--- a/packages/addons/service/nextpvr/source/resources/Language/English/strings.po
+++ b/packages/addons/service/nextpvr/source/resources/Language/English/strings.po
@@ -38,11 +38,11 @@ msgid "Rescan m3u file(s) and update URLs"
 msgstr ""
 
 msgctxt "#30009"
-msgid "Apply transcoding selection"
+msgid "Transcode options"
 msgstr ""
 
 msgctxt "#30010"
-msgid "Change HLS transcoding mode, may not work on all platforms"
+msgid "Change FFmpeg video transcoding options for web streaming"
 msgstr ""
 
 msgctxt "#30011"
@@ -146,11 +146,19 @@ msgid "Delay service launch on boot to specified uptime (seconds)"
 msgstr ""
 
 msgctxt "#30051"
-msgid "Custom video preset"
+msgid "Choose video preset"
 msgstr ""
 
 msgctxt "#30052"
-msgid "Manage FFmpeg video transcoding settings"
+msgid "Manage FFmpeg video transcoding option"
+msgstr ""
+
+msgctxt "#30053"
+msgid "Set crf value"
+msgstr ""
+
+msgctxt "#30054"
+msgid "Constant Rate Factor (crf) quality. High to low with 18-28 recommended"
 msgstr ""
 
 msgctxt "#31000"

--- a/packages/addons/service/nextpvr/source/resources/settings.xml
+++ b/packages/addons/service/nextpvr/source/resources/settings.xml
@@ -20,7 +20,7 @@
       </group>
     </category>
     <category id="control" label="30004">
-      <group id="0">
+      <group id="1">
         <setting id="waitfor" type="integer" label="30049" help="30050">
           <level>1</level>
           <default>5</default>
@@ -54,30 +54,6 @@
             <close>false</close>
           </control>
         </setting>
-        <setting id="preset" type="string" label="30051" help="30052">
-            <level>2</level>
-            <default>copy</default>
-            <constraints>
-                <options>
-                    <option label="31000">copy</option>
-                    <option label="31001">default</option>
-                    <option label="31002">ultrafast</option>
-                    <option label="31003">superfast</option>
-                    <option label="31004">veryfast</option>
-                    <option label="31005">faster</option>
-                    <option label="31006">fast</option>
-                    <option label="31007">medium</option>
-                </options>
-            </constraints>
-            <control type="spinner" format="string"/>
-        </setting>
-        <setting id="transcode" type="action" label="30009" help="30010">
-          <level>2</level>
-          <data>RunScript(service.nextpvr, transcode)</data>
-          <control type="button" format="action">
-            <close>false</close>
-          </control>
-        </setting>
         <setting id="defaults" type="action" label="30044" help="30045">
           <level>3</level>
           <data>RunScript(service.nextpvr, defaults)</data>
@@ -93,6 +69,40 @@
           </control>
         </setting>
       </group>
+    </category>
+    <category id="ffmpeg" label="30009" help="30010">
+      <level type="ffmpeg">3</level>
+      <group id="3">
+        <setting id="preset" type="string" label="30051" help="30052">
+            <level>2</level>
+            <default>default</default>
+            <constraints>
+                <options>
+                    <option label="31000">copy</option>
+                    <option label="31001">default</option>
+                    <option label="31002">ultrafast</option>
+                    <option label="31003">superfast</option>
+                    <option label="31004">veryfast</option>
+                    <option label="31005">faster</option>
+                    <option label="31006">fast</option>
+                    <option label="31007">medium</option>
+                </options>
+            </constraints>
+            <control type="spinner" format="string"/>
+        </setting>
+        <setting id="crf" type="integer" label="30053" help="30054">
+          <level>2</level>
+          <default>26</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>51</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+        </setting>
+        </group>
     </category>
   </section>
 </settings>

--- a/packages/addons/service/nextpvr/source/settings-default.xml
+++ b/packages/addons/service/nextpvr/source/settings-default.xml
@@ -1,5 +1,5 @@
 <settings version="2">
     <setting id="waitfor" default="true">5</setting>
     <setting id="satiprtsp" default="true">554</setting>
-    <setting id="customvideo" default="true">-vcodec copy</setting>
+    <setting id="crf" default="true">26</setting>
 </settings>


### PR DESCRIPTION
- addresses an issue with usage of the FFmpeg option selection discussed on the Kodi forum https://forum.kodi.tv/showthread.php?tid=383046.
- added option to modify crf value

Note that choosing vaapi can be done via the browser but  could allow for setting v4l options in the future.
