### PR TITLE
kodi: pastekodi: log Xorg.0.log of Generic-legacy

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -84,6 +84,8 @@ fi
 
   journalctl -a -b -0 -o short-precise | cat_data "journalctl -a -b -0"
 
+  cat_file "/var/log/Xorg.0.log" # x86 legacy
+
   kmsprint | cat_data "kmsprint"
 
   if [ "${LIBREELEC_PROJECT}" = "RPi" ]; then


### PR DESCRIPTION
While discussing an [issue in forum](https://forum.libreelec.tv/thread/30037-x86-64-le-12-2-doesn-t-boot-on-asus-chromebox-cn60/) Xorg.0.log of Generic-legacy was missing in pastekodi. Add it.

This is a noop on other platforms.

Backport of #10674