### PR TITLE
nano: enable utf-8 support

### DIFF
--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -11,7 +11,7 @@ PKG_URL="https://www.nano-editor.org/dist/v${PKG_VERSION%%.*}/${PKG_NAME}-${PKG_
 PKG_DEPENDS_TARGET="toolchain ncurses"
 PKG_LONGDESC="Nano is an enhanced clone of the Pico text editor."
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-utf8 \
+PKG_CONFIGURE_OPTS_TARGET="--enable-utf8 \
                            --disable-nls \
                            --disable-libmagic \
                            --disable-wrapping"


### PR DESCRIPTION
In the [forum](https://forum.libreelec.tv/thread/29797-nano-editor-can-%C3%BC%C3%B6%C3%A4-but-not-%C3%9F-locale-de-de-utf-8/) missing nano utf-8 support was requested.

Technically this can be done since we changed ncurses to wchar.

Backport of #10676