### PR TITLE
nextpvr: replace unzip which doesn't support utf-8

### DIFF
--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="nextpvr"
 PKG_VERSION="7.0.4"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"
 PKG_SITE="https://nextpvr.com"

--- a/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
+++ b/packages/addons/service/nextpvr/source/bin/nextpvr-downloader
@@ -67,7 +67,7 @@ chmod +x ${ADDON_DIR}/lbin/comskip
 ln -s ${ADDON_DIR}/lbin/hdhomerun_config ${ADDON_DIR}/nextpvr-bin
 ln -s ${ADDON_DIR}/lib.private/libmediainfo.so ${ADDON_DIR}/nextpvr-bin
 
-unzip ${NEXTPVR_FILE} -d ${ADDON_DIR}/nextpvr-bin >/dev/null
+python -m zipfile --extract ${NEXTPVR_FILE} ${ADDON_DIR}/nextpvr-bin >/dev/null
 
 if [ "$(uname -m)" != "x86_64" ] && [ $(grep -c  RPi5 /etc/os-release) -eq 0 ] && \
    [ $(grep -c  RK3588 /etc/os-release) -eq 0 ] && [ $(grep -c  S928 /proc/cpuinfo) -eq 0 ]; then


### PR DESCRIPTION
Use python cli to extract files needed for SAT>IP support with utf-8 characters.  See forum post https://forum.libreelec.tv/thread/30118-include-unzip-with-utf-8-support