### PR TITLE
atf: update to 2.14

### DIFF
--- a/packages/tools/atf/package.mk
+++ b/packages/tools/atf/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC
 
 PKG_NAME="atf"
-PKG_VERSION="2.13.0"
-PKG_SHA256="28bc15daeeed000ecd30819ecc4851bf9ffc2d33e1d4553a71985c17f47a999e"
+PKG_VERSION="2.14.0"
+PKG_SHA256="b2a3bc360307c929714ffd8e7f1441c4888cd5d80531276e809c2de54db5dc16"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3c"
 PKG_SITE="https://github.com/ARM-software/arm-trusted-firmware"

--- a/projects/Allwinner/patches/atf/0003-sunxi-Don-t-enable-referenced-regulators.patch
+++ b/projects/Allwinner/patches/atf/0003-sunxi-Don-t-enable-referenced-regulators.patch
@@ -10,8 +10,8 @@ This break certain devices which need appropriate power on sequence.
 
 --- a/drivers/allwinner/axp/common.c
 +++ b/drivers/allwinner/axp/common.c
-@@ -112,9 +112,6 @@ static bool should_enable_regulator(const void *fdt,
- 	if (is_node_disabled(fdt, node)) {
+@@ -103,9 +103,6 @@ static bool should_enable_regulator(const void *fdt,
+ 	if (!fdt_node_is_enabled(fdt, node)) {
  		return false;
  	}
 -	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL) {


### PR DESCRIPTION
DRAFT

Built on
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build atf
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build atf
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build atf
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build atf
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build atf
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build atf
``` 