### PR TITLE
linux: update to 6.17.8

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,8 +37,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rockchip rtlwifi/6.18"
     ;;
   *)
-    PKG_VERSION="6.17.7"
-    PKG_SHA256="ddf2ea0d4439e1d57136be3623102af9458f601f5b1cb77e83246e88aea09d0e"
+    PKG_VERSION="6.17.8"
+    PKG_SHA256="5a8de64a75fca706c01c6c0a77cf75a74618439db195e25f1f0268af6b2fb1da"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     case ${DEVICE} in


### PR DESCRIPTION
### packages updated
- linux: update to 6.17.8


### 6.17.x mainline kernel update
- https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.17.8

6.17.8 - 849 patches

### errors / fixes / issues / regressions / todo
- wip
- done


### log 
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.17.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=linux-6.17.y
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/log/
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git/log/?h=queue/6.17
- https://linux-regtracking.leemhuis.info/regzbot/mainline/
- https://linux-regtracking.leemhuis.info/regzbot/stable/

### 6.17.8 Build tested on all of:
```
PROJECT=Allwinner ARCH=aarch64 DEVICE=A64 s/build linux
PROJECT=Allwinner ARCH=arm DEVICE=H3 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H5 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=H6 s/build linux
PROJECT=Allwinner ARCH=aarch64 DEVICE=R40 s/build linux
PROJECT=Rockchip ARCH=arm DEVICE=RK3288 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3328 s/build linux
PROJECT=Rockchip ARCH=aarch64 DEVICE=RK3399 s/build linux
PROJECT=NXP ARCH=arm DEVICE=iMX6 s/build linux
PROJECT=NXP ARCH=aarch64 DEVICE=iMX8 s/build linux
PROJECT=Qualcomm ARCH=aarch64 DEVICE=Dragonboard s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic s/build linux
PROJECT=Generic ARCH=x86_64 DEVICE=Generic-legacy s/build linux
PROJECT=Samsung ARCH=arm DEVICE=Exynos s/build linux
```

### 6.17.y Run tested on all of:
- Allwinner all - tested - TBA - jernejsk
- Allwinner H6 (Tanix TX6) - TBA - heitbaum
- Generic Generic (Intel ADL - NUC12) - 6.17.1 - heitbaum
- Generic Generic (AMD 7840HS - SER7) - 6.17.7 - heitbaum
- NXP iMX6 (Cubox-i4Pro) - TBA - heitbaum
- NXP iMX8 (Coral Dev Board - Phanbell) - TBA - heitbaum
- Rockchip RK3399pro (Rock Pi N10) - TBA - heitbaum
- RK all - tested - TBA - knaerzche
- Samsung Exynos (Hardkernel ODROID XU4) - TBA - heitbaum