### PR TITLE
espeak-ng: fix build with VALGRIND env variable set

### DIFF
--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -21,6 +21,10 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=ON \
                        -DENABLE_TESTS=OFF \
                        -DNativeBuild_DIR=${TOOLCHAIN}/bin"
 
+pre_configure_target() {
+  unset VALGRIND
+}
+
 post_makeinstall_target() {
   safe_remove ${INSTALL}/usr/share/vim
 


### PR DESCRIPTION
espeak-ng doesn't build if the environment variable "VALGRIND" is set, because the command gets malformed due to an added "yes" in between.

Note:
The only place, where `$VALGRIND` is asked for in LibreELEC is in the [debug](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/virtual/debug/package.mk#L20) package.

Maybe instead of patching other packages it would be more appropriate to either rename the name of the environment variable (which could break existing build environments) or find some other solution.

So, consider this more as an issue report with a possible (temp) solution...