### PR TITLE
systemd: update to 259

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="systemd"
-PKG_VERSION="258.2"
-PKG_SHA256="05208e76bf1f9b369b1a8159e6631ef67c82f2d27c21e931962026a79bf4ba64"
+PKG_VERSION="259"
+PKG_SHA256="a84123692d1add7f9c48fd11cdf5f901393008c2d2ade667c18f25a20bf1290d"
 PKG_LICENSE="LGPL2.1+"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/systemd"
 PKG_URL="https://github.com/systemd/systemd/archive/v${PKG_VERSION}.tar.gz"
@@ -93,6 +93,7 @@ PKG_MESON_OPTS_TARGET="--libdir=/usr/lib \
                        -Dlink-udev-shared=true \
                        -Dlink-systemctl-shared=true \
                        -Dlink-networkd-shared=false \
+                       -Djournal-storage-default=auto \
                        -Dbashcompletiondir=no \
                        -Dzshcompletiondir=no \
                        -Dkmod-path=/usr/bin/kmod \


### PR DESCRIPTION
Draft PR 

Warnings now showing in v259.2. Not sure if this is a hard requirement coming in 260. This PR is the start of a MVP to allow systemd to build, if that is the case. If we don’t proceed with the MVP in 259 (I don’t think it is required) we will need to comment out the warning.
- Ref: https://github.com/systemd/systemd/releases
- https://github.com/systemd/systemd/blob/2fd63f831fb1c19baaf1e2c4967cbb806567d4e2/src/shared/cryptsetup-util.c#L301
- the code hasn’t changed so maybe this is a regression, in the code path.

Also there is an issue with 259-rc1 and 259-rc2 that it is not honoring without-acl.
- https://github.com/systemd/systemd/issues/39928



```
# dmesg | grep "not compile"
[    1.360261] (mount)[283]: sys-kernel-debug.mount: cryptsetup support is not compiled in.
``` 


- systemd: add version 260 dependency of cryptsetup
- cryptsetup: update to 2.8.1 and meson
- lvm2-lib: update to 2.03.37
- lvm2: update to 2.03.37
- lvm2: lvm2-2.03.16
- cryptsetup: cryptsetup-2.6.1
- revert-tar-systemd
- systemd: update to 259-rc2


- Ref: https://github.com/sky42src/LibreELEC.tv/commits/libreelec-12.2.x/
- ref: https://forum.libreelec.tv/thread/30135-svt-play-livestream-spontaneously-quits-after-1-second-if-played-on-libreelec/?postID=203527#post203527