### PR TITLE
moby: fix git clean issue when in CI/CD

### DIFF
--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -41,6 +41,9 @@ make_target() {
   mkdir -p bin
   ${GOLANG} build -mod=mod -modfile=go.mod -v -o bin/docker-proxy -a -ldflags "${LDFLAGS}" ./cmd/docker-proxy
   ${GOLANG} build -mod=mod -modfile=go.mod -v -o bin/dockerd -a -tags "${PKG_MOBY_BUILDTAGS}" -ldflags "${LDFLAGS}" ./cmd/dockerd
+
+  # fix permissions of .gopath to allow clean during CI build
+  chmod -R u+w .gopath
 }
 
 makeinstall_target() {


### PR DESCRIPTION
git clean fails in GHA CI/CD when the directories have a 555 permission instead of 755 recursively add u+w to .gopath

dr-xr-xr-x   6 runner   1001         4096 Nov 29 13:48 .gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64
dr-xr-xr-x   4 runner   1001         4096 Nov 29 13:48 .gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/pkg
dr-xr-xr-x   3 runner   1001         4096 Nov 29 13:48 .gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/pkg/tool
dr-xr-xr-x   2 runner   1001         4096 Nov 29 13:48 .gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/pkg/tool/linux_amd64
...