### PR TITLE
media-driver: update to 25.4.4

### DIFF
--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="25.4.0"
-PKG_SHA256="2821cab73a9f40ed3f835836f68102a63943170dbd7b2c34484f28d357ae9392"
+PKG_VERSION="25.4.4"
+PKG_SHA256="2e034525b508aa85914736ef9b9c59b6ab51ae9008c9c815e3ee354a5ada76b4"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"


### PR DESCRIPTION
```
=== tested on ===
Generic.x86_64-devel-20251201112308-2f4d21c
Linux nuc12 6.18.0 #1 SMP Mon Dec  1 01:58:57 UTC 2025 x86_64 GNU/Linux
Starting Kodi (22.0-ALPHA2 (21.90.702) Git:dba0acc9c66f7d48d53dfb927b1c1fd19af5cd69). Platform: Linux x86 64-bit
Using Release Kodi x64
Kodi compiled 2025-11-30 by GCC 16.0.0 for Linux x86 64-bit version 6.18.0 (397824)
Running on LibreELEC (heitbaum): devel-20251201112308-2f4d21c 13.0, kernel: Linux x86 64-bit version 6.18.0
FFmpeg version/source: 7.1.1
Host CPU: 12th Gen Intel(R) Core(TM) i7-1260P, 16 cores available
[    0.000000] DMI: Intel(R) Client Systems NUC12WSKi7/NUC12WSBi7, BIOS WSADL357.0097.2025.0812.1627 08/12/2025
CApplication::CreateGUI - trying to init gbm windowing system
CApplication::CreateGUI - using the gbm windowing system
EGL_VENDOR = Mesa Project
CRenderSystemGL::InitRenderSystem - Version: 4.6 (Core Profile) Mesa 25.3.0, Major: 4, Minor: 6
GL_RENDERER = Mesa Intel(R) Graphics (ADL GT2)
libva info: VA-API version 1.22.0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.4.4 (2f4d21ca99d)
```