### PR TITLE
Delay snapclient start to avoid interference with Kodi ALSA output detection

### DIFF
--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Prevents snapclient from interfering with Kodi ALSA output detection on boot
+# TODO: is this masking a root cause? This service should already be waiting for kodi, perhaps best to just improve the detection of when Kodi has more fully initialized?
+# TODO: make user configurable in add-on settings? Or perhaps add as hardware specific quirk?
+sleep 3
+
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 


### PR DESCRIPTION
Possible solution or workaround for https://github.com/LibreELEC/LibreELEC.tv/issues/10752

Prevents snapclient from interfering with Kodi ALSA output detection on boot
To discuss/review:
1. is this masking a root cause? This service should already be waiting for kodi, perhaps best to just improve the detection of when Kodi has more fully initialized?
1. should this be user configurable in add-on settings? Or perhaps add as hardware specific quirk constant?