### PR TITLE
iptables: do not build legacy tools

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -12,6 +12,8 @@ PKG_DEPENDS_TARGET="autotools:host gcc:host linux:host libmnl libnftnl"
 PKG_LONGDESC="IP packet filter administration."
 PKG_TOOLCHAIN="autotools"
 
+PKG_CONFIGURE_OPTS_TARGET+=" --enable-nftables --disable-ipv4 --disable-ipv6"
+
 post_configure_target() {
   libtool_remove_rpath libtool
 }
@@ -26,12 +28,6 @@ post_makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libreelec
     cp ${PKG_DIR}/scripts/iptables_helper ${INSTALL}/usr/lib/libreelec
 
-  safe_remove              ${INSTALL}/usr/sbin/iptables
-  safe_remove              ${INSTALL}/usr/sbin/iptables-restore
-  safe_remove              ${INSTALL}/usr/sbin/iptables-save
-  safe_remove              ${INSTALL}/usr/sbin/ip6tables
-  safe_remove              ${INSTALL}/usr/sbin/ip6tables-restore
-  safe_remove              ${INSTALL}/usr/sbin/ip6tables-save
   ln -sf xtables-nft-multi ${INSTALL}/usr/sbin/iptables
   ln -sf xtables-nft-multi ${INSTALL}/usr/sbin/iptables-restore
   ln -sf xtables-nft-multi ${INSTALL}/usr/sbin/iptables-save


### PR DESCRIPTION
only build nftables tools

files no longer built:
- /usr/sbin/ip6tables-legacy-save
- /usr/sbin/iptables-legacy-save
- /usr/sbin/ip6tables-legacy
- /usr/sbin/ip6tables-legacy-restore
- /usr/sbin/iptables-legacy-restore
- /usr/sbin/iptables-legacy
- /usr/lib/xtables/libip6t_frag.so
- /usr/lib/xtables/libip6t_dst.so
- /usr/lib/xtables/libip6t_srh.so
- /usr/lib/xtables/libip6t_icmp6.so
- /usr/lib/xtables/libip6t_SNPT.so
- /usr/lib/xtables/libipt_ttl.so
- /usr/lib/xtables/libipt_CLUSTERIP.so
- /usr/lib/xtables/libipt_ah.so
- /usr/lib/xtables/libip6t_NETMAP.so
- /usr/lib/xtables/libip6t_eui64.so
- /usr/lib/xtables/libipt_ECN.so
- /usr/lib/xtables/libipt_realm.so
- /usr/lib/xtables/libipt_icmp.so
- /usr/lib/xtables/libipt_NETMAP.so
- /usr/lib/xtables/libip6t_hl.so
- /usr/lib/xtables/libip6t_mh.so
- /usr/lib/xtables/libipt_REJECT.so
- /usr/lib/xtables/libip6t_rt.so
- /usr/lib/xtables/libip6t_REJECT.so
- /usr/lib/xtables/libip6t_hbh.so
- /usr/lib/xtables/libip6t_ipv6header.so
- /usr/lib/xtables/libipt_TTL.so
- /usr/lib/xtables/libip6t_ah.so
- /usr/lib/xtables/libip6t_DNPT.so
- /usr/lib/xtables/libipt_ULOG.so
- /usr/lib/xtables/libip6t_HL.so