### PR TITLE
pastekodi: include hexdump of EDIDs

### DIFF
--- a/packages/mediacenter/kodi/scripts/pastekodi
+++ b/packages/mediacenter/kodi/scripts/pastekodi
@@ -94,6 +94,15 @@ fi
 
   kmsprint | cat_data "kmsprint"
 
+  for f in /sys/class/drm/card*/edid; do
+    if [ -e "${f}" ]; then
+      EDID=$(hexdump -v -e '16/1 "%02x ""\n"' "${f}" 2>/dev/null)
+      if [ -n "${EDID}" ]; then
+        echo "${EDID}" | cat_data "${f}"
+      fi
+    fi 
+  done 
+
   if [ "${DISTRO_PROJECT}" = "RPi" ]; then
     vcgencmd bootloader_version | cat_data "Bootloader version"
   fi


### PR DESCRIPTION
This is helpful to analyze and/or reproduce audio and video issues.

To save space the edids are included as hexdumps which are natively supported by edid-decode, can be uploaded to
https://people.freedesktop.org/~imirkin/edid-decode/ for online decoding or fed to xxd -r -p to get a binary file.