### PR TITLE
alsa-lib: add current fixes from master

### DIFF
--- a/packages/audio/alsa-lib/patches/alsa-lib-master-fixes.patch
+++ b/packages/audio/alsa-lib/patches/alsa-lib-master-fixes.patch
@@ -1,0 +1,4986 @@
+From a068cf08ad67447893b707cddfce31c9cafee643 Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Mon, 8 Dec 2025 23:46:17 -0500
+Subject: [PATCH 01/43] ucm: use closefrom instead of close_range
+
+closefrom is a library function with a fallback mechanism for when the
+kernel does not support the close_range syscall.
+
+Also check for the function properly instead of assuming it is available
+with _GNU_SOURCE defined.
+
+Closes: https://github.com/alsa-project/alsa-lib/pull/486
+Fixes: https://github.com/alsa-project/alsa-lib/issues/485
+Signed-off-by: Mike Gilbert <floppym@gentoo.org>
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ configure.ac       | 1 +
+ src/ucm/ucm_exec.c | 4 ++--
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8f4bd0de1400..f4862f64cd4c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -52,6 +52,7 @@ dnl Checks for library functions.
+ AC_PROG_GCC_TRADITIONAL
+ AC_CHECK_FUNCS([uselocale])
+ AC_CHECK_FUNCS([eaccess])
++AC_CHECK_DECLS([closefrom])
+ 
+ dnl Enable largefile support
+ AC_SYS_LARGEFILE
+diff --git a/src/ucm/ucm_exec.c b/src/ucm/ucm_exec.c
+index b5a22023b680..713039b4920f 100644
+--- a/src/ucm/ucm_exec.c
++++ b/src/ucm/ucm_exec.c
+@@ -259,8 +259,8 @@ int uc_mgr_exec(const char *prog)
+ 
+ 		close(f);
+ 
+-#if defined(_GNU_SOURCE)
+-		close_range(3, maxfd, 0);
++#if HAVE_DECL_CLOSEFROM
++		closefrom(3);
+ #else
+ 		for (f = 3; f < maxfd; f++)
+ 			close(f);
+-- 
+2.47.3
+
+
+From 813ffe34ff6c720dcc56e4549338bf9e9184af1f Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Tue, 9 Dec 2025 17:48:34 +0100
+Subject: [PATCH 02/43] ucm: exec - fix maxfd used warning
+
+Fixes: a068cf08 ("ucm: use closefrom instead of close_range")
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/ucm/ucm_exec.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/src/ucm/ucm_exec.c b/src/ucm/ucm_exec.c
+index 713039b4920f..c16a4cfdaec0 100644
+--- a/src/ucm/ucm_exec.c
++++ b/src/ucm/ucm_exec.c
+@@ -183,7 +183,7 @@ static int parse_args(char ***argv, int argc, const char *cmd)
+  */
+ int uc_mgr_exec(const char *prog)
+ {
+-	pid_t p, f, maxfd;
++	pid_t p, f;
+ 	int err = 0, status;
+ 	char bin[PATH_MAX];
+ 	struct sigaction sa;
+@@ -212,8 +212,6 @@ int uc_mgr_exec(const char *prog)
+ 		prog = bin;
+ 	}
+ 
+-	maxfd = sysconf(_SC_OPEN_MAX);
+-
+ 	/*
+ 	 * block SIGCHLD signal
+ 	 * ignore SIGINT and SIGQUIT in parent
+@@ -262,8 +260,11 @@ int uc_mgr_exec(const char *prog)
+ #if HAVE_DECL_CLOSEFROM
+ 		closefrom(3);
+ #else
+-		for (f = 3; f < maxfd; f++)
+-			close(f);
++		{
++			pid_t maxfd = sysconf(_SC_OPEN_MAX);
++			for (f = 3; f < maxfd; f++)
++				close(f);
++		}
+ #endif
+ 
+ 		/* install default handlers for the forked process */
+-- 
+2.47.3
+
+
+From a6238053c4fa518b214f99d91a01b96c5ef6e3ca Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Tue, 9 Dec 2025 18:04:07 +0100
+Subject: [PATCH 03/43] conf: merge card specific contents per file (whole)
+ after parsing
+
+Unfortunately, mentioned fix caused a regression for items stored in one file.
+Merge the file contents after parsing not inside parsing process.
+
+BugLink: https://bugzilla.redhat.com/show_bug.cgi?id=2420645
+Fixes: eda76146 ("conf: fix load_for_all_cards() - do not merge the card specific contents")
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/src/conf.c b/src/conf.c
+index 49499ecdfc3c..b1ec9b382d66 100644
+--- a/src/conf.c
++++ b/src/conf.c
+@@ -4119,14 +4119,21 @@ static int config_filename_filter(const struct dirent64 *dirent)
+ static int config_file_open(snd_config_t *root, const char *filename, int merge)
+ {
+ 	snd_input_t *in;
++	snd_config_t *top;
+ 	int err;
+ 
+ 	err = snd_input_stdio_open(&in, filename, "r");
+ 	if (err >= 0) {
+-		if (merge)
++		if (merge) {
+ 			err = snd_config_load(root, in);
+-		else
+-			err = snd_config_load_override(root, in);
++		} else {
++			err = snd_config_top(&top);
++			if (err >= 0) {
++				err = snd_config_load(top, in);
++				if (err >= 0)
++					err = snd_config_merge(root, top, 1);
++			}
++		}
+ 		snd_input_close(in);
+ 		if (err < 0)
+ 			snd_error(CORE, "%s may be old or corrupted: consider to remove or fix it", filename);
+-- 
+2.47.3
+
+
+From 2f59398c83b8065fb9ff58939df3a9187746068e Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Tue, 9 Dec 2025 18:39:52 +0100
+Subject: [PATCH 04/43] conf: fix possible memory leak in config_file_open() -
+ error path
+
+Fixes: a6238053 ("conf: merge card specific contents per file (whole) after parsing")
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/conf.c b/src/conf.c
+index b1ec9b382d66..d90f6dc35d3b 100644
+--- a/src/conf.c
++++ b/src/conf.c
+@@ -4130,8 +4130,11 @@ static int config_file_open(snd_config_t *root, const char *filename, int merge)
+ 			err = snd_config_top(&top);
+ 			if (err >= 0) {
+ 				err = snd_config_load(top, in);
+-				if (err >= 0)
++				if (err >= 0) {
+ 					err = snd_config_merge(root, top, 1);
++					if (err < 0)
++						snd_config_delete(top);
++				}
+ 			}
+ 		}
+ 		snd_input_close(in);
+-- 
+2.47.3
+
+
+From 2ef8952b46a46b97a6df2f29bcd182f895ebf9e4 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:03:29 +0100
+Subject: [PATCH 05/43] Revert "conf: fix load_for_all_cards() - do not merge
+ the card specific contents"
+
+This reverts commit eda76146c5653ff1d5bc4b4c53f7a2d5ccc17da2.
+
+Also, revert additional related commits:
+
+  Revert "conf: fix possible memory leak in config_file_open() - error path"
+  This reverts commit 2f59398c83b8065fb9ff58939df3a9187746068e.
+
+  Revert "conf: merge card specific contents per file (whole) after parsing"
+  This reverts commit a6238053c4fa518b214f99d91a01b96c5ef6e3ca.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf.c | 42 ++++++++++++------------------------------
+ 1 file changed, 12 insertions(+), 30 deletions(-)
+
+diff --git a/src/conf.c b/src/conf.c
+index d90f6dc35d3b..fb9f0658a816 100644
+--- a/src/conf.c
++++ b/src/conf.c
+@@ -4116,27 +4116,14 @@ static int config_filename_filter(const struct dirent64 *dirent)
+ 	return 0;
+ }
+ 
+-static int config_file_open(snd_config_t *root, const char *filename, int merge)
++static int config_file_open(snd_config_t *root, const char *filename)
+ {
+ 	snd_input_t *in;
+-	snd_config_t *top;
+ 	int err;
+ 
+ 	err = snd_input_stdio_open(&in, filename, "r");
+ 	if (err >= 0) {
+-		if (merge) {
+-			err = snd_config_load(root, in);
+-		} else {
+-			err = snd_config_top(&top);
+-			if (err >= 0) {
+-				err = snd_config_load(top, in);
+-				if (err >= 0) {
+-					err = snd_config_merge(root, top, 1);
+-					if (err < 0)
+-						snd_config_delete(top);
+-				}
+-			}
+-		}
++		err = snd_config_load(root, in);
+ 		snd_input_close(in);
+ 		if (err < 0)
+ 			snd_error(CORE, "%s may be old or corrupted: consider to remove or fix it", filename);
+@@ -4146,7 +4133,7 @@ static int config_file_open(snd_config_t *root, const char *filename, int merge)
+ 	return err;
+ }
+ 
+-static int config_file_load(snd_config_t *root, const char *fn, int errors, int merge)
++static int config_file_load(snd_config_t *root, const char *fn, int errors)
+ {
+ 	struct stat64 st;
+ 	struct dirent64 **namelist;
+@@ -4159,7 +4146,7 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors, int
+ 		return 1;
+ 	}
+ 	if (!S_ISDIR(st.st_mode))
+-		return config_file_open(root, fn, merge);
++		return config_file_open(root, fn);
+ #ifndef DOC_HIDDEN
+ #if defined(_GNU_SOURCE) && \
+     !defined(__NetBSD__) && \
+@@ -4185,7 +4172,7 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors, int
+ 				snprintf(filename, sl, "%s/%s", fn, namelist[j]->d_name);
+ 				filename[sl-1] = '\0';
+ 
+-				err = config_file_open(root, filename, merge);
++				err = config_file_open(root, filename);
+ 				free(filename);
+ 			}
+ 			free(namelist[j]);
+@@ -4197,20 +4184,20 @@ static int config_file_load(snd_config_t *root, const char *fn, int errors, int
+ 	return 0;
+ }
+ 
+-static int config_file_load_user(snd_config_t *root, const char *fn, int errors, int merge)
++static int config_file_load_user(snd_config_t *root, const char *fn, int errors)
+ {
+ 	char *fn2;
+ 	int err;
+ 
+ 	err = snd_user_file(fn, &fn2);
+ 	if (err < 0)
+-		return config_file_load(root, fn, errors, merge);
+-	err = config_file_load(root, fn2, errors, merge);
++		return config_file_load(root, fn, errors);
++	err = config_file_load(root, fn2, errors);
+ 	free(fn2);
+ 	return err;
+ }
+ 
+-static int config_file_load_user_all(snd_config_t *_root, snd_config_t *_file, int errors, int merge)
++static int config_file_load_user_all(snd_config_t *_root, snd_config_t *_file, int errors)
+ {
+ 	snd_config_t *file = _file, *root = _root, *n;
+ 	char *name, *name2, *remain, *rname = NULL;
+@@ -4241,7 +4228,7 @@ static int config_file_load_user_all(snd_config_t *_root, snd_config_t *_file, i
+ 			*remain = '\0';
+ 			remain += 3;
+ 		}
+-		err = config_file_load_user(root, name2, errors, merge);
++		err = config_file_load_user(root, name2, errors);
+ 		if (err < 0)
+ 			goto _err;
+ 		if (err == 0)	/* first hit wins */
+@@ -4290,7 +4277,7 @@ int snd_config_hook_load(snd_config_t *root, snd_config_t *config, snd_config_t
+ {
+ 	snd_config_t *n;
+ 	snd_config_iterator_t i, next;
+-	int err, idx = 0, errors = 1, merge = 1, hit;
++	int err, idx = 0, errors = 1, hit;
+ 
+ 	assert(root && dst);
+ 	if ((err = snd_config_search(config, "errors", &n)) >= 0) {
+@@ -4300,10 +4287,6 @@ int snd_config_hook_load(snd_config_t *root, snd_config_t *config, snd_config_t
+ 			return errors;
+ 		}
+ 	}
+-	/* special case, we know the card number (may be multiple times) */
+-	if (private_data && snd_config_search(private_data, "integer", &n) >= 0) {
+-		merge = 0;
+-	}
+ 	if ((err = snd_config_search(config, "files", &n)) < 0) {
+ 		snd_error(CORE, "Unable to find field files in the pre-load section");
+ 		return -EINVAL;
+@@ -4316,7 +4299,6 @@ int snd_config_hook_load(snd_config_t *root, snd_config_t *config, snd_config_t
+ 		snd_error(CORE, "Invalid type for field filenames");
+ 		goto _err;
+ 	}
+-
+ 	do {
+ 		hit = 0;
+ 		snd_config_for_each(i, next, n) {
+@@ -4330,7 +4312,7 @@ int snd_config_hook_load(snd_config_t *root, snd_config_t *config, snd_config_t
+ 				goto _err;
+ 			}
+ 			if (i == idx) {
+-				err = config_file_load_user_all(root, n, errors, merge);
++				err = config_file_load_user_all(root, n, errors);
+ 				if (err < 0)
+ 					goto _err;
+ 				idx++;
+-- 
+2.47.3
+
+
+From 16ab43db6ed6f71424d5ad78e62f85baaeae5051 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 06/43] conf: USB-Audio: define pcm configuration block only
+ one time
+
+There may be multiple USB soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/USB-Audio.conf | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/conf/cards/USB-Audio.conf b/src/conf/cards/USB-Audio.conf
+index 2f6d2ee0af3d..1fc540e2eb4d 100644
+--- a/src/conf/cards/USB-Audio.conf
++++ b/src/conf/cards/USB-Audio.conf
+@@ -99,7 +99,7 @@ USB-Audio.pcm.iec958_2_device {
+ # device 0: analog output, digital input
+ # device 1: digital output, analog input
+ USB-Audio."AudioPhile".pcm.default "cards.USB-Audio.Audiophile USB (tm).pcm.default"
+-USB-Audio."Audiophile USB (tm)".pcm.default {
++USB-Audio."Audiophile USB (tm)".pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	type asym
+@@ -120,7 +120,7 @@ USB-Audio."Audiophile USB (tm)".pcm.default {
+ 	}
+ }
+ USB-Audio."AudioPhile".pcm.iec958 "cards.USB-Audio.Audiophile USB (tm).pcm.iec958"
+-USB-Audio."Audiophile USB (tm)".pcm.iec958 {
++USB-Audio."Audiophile USB (tm)".pcm.!iec958 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -142,7 +142,7 @@ USB-Audio."Audiophile USB (tm)".pcm.iec958 {
+ 
+ # For this card we can (and must to get IEC61937) set AES bits
+ USB-Audio."MicroII".pcm.iec958 "cards.USB-Audio.Audio Advantage MicroII.pcm.iec958"
+-USB-Audio."Audio Advantage MicroII".pcm.iec958 {
++USB-Audio."Audio Advantage MicroII".pcm.!iec958 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -180,7 +180,7 @@ USB-Audio."Audio Advantage MicroII".pcm.iec958 {
+ 
+ <confdir:pcm/front.conf>
+ 
+-USB-Audio.pcm.front.0 {
++USB-Audio.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func refer
+@@ -201,7 +201,7 @@ USB-Audio.pcm.front.0 {
+ 	}
+ }
+ 
+-USB-Audio.pcm.default {
++USB-Audio.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func refer
+@@ -249,14 +249,14 @@ USB-Audio.pcm.default {
+ 	}
+ }
+ 
+-USB-Audio.pcm.default_playback_dmix_yes {
++USB-Audio.pcm.!default_playback_dmix_yes {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func concat
+ 	strings [ "dmix:" $CARD ]
+ }
+ 
+-USB-Audio.pcm.default_playback_dmix_no {
++USB-Audio.pcm.!default_playback_dmix_no {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	type hw
+@@ -266,7 +266,7 @@ USB-Audio.pcm.default_playback_dmix_no {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-USB-Audio.pcm.surround40.0 {
++USB-Audio.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func refer
+@@ -301,7 +301,7 @@ USB-Audio.pcm.surround40.0 {
+ 	}
+ }
+ 
+-USB-Audio.pcm.surround40_default {
++USB-Audio.pcm.!surround40_default {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	type hw
+@@ -309,7 +309,7 @@ USB-Audio.pcm.surround40_default {
+ 	device 0
+ }
+ 
+-USB-Audio.pcm.surround40_six_channels {
++USB-Audio.pcm.!surround40_six_channels {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	type route
+@@ -327,7 +327,7 @@ USB-Audio.pcm.surround40_six_channels {
+ 	}
+ }
+ 
+-USB-Audio.pcm.surround40_two_stereo_devices {
++USB-Audio.pcm.!surround40_two_stereo_devices {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	type route
+@@ -369,7 +369,7 @@ USB-Audio.pcm.surround40_two_stereo_devices {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-USB-Audio.pcm.surround51.0 {
++USB-Audio.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func refer
+@@ -402,7 +402,7 @@ USB-Audio.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-USB-Audio.pcm.surround71.0 {
++USB-Audio.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD { type string }
+ 	@func refer
+@@ -437,7 +437,7 @@ USB-Audio.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-USB-Audio.pcm.iec958.0 {
++USB-Audio.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -472,7 +472,7 @@ USB-Audio.pcm.iec958.0 {
+ 	}
+ }
+ 
+-USB-Audio.pcm.iec958.1 {
++USB-Audio.pcm.iec958.!1 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+-- 
+2.47.3
+
+
+From 010b699c92a9a6ffdca1874cd2e3c6c054d212e0 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 07/43] conf: HDA-Intel: define pcm configuration block only
+ one time
+
+There may be multiple HDA-Intel soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/HDA-Intel.conf | 32 ++++++++++++++++----------------
+ 1 file changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/src/conf/cards/HDA-Intel.conf b/src/conf/cards/HDA-Intel.conf
+index 5451606f4d31..76775b9753df 100644
+--- a/src/conf/cards/HDA-Intel.conf
++++ b/src/conf/cards/HDA-Intel.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-HDA-Intel.pcm.front.0 {
++HDA-Intel.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -29,7 +29,7 @@ HDA-Intel.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-HDA-Intel.pcm.default {
++HDA-Intel.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -84,7 +84,7 @@ HDA-Intel.pcm.surround71.0 cards.HDA-Intel.pcm.front.0
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-HDA-Intel.pcm.iec958.0 {
++HDA-Intel.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+@@ -163,7 +163,7 @@ HDA-Intel.pcm.iec958.0 {
+ 	hint.device 1
+ }
+ 
+-HDA-Intel.pcm.hdmi.common {
++HDA-Intel.pcm.hdmi.!common {
+ 	@args [ CARD DEVICE CTLINDEX AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+@@ -212,7 +212,7 @@ HDA-Intel.pcm.hdmi.common {
+ 	hint.device $DEVICE
+ }
+ 
+-HDA-Intel.pcm.hdmi.0 {
++HDA-Intel.pcm.hdmi.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -235,7 +235,7 @@ HDA-Intel.pcm.hdmi.0 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.1 {
++HDA-Intel.pcm.hdmi.!1 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -258,7 +258,7 @@ HDA-Intel.pcm.hdmi.1 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.2 {
++HDA-Intel.pcm.hdmi.!2 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -281,7 +281,7 @@ HDA-Intel.pcm.hdmi.2 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.3 {
++HDA-Intel.pcm.hdmi.!3 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -304,7 +304,7 @@ HDA-Intel.pcm.hdmi.3 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.4 {
++HDA-Intel.pcm.hdmi.!4 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -327,7 +327,7 @@ HDA-Intel.pcm.hdmi.4 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.5 {
++HDA-Intel.pcm.hdmi.!5 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -350,7 +350,7 @@ HDA-Intel.pcm.hdmi.5 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.6 {
++HDA-Intel.pcm.hdmi.!6 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -373,7 +373,7 @@ HDA-Intel.pcm.hdmi.6 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.7 {
++HDA-Intel.pcm.hdmi.!7 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -396,7 +396,7 @@ HDA-Intel.pcm.hdmi.7 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.8 {
++HDA-Intel.pcm.hdmi.!8 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -419,7 +419,7 @@ HDA-Intel.pcm.hdmi.8 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.9 {
++HDA-Intel.pcm.hdmi.!9 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -442,7 +442,7 @@ HDA-Intel.pcm.hdmi.9 {
+ 	}
+ }
+ 
+-HDA-Intel.pcm.hdmi.10 {
++HDA-Intel.pcm.hdmi.!10 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD { type string }
+ 	@args.AES0 { type integer }
+@@ -467,7 +467,7 @@ HDA-Intel.pcm.hdmi.10 {
+ 
+ <confdir:pcm/modem.conf>
+ 
+-HDA-Intel.pcm.modem.0 {
++HDA-Intel.pcm.modem.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From d83af363f1fc17e2b3e7cf2a0f848722f6643a9a Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 08/43] conf: vc4-hdmi: define pcm configuration block only one
+ time
+
+There may be multiple vc4-hdmi soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+BugLink: https://github.com/alsa-project/alsa-lib/issues/488
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/vc4-hdmi.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conf/cards/vc4-hdmi.conf b/src/conf/cards/vc4-hdmi.conf
+index 0f313d82119b..7041d1850b3f 100644
+--- a/src/conf/cards/vc4-hdmi.conf
++++ b/src/conf/cards/vc4-hdmi.conf
+@@ -3,7 +3,7 @@
+ # subframe conversion
+ #
+ 
+-vc4-hdmi.pcm.hdmi.0 {
++vc4-hdmi.pcm.hdmi.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+@@ -50,7 +50,7 @@ vc4-hdmi.pcm.hdmi.0 {
+ }
+ 
+ # default with plug and softvol
+-vc4-hdmi.pcm.default {
++vc4-hdmi.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 3969e458124f6933e2f440c2b0b39b29de791a78 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 09/43] conf: AACI,ATIIXP: define pcm configuration block only
+ one time
+
+There may be multiple AACI,ATIIXP soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/AACI.conf         |  4 ++--
+ src/conf/cards/ATIIXP-MODEM.conf |  2 +-
+ src/conf/cards/ATIIXP-SPDMA.conf | 10 +++++-----
+ src/conf/cards/ATIIXP.conf       | 10 +++++-----
+ 4 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/conf/cards/AACI.conf b/src/conf/cards/AACI.conf
+index 748586a0726c..ff4778b4412f 100644
+--- a/src/conf/cards/AACI.conf
++++ b/src/conf/cards/AACI.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-AACI.pcm.front.0 {
++AACI.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -19,7 +19,7 @@ AACI.pcm.surround40.0 "cards.AACI.pcm.front.0"
+ 
+ <confdir:pcm/surround51.conf>
+ 
+-AACI.pcm.surround51.0 {
++AACI.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ATIIXP-MODEM.conf b/src/conf/cards/ATIIXP-MODEM.conf
+index 6e52af053cc8..1f69b735d84e 100644
+--- a/src/conf/cards/ATIIXP-MODEM.conf
++++ b/src/conf/cards/ATIIXP-MODEM.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/modem.conf>
+ 
+-ATIIXP-MODEM.pcm.modem.0 {
++ATIIXP-MODEM.pcm.modem.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ATIIXP-SPDMA.conf b/src/conf/cards/ATIIXP-SPDMA.conf
+index 42540d6817c0..12c40efc8f34 100644
+--- a/src/conf/cards/ATIIXP-SPDMA.conf
++++ b/src/conf/cards/ATIIXP-SPDMA.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ATIIXP-SPDMA.pcm.front.0 {
++ATIIXP-SPDMA.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ ATIIXP-SPDMA.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-ATIIXP.pcm.default {
++ATIIXP.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ ATIIXP.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ATIIXP-SPDMA.pcm.surround40.0 {
++ATIIXP-SPDMA.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -82,7 +82,7 @@ ATIIXP-SPDMA.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-ATIIXP-SPDMA.pcm.surround51.0 {
++ATIIXP-SPDMA.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -136,7 +136,7 @@ ATIIXP-SPDMA.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ATIIXP-SPDMA.pcm.iec958.0 {
++ATIIXP-SPDMA.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ATIIXP.conf b/src/conf/cards/ATIIXP.conf
+index c4d33ef34a68..13e01c488b31 100644
+--- a/src/conf/cards/ATIIXP.conf
++++ b/src/conf/cards/ATIIXP.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ATIIXP.pcm.front.0 {
++ATIIXP.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ ATIIXP.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-ATIIXP.pcm.default {
++ATIIXP.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ ATIIXP.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ATIIXP.pcm.surround40.0 {
++ATIIXP.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -82,7 +82,7 @@ ATIIXP.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-ATIIXP.pcm.surround51.0 {
++ATIIXP.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -136,7 +136,7 @@ ATIIXP.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ATIIXP.pcm.iec958.0 {
++ATIIXP.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From e5dbefdff1254fb66ffa82983c6fed08ba8e37df Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 10/43] conf: Audigy: define pcm configuration block only one
+ time
+
+There may be multiple Audigy soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Audigy.conf  | 12 ++++++------
+ src/conf/cards/Audigy2.conf | 16 ++++++++--------
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/conf/cards/Audigy.conf b/src/conf/cards/Audigy.conf
+index 42692cfde6f7..a353c6242def 100644
+--- a/src/conf/cards/Audigy.conf
++++ b/src/conf/cards/Audigy.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-Audigy.pcm.front.0 {
++Audigy.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -40,7 +40,7 @@ Audigy.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-Audigy.pcm.rear.0 {
++Audigy.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -68,7 +68,7 @@ Audigy.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-Audigy.pcm.center_lfe.0 {
++Audigy.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -107,7 +107,7 @@ Audigy.pcm.center_lfe.0 {
+ <confdir:pcm/surround41.conf>
+ <confdir:pcm/surround50.conf>
+ 
+-Audigy.pcm.surround40.0 {
++Audigy.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -143,7 +143,7 @@ Audigy.pcm.surround40.0 {
+ 
+ <confdir:pcm/surround51.conf>
+ 
+-Audigy.pcm.surround51.0 {
++Audigy.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -190,7 +190,7 @@ Audigy.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-Audigy.pcm.iec958.0 {
++Audigy.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/Audigy2.conf b/src/conf/cards/Audigy2.conf
+index 35126d23fd1c..3c15fd1d4e2e 100644
+--- a/src/conf/cards/Audigy2.conf
++++ b/src/conf/cards/Audigy2.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-Audigy2.pcm.front.0 {
++Audigy2.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -41,7 +41,7 @@ Audigy2.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-Audigy2.pcm.rear.0 {
++Audigy2.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -69,7 +69,7 @@ Audigy2.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-Audigy2.pcm.center_lfe.0 {
++Audigy2.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -105,7 +105,7 @@ Audigy2.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-Audigy2.pcm.side.0 {
++Audigy2.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -144,7 +144,7 @@ Audigy2.pcm.side.0 {
+ <confdir:pcm/surround41.conf>
+ <confdir:pcm/surround50.conf>
+ 
+-Audigy2.pcm.surround40.0 {
++Audigy2.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -180,7 +180,7 @@ Audigy2.pcm.surround40.0 {
+ 
+ <confdir:pcm/surround51.conf>
+ 
+-Audigy2.pcm.surround51.0 {
++Audigy2.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -227,7 +227,7 @@ Audigy2.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-Audigy2.pcm.surround71.0 {
++Audigy2.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -285,7 +285,7 @@ Audigy2.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-Audigy2.pcm.iec958.0 {
++Audigy2.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 7079887cd21077fe9569a0d910b11e40f7e5153d Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 11/43] conf: Aureon: define pcm configuration block only one
+ time
+
+There may be multiple Aureon soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Aureon51.conf | 14 +++++++-------
+ src/conf/cards/Aureon71.conf | 18 +++++++++---------
+ 2 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/src/conf/cards/Aureon51.conf b/src/conf/cards/Aureon51.conf
+index 07be4a77aa12..9bf346610c67 100644
+--- a/src/conf/cards/Aureon51.conf
++++ b/src/conf/cards/Aureon51.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-Aureon51.pcm.default {
++Aureon51.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ Aureon51.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-Aureon51.pcm.front.0 {
++Aureon51.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ Aureon51.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-Aureon51.pcm.rear.0 {
++Aureon51.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -51,7 +51,7 @@ Aureon51.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-Aureon51.pcm.center_lfe.0 {
++Aureon51.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -63,7 +63,7 @@ Aureon51.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-Aureon51.pcm.side.0 {
++Aureon51.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -91,7 +91,7 @@ Aureon51.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-Aureon51.pcm.surround51.0 {
++Aureon51.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -103,7 +103,7 @@ Aureon51.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-Aureon51.pcm.iec958.0 {
++Aureon51.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/Aureon71.conf b/src/conf/cards/Aureon71.conf
+index a43ce2cee5fa..f29bc2974448 100644
+--- a/src/conf/cards/Aureon71.conf
++++ b/src/conf/cards/Aureon71.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-Aureon71.pcm.default {
++Aureon71.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ Aureon71.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-Aureon71.pcm.front.0 {
++Aureon71.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ Aureon71.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-Aureon71.pcm.rear.0 {
++Aureon71.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -50,7 +50,7 @@ Aureon71.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-Aureon71.pcm.center_lfe.0 {
++Aureon71.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -63,7 +63,7 @@ Aureon71.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-Aureon71.pcm.side.0 {
++Aureon71.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -76,7 +76,7 @@ Aureon71.pcm.side.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-Aureon71.pcm.surround40.0 {
++Aureon71.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -91,7 +91,7 @@ Aureon71.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-Aureon71.pcm.surround51.0 {
++Aureon71.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -103,7 +103,7 @@ Aureon71.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-Aureon71.pcm.surround71.0 {
++Aureon71.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -114,7 +114,7 @@ Aureon71.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-Aureon71.pcm.iec958.0 {
++Aureon71.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From ea984c3a7d6fbc3613c72614f5fce18ad2c7f9b1 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 12/43] conf: AU88[123]0: define pcm configuration block only
+ one time
+
+There may be multiple AU88[123]0 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/AU8810.conf | 4 ++--
+ src/conf/cards/AU8820.conf | 2 +-
+ src/conf/cards/AU8830.conf | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/conf/cards/AU8810.conf b/src/conf/cards/AU8810.conf
+index 24d46c344780..6b596b68dbd4 100644
+--- a/src/conf/cards/AU8810.conf
++++ b/src/conf/cards/AU8810.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-AU8810.pcm.front.0 {
++AU8810.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ AU8810.pcm.front.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-AU8810.pcm.iec958.0 {
++AU8810.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/AU8820.conf b/src/conf/cards/AU8820.conf
+index 07890254112b..fe2cbc11b6f4 100644
+--- a/src/conf/cards/AU8820.conf
++++ b/src/conf/cards/AU8820.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-AU8820.pcm.front.0 {
++AU8820.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/AU8830.conf b/src/conf/cards/AU8830.conf
+index 39e66d50b0ac..9cd78b3e61fc 100644
+--- a/src/conf/cards/AU8830.conf
++++ b/src/conf/cards/AU8830.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-AU8830.pcm.front.0 {
++AU8830.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -19,7 +19,7 @@ AU8830.pcm.surround40.0 "cards.AU8830.pcm.front.0"
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-AU8830.pcm.iec958.0 {
++AU8830.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 68b8b435416ea734dda55c39f59bea90ea4b0dd6 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 13/43] conf: CA0106: define pcm configuration block only one
+ time
+
+There may be multiple CA0106 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/CA0106.conf | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/conf/cards/CA0106.conf b/src/conf/cards/CA0106.conf
+index 2f0eaf0afdc8..1fea79f5b408 100644
+--- a/src/conf/cards/CA0106.conf
++++ b/src/conf/cards/CA0106.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-CA0106.pcm.default {
++CA0106.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ CA0106.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-CA0106.pcm.front.0 {
++CA0106.pcm.front.!0 {
+ 	@args [ CARD  ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ CA0106.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-CA0106.pcm.rear.0 {
++CA0106.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -50,7 +50,7 @@ CA0106.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-CA0106.pcm.center_lfe.0 {
++CA0106.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -62,7 +62,7 @@ CA0106.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-CA0106.pcm.side.0 {
++CA0106.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -74,7 +74,7 @@ CA0106.pcm.side.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-CA0106.pcm.surround40.0 {
++CA0106.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -114,7 +114,7 @@ CA0106.pcm.surround40.0 {
+ <confdir:pcm/surround51.conf>
+ <confdir:pcm/surround71.conf>
+ 
+-CA0106.pcm.surround51.0 {
++CA0106.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -159,7 +159,7 @@ CA0106.pcm.surround51.0 {
+ 	]
+ }
+ 
+-CA0106.pcm.surround71.0 {
++CA0106.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -220,7 +220,7 @@ CA0106.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CA0106.pcm.iec958.0 {
++CA0106.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 041299ea39a7a8d2cb55cb8c2cb5a2e985d38fc3 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 14/43] conf: CMI8xxx: define pcm configuration block only one
+ time
+
+There may be multiple CMI8xxx soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/CMI8338-SWIEC.conf | 10 +++++-----
+ src/conf/cards/CMI8338.conf       | 10 +++++-----
+ src/conf/cards/CMI8738-MC6.conf   | 12 ++++++------
+ src/conf/cards/CMI8738-MC8.conf   | 14 +++++++-------
+ src/conf/cards/CMI8788.conf       | 12 ++++++------
+ 5 files changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/src/conf/cards/CMI8338-SWIEC.conf b/src/conf/cards/CMI8338-SWIEC.conf
+index af3a579f9e84..ca86c46651dd 100644
+--- a/src/conf/cards/CMI8338-SWIEC.conf
++++ b/src/conf/cards/CMI8338-SWIEC.conf
+@@ -5,7 +5,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CMI8338-SWIEC.pcm.front.0 {
++CMI8338-SWIEC.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ CMI8338-SWIEC.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-CMI8338-SWIEC.pcm.default {
++CMI8338-SWIEC.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -41,7 +41,7 @@ CMI8338-SWIEC.pcm.default {
+ 
+ # 2nd DAC
+ # FIXME: we need a volume attenuator for rear channel.
+-CMI8338-SWIEC.pcm.rear.0 {
++CMI8338-SWIEC.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -54,7 +54,7 @@ CMI8338-SWIEC.pcm.rear.0 {
+ <confdir:pcm/surround40.conf>
+ 
+ # for the old CM8738 with 2nd DAC for rear
+-CMI8338-SWIEC.pcm.surround40.0 {
++CMI8338-SWIEC.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -91,7 +91,7 @@ CMI8338-SWIEC.pcm.surround40.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CMI8338-SWIEC.pcm.iec958.0 {
++CMI8338-SWIEC.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/CMI8338.conf b/src/conf/cards/CMI8338.conf
+index 144fc9b0d75c..0f92ad0b9d5d 100644
+--- a/src/conf/cards/CMI8338.conf
++++ b/src/conf/cards/CMI8338.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CMI8338.pcm.front.0 {
++CMI8338.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ CMI8338.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-CMI8338.pcm.default {
++CMI8338.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -40,7 +40,7 @@ CMI8338.pcm.default {
+ 
+ # 2nd DAC
+ # FIXME: we need a volume attenuator for rear channel.
+-CMI8338.pcm.rear.0 {
++CMI8338.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -53,7 +53,7 @@ CMI8338.pcm.rear.0 {
+ <confdir:pcm/surround40.conf>
+ 
+ # for the old CM8738 with 2nd DAC for rear
+-CMI8338.pcm.surround40.0 {
++CMI8338.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -90,7 +90,7 @@ CMI8338.pcm.surround40.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CMI8338.pcm.iec958.0 {
++CMI8338.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/CMI8738-MC6.conf b/src/conf/cards/CMI8738-MC6.conf
+index edc67d44d96a..2b1c7d05e81d 100644
+--- a/src/conf/cards/CMI8738-MC6.conf
++++ b/src/conf/cards/CMI8738-MC6.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CMI8738-MC6.pcm.front.0 {
++CMI8738-MC6.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ CMI8738-MC6.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-CMI8738-MC6.pcm.default {
++CMI8738-MC6.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -40,7 +40,7 @@ CMI8738-MC6.pcm.default {
+ 
+ # 2nd DAC
+ # FIXME: we need a volume attenuator for rear channel.
+-CMI8738-MC6.pcm.rear.0 {
++CMI8738-MC6.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -52,7 +52,7 @@ CMI8738-MC6.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-CMI8738-MC6.pcm.surround40.0 {
++CMI8738-MC6.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -82,7 +82,7 @@ CMI8738-MC6.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-CMI8738-MC6.pcm.surround51.0 {
++CMI8738-MC6.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -109,7 +109,7 @@ CMI8738-MC6.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CMI8738-MC6.pcm.iec958.0 {
++CMI8738-MC6.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/CMI8738-MC8.conf b/src/conf/cards/CMI8738-MC8.conf
+index ddff75304bc3..96cb3f105796 100644
+--- a/src/conf/cards/CMI8738-MC8.conf
++++ b/src/conf/cards/CMI8738-MC8.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CMI8738-MC8.pcm.front.0 {
++CMI8738-MC8.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ CMI8738-MC8.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-CMI8738-MC8.pcm.default {
++CMI8738-MC8.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -53,7 +53,7 @@ CMI8738-MC8.pcm.default {
+ <confdir:pcm/rear.conf>
+ 
+ # 2nd DAC
+-CMI8738-MC8.pcm.rear.0 {
++CMI8738-MC8.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -72,7 +72,7 @@ CMI8738-MC8.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-CMI8738-MC8.pcm.surround40.0 {
++CMI8738-MC8.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -110,7 +110,7 @@ CMI8738-MC8.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-CMI8738-MC8.pcm.surround51.0 {
++CMI8738-MC8.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -144,7 +144,7 @@ CMI8738-MC8.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-CMI8738-MC8.pcm.surround71.0 {
++CMI8738-MC8.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -178,7 +178,7 @@ CMI8738-MC8.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CMI8738-MC8.pcm.iec958.0 {
++CMI8738-MC8.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/CMI8788.conf b/src/conf/cards/CMI8788.conf
+index edcb0c9ccc36..c4ad9f483475 100644
+--- a/src/conf/cards/CMI8788.conf
++++ b/src/conf/cards/CMI8788.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CMI8788.pcm.front.0 {
++CMI8788.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ CMI8788.pcm.front.0 {
+ }	
+ 
+ # default with dmix & dsnoop
+-CMI8788.pcm.default {
++CMI8788.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ CMI8788.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-CMI8788.pcm.surround40.0 {
++CMI8788.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -53,7 +53,7 @@ CMI8788.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-CMI8788.pcm.surround51.0 {
++CMI8788.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -65,7 +65,7 @@ CMI8788.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-CMI8788.pcm.surround71.0 {
++CMI8788.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -77,7 +77,7 @@ CMI8788.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CMI8788.pcm.iec958.0 {
++CMI8788.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 1e29ff18400e9b219159f9d0cb9aaf4be3b82efa Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 15/43] conf: CS46xx: define pcm configuration block only one
+ time
+
+There may be multiple CS46xx soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/CS46xx.conf | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/conf/cards/CS46xx.conf b/src/conf/cards/CS46xx.conf
+index b71c30aad514..478cbf3e0687 100644
+--- a/src/conf/cards/CS46xx.conf
++++ b/src/conf/cards/CS46xx.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-CS46xx.pcm.front.0 {
++CS46xx.pcm.front.!0 {
+ 	@args [ CARD  ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ CS46xx.pcm.front.0 {
+ 
+ # default with plughw
+ # CS46xx supports multi-playback
+-CS46xx.pcm.default {
++CS46xx.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -39,7 +39,7 @@ CS46xx.pcm.default {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-CS46xx.pcm.rear.0 {
++CS46xx.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -66,7 +66,7 @@ CS46xx.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-CS46xx.pcm.center_lfe.0 {
++CS46xx.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -78,7 +78,7 @@ CS46xx.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-CS46xx.pcm.surround40.0 {
++CS46xx.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -117,7 +117,7 @@ CS46xx.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-CS46xx.pcm.surround51.0 {
++CS46xx.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -164,7 +164,7 @@ CS46xx.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-CS46xx.pcm.iec958.0 {
++CS46xx.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 0ba7c2716567875d207b71b61e1205b855c7fd9c Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 12:12:47 +0100
+Subject: [PATCH 16/43] conf: Echo3G: define pcm configuration block only one
+ time
+
+There may be multiple Echo3G soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Echo_Echo3G.conf | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/conf/cards/Echo_Echo3G.conf b/src/conf/cards/Echo_Echo3G.conf
+index 766f13f77028..fb2a7b67ede7 100644
+--- a/src/conf/cards/Echo_Echo3G.conf
++++ b/src/conf/cards/Echo_Echo3G.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ <confdir:pcm/front.conf>
+-Echo_Echo3G.pcm.front.0 {
++Echo_Echo3G.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ Echo_Echo3G.pcm.front.0 {
+ }
+ 
+ <confdir:pcm/rear.conf>
+-Echo_Echo3G.pcm.rear.0 {
++Echo_Echo3G.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ Echo_Echo3G.pcm.rear.0 {
+ }
+ 
+ <confdir:pcm/center_lfe.conf>
+-Echo_Echo3G.pcm.center_lfe.0 {
++Echo_Echo3G.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -39,7 +39,7 @@ Echo_Echo3G.pcm.center_lfe.0 {
+ }
+ 
+ <confdir:pcm/side.conf>
+-Echo_Echo3G.pcm.side.0 {
++Echo_Echo3G.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -51,7 +51,7 @@ Echo_Echo3G.pcm.side.0 {
+ }
+ 
+ <confdir:pcm/surround40.conf>
+-Echo_Echo3G.pcm.surround40.0 {
++Echo_Echo3G.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -86,7 +86,7 @@ Echo_Echo3G.pcm.surround40.0 {
+ }
+ 
+ <confdir:pcm/surround41.conf>
+-Echo_Echo3G.pcm.surround41.0 {
++Echo_Echo3G.pcm.surround41.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -131,7 +131,7 @@ Echo_Echo3G.pcm.surround41.0 {
+ }
+ 
+ <confdir:pcm/surround50.conf>
+-Echo_Echo3G.pcm.surround50.0 {
++Echo_Echo3G.pcm.surround50.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -176,7 +176,7 @@ Echo_Echo3G.pcm.surround50.0 {
+ }
+ 
+ <confdir:pcm/surround51.conf>
+-Echo_Echo3G.pcm.surround51.0 {
++Echo_Echo3G.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -222,7 +222,7 @@ Echo_Echo3G.pcm.surround51.0 {
+ }
+ 
+ <confdir:pcm/surround71.conf>
+-Echo_Echo3G.pcm.surround71.0 {
++Echo_Echo3G.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -279,7 +279,7 @@ Echo_Echo3G.pcm.surround71.0 {
+ }
+ 
+ <confdir:pcm/iec958.conf>
+-Echo_Echo3G.pcm.iec958.0 {
++Echo_Echo3G.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 8c1005624495b61919080959088dc744d6d213ea Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:08:42 +0100
+Subject: [PATCH 17/43] conf: Aureon51: define pcm configuration block only one
+ time
+
+There may be multiple Aureon51 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Aureon51.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/conf/cards/Aureon51.conf b/src/conf/cards/Aureon51.conf
+index 9bf346610c67..db907f82abc4 100644
+--- a/src/conf/cards/Aureon51.conf
++++ b/src/conf/cards/Aureon51.conf
+@@ -76,7 +76,7 @@ Aureon51.pcm.side.!0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-Aureon51.pcm.surround40.0 {
++Aureon51.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From ed4884cbe179f42a10771584ebe9fff844b90d4f Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:08:42 +0100
+Subject: [PATCH 18/43] conf: EMU10K1: define pcm configuration block only one
+ time
+
+There may be multiple EMU10K1 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/EMU10K1.conf | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/conf/cards/EMU10K1.conf b/src/conf/cards/EMU10K1.conf
+index 430926c7daec..5ef12c035f49 100644
+--- a/src/conf/cards/EMU10K1.conf
++++ b/src/conf/cards/EMU10K1.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-EMU10K1.pcm.front.0 {
++EMU10K1.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -47,7 +47,7 @@ EMU10K1.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-EMU10K1.pcm.rear.0 {
++EMU10K1.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -78,7 +78,7 @@ EMU10K1.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-EMU10K1.pcm.center_lfe.0 {
++EMU10K1.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -143,7 +143,7 @@ EMU10K1.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-EMU10K1.pcm.surround40.0 {
++EMU10K1.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -182,7 +182,7 @@ EMU10K1.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-EMU10K1.pcm.surround51.0 {
++EMU10K1.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -229,7 +229,7 @@ EMU10K1.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-EMU10K1.pcm.iec958.0 {
++EMU10K1.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From dba724706a6eec70e52e31595b3ff1ec055bf50c Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:45 +0100
+Subject: [PATCH 19/43] conf: EMU10K1X: define pcm configuration block only one
+ time
+
+There may be multiple EMU10K1X soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/EMU10K1X.conf | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/conf/cards/EMU10K1X.conf b/src/conf/cards/EMU10K1X.conf
+index f742863679cb..334f897dbca7 100644
+--- a/src/conf/cards/EMU10K1X.conf
++++ b/src/conf/cards/EMU10K1X.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-EMU10K1X.pcm.default {
++EMU10K1X.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ EMU10K1X.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-EMU10K1X.pcm.front.0 {
++EMU10K1X.pcm.front.!0 {
+ 	@args [ CARD  ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ EMU10K1X.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-EMU10K1X.pcm.rear.0 {
++EMU10K1X.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -50,7 +50,7 @@ EMU10K1X.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-EMU10K1X.pcm.center_lfe.0 {
++EMU10K1X.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -62,7 +62,7 @@ EMU10K1X.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-EMU10K1X.pcm.surround40.0 {
++EMU10K1X.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -101,7 +101,7 @@ EMU10K1X.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-EMU10K1X.pcm.surround51.0 {
++EMU10K1X.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -148,7 +148,7 @@ EMU10K1X.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-EMU10K1X.pcm.iec958.0 {
++EMU10K1X.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 7cf26f603823cccd3e89eb57f459642c890b79af Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:45 +0100
+Subject: [PATCH 20/43] conf: ENS137[01]: define pcm configuration block only
+ one time
+
+There may be multiple ENS137[01] soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/ENS1370.conf |  8 ++++----
+ src/conf/cards/ENS1371.conf | 10 +++++-----
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/conf/cards/ENS1370.conf b/src/conf/cards/ENS1370.conf
+index 32e4782e8dbc..c65e224f3af0 100644
+--- a/src/conf/cards/ENS1370.conf
++++ b/src/conf/cards/ENS1370.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ENS1370.pcm.front.0 {
++ENS1370.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ ENS1370.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-ENS1370.pcm.default {
++ENS1370.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -39,7 +39,7 @@ ENS1370.pcm.default {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-ENS1370.pcm.rear.0 {
++ENS1370.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -71,7 +71,7 @@ ENS1370.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ENS1370.pcm.surround40.0 {
++ENS1370.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ENS1371.conf b/src/conf/cards/ENS1371.conf
+index a6df42513f5a..560fda9fe552 100644
+--- a/src/conf/cards/ENS1371.conf
++++ b/src/conf/cards/ENS1371.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ENS1371.pcm.front.0 {
++ENS1371.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ ENS1371.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-ENS1371.pcm.default {
++ENS1371.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ ENS1371.pcm.default {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-ENS1371.pcm.rear.0 {
++ENS1371.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -65,7 +65,7 @@ ENS1371.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ENS1371.pcm.surround40.0 {
++ENS1371.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -97,7 +97,7 @@ ENS1371.pcm.surround40.0 {
+                                         
+ <confdir:pcm/iec958.conf>
+ 
+-ENS1371.pcm.iec958.0 {
++ENS1371.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 001a2f3809865d071b53e802d4fbc89bb37a2fe1 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:45 +0100
+Subject: [PATCH 21/43] conf: ES1968: define pcm configuration block only one
+ time
+
+There may be multiple ES1968 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/ES1968.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/conf/cards/ES1968.conf b/src/conf/cards/ES1968.conf
+index a6ee11925e95..296baa131c1b 100644
+--- a/src/conf/cards/ES1968.conf
++++ b/src/conf/cards/ES1968.conf
+@@ -2,7 +2,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ES1968.pcm.front.0 {
++ES1968.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 2d5aa02738faf79895fa7457182810bee2ce7b90 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:46 +0100
+Subject: [PATCH 22/43] conf: FireWave: define pcm configuration block only one
+ time
+
+There may be multiple FireWave soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/FireWave.conf | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/conf/cards/FireWave.conf b/src/conf/cards/FireWave.conf
+index fcfc83ccfb19..786169f2d804 100644
+--- a/src/conf/cards/FireWave.conf
++++ b/src/conf/cards/FireWave.conf
+@@ -2,7 +2,7 @@
+ # Configuration for the Griffin FireWave Surround
+ #
+ 
+-FireWave.pcm.default {
++FireWave.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -16,7 +16,7 @@ FireWave.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-FireWave.pcm.front.0 {
++FireWave.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -30,7 +30,7 @@ FireWave.pcm.front.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-FireWave.pcm.surround51.0 {
++FireWave.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 9f46e1a5a48f863e38794aa5b7c350d291078924 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:46 +0100
+Subject: [PATCH 23/43] conf: FM801: define pcm configuration block only one
+ time
+
+There may be multiple FM801 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/FM801.conf | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/conf/cards/FM801.conf b/src/conf/cards/FM801.conf
+index 0ddf799cd029..14cfdbe88ca0 100644
+--- a/src/conf/cards/FM801.conf
++++ b/src/conf/cards/FM801.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-FM801.pcm.front.0 {
++FM801.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ FM801.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-FM801.pcm.default {
++FM801.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -49,7 +49,7 @@ FM801.pcm.surround51.0 "cards.FM801.pcm.front.0"
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-FM801.pcm.iec958.0 {
++FM801.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From ea939799299ff88c254344c7a89e86ffa159e5a7 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:46 +0100
+Subject: [PATCH 24/43] conf: FWSpeakers: define pcm configuration block only
+ one time
+
+There may be multiple FWSpeakers soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/FWSpeakers.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conf/cards/FWSpeakers.conf b/src/conf/cards/FWSpeakers.conf
+index cd6fa6050b3d..96ab5cb90350 100644
+--- a/src/conf/cards/FWSpeakers.conf
++++ b/src/conf/cards/FWSpeakers.conf
+@@ -2,7 +2,7 @@
+ # Configuration for the LaCie Firewire speakers
+ #
+ 
+-FWSpeakers.pcm.default {
++FWSpeakers.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -16,7 +16,7 @@ FWSpeakers.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-FWSpeakers.pcm.front.0 {
++FWSpeakers.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From a87570df7247d979eb5106ca549fa776e4c51ab3 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:47 +0100
+Subject: [PATCH 25/43] conf: GUS: define pcm configuration block only one time
+
+There may be multiple GUS soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/GUS.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/conf/cards/GUS.conf b/src/conf/cards/GUS.conf
+index d744c548a3f9..a1ccd0e92260 100644
+--- a/src/conf/cards/GUS.conf
++++ b/src/conf/cards/GUS.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-GUS.pcm.front.0 {
++GUS.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From dded72a687e8e8210b276ab13f4e26b63bfa782b Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:47 +0100
+Subject: [PATCH 26/43] conf: HdmiLpeAudio: define pcm configuration block only
+ one time
+
+There may be multiple HdmiLpeAudio soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/HdmiLpeAudio.conf | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/conf/cards/HdmiLpeAudio.conf b/src/conf/cards/HdmiLpeAudio.conf
+index a9104f43e9db..799946a26d22 100644
+--- a/src/conf/cards/HdmiLpeAudio.conf
++++ b/src/conf/cards/HdmiLpeAudio.conf
+@@ -2,7 +2,7 @@
+ # Configuration for the Intel HDMI/DP LPE audio
+ #
+ 
+-HdmiLpeAudio.pcm.hdmi.0 {
++HdmiLpeAudio.pcm.hdmi.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+@@ -39,7 +39,7 @@ HdmiLpeAudio.pcm.hdmi.0 {
+ 	}
+ }
+ 
+-HdmiLpeAudio.pcm.hdmi.1 {
++HdmiLpeAudio.pcm.hdmi.!1 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+@@ -77,7 +77,7 @@ HdmiLpeAudio.pcm.hdmi.1 {
+ 	}
+ }
+ 
+-HdmiLpeAudio.pcm.hdmi.2 {
++HdmiLpeAudio.pcm.hdmi.!2 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 1f52b57ff8f023b396b459407e60d8498c69f6e7 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:57 +0100
+Subject: [PATCH 27/43] conf: ICE17[12][24]: define pcm configuration block
+ only one time
+
+There may be multiple ICE17[12][24] soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/ICE1712.conf | 12 ++++++------
+ src/conf/cards/ICE1724.conf | 18 +++++++++---------
+ 2 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/conf/cards/ICE1712.conf b/src/conf/cards/ICE1712.conf
+index db62684e25f2..190d2c599052 100644
+--- a/src/conf/cards/ICE1712.conf
++++ b/src/conf/cards/ICE1712.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-ICE1712.pcm.default {
++ICE1712.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ ICE1712.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-ICE1712.pcm.front.0 {
++ICE1712.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -57,7 +57,7 @@ ICE1712.pcm.front.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ICE1712.pcm.surround40.0 {
++ICE1712.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -80,7 +80,7 @@ ICE1712.pcm.surround40.0 {
+ <confdir:pcm/surround51.conf>
+ <confdir:pcm/surround71.conf>
+ 
+-ICE1712.pcm.surround51.0 {
++ICE1712.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -99,7 +99,7 @@ ICE1712.pcm.surround51.0 {
+ 	slave.channels 10
+ }
+ 
+-ICE1712.pcm.surround71.0 {
++ICE1712.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -122,7 +122,7 @@ ICE1712.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ICE1712.pcm.iec958.0 {
++ICE1712.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ICE1724.conf b/src/conf/cards/ICE1724.conf
+index 61cac0132f07..16045dc439ac 100644
+--- a/src/conf/cards/ICE1724.conf
++++ b/src/conf/cards/ICE1724.conf
+@@ -3,7 +3,7 @@
+ #
+ 
+ # default with dmix & dsnoop
+-ICE1724.pcm.default {
++ICE1724.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ ICE1724.pcm.default {
+ 
+ <confdir:pcm/front.conf>
+ 
+-ICE1724.pcm.front.0 {
++ICE1724.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ ICE1724.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-ICE1724.pcm.rear.0 {
++ICE1724.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -51,7 +51,7 @@ ICE1724.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-ICE1724.pcm.center_lfe.0 {
++ICE1724.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -63,7 +63,7 @@ ICE1724.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-ICE1724.pcm.side.0 {
++ICE1724.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -76,7 +76,7 @@ ICE1724.pcm.side.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ICE1724.pcm.surround40.0 {
++ICE1724.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -100,7 +100,7 @@ ICE1724.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-ICE1724.pcm.surround51.0 {
++ICE1724.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -123,7 +123,7 @@ ICE1724.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-ICE1724.pcm.surround71.0 {
++ICE1724.pcm.surround71.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -148,7 +148,7 @@ ICE1724.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ICE1724.pcm.iec958.0 {
++ICE1724.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 99f1987a1e864523a7a423f1840ca6a76045d619 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:57 +0100
+Subject: [PATCH 28/43] conf: ICH,ICH4,ICH-MODEM: define pcm configuration
+ block only one time
+
+There may be multiple ICH soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/ICH-MODEM.conf |  2 +-
+ src/conf/cards/ICH.conf       | 10 +++++-----
+ src/conf/cards/ICH4.conf      | 10 +++++-----
+ 3 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/src/conf/cards/ICH-MODEM.conf b/src/conf/cards/ICH-MODEM.conf
+index b96b5aaf1ad0..855f3a960f32 100644
+--- a/src/conf/cards/ICH-MODEM.conf
++++ b/src/conf/cards/ICH-MODEM.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/modem.conf>
+ 
+-ICH-MODEM.pcm.modem.0 {
++ICH-MODEM.pcm.modem.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ICH.conf b/src/conf/cards/ICH.conf
+index 6fc9a5a236c1..c35c8d0209c0 100644
+--- a/src/conf/cards/ICH.conf
++++ b/src/conf/cards/ICH.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ICH.pcm.front.0 {
++ICH.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ ICH.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-ICH.pcm.default {
++ICH.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -52,7 +52,7 @@ ICH.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ICH.pcm.surround40.0 {
++ICH.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -103,7 +103,7 @@ ICH.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-ICH.pcm.surround51.0 {
++ICH.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -174,7 +174,7 @@ ICH.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ICH.pcm.iec958.0 {
++ICH.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/ICH4.conf b/src/conf/cards/ICH4.conf
+index 64ec883d9c73..11c85a6e08ae 100644
+--- a/src/conf/cards/ICH4.conf
++++ b/src/conf/cards/ICH4.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-ICH4.pcm.front.0 {
++ICH4.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ ICH4.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-ICH4.pcm.default {
++ICH4.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -52,7 +52,7 @@ ICH4.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-ICH4.pcm.surround40.0 {
++ICH4.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -103,7 +103,7 @@ ICH4.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-ICH4.pcm.surround51.0 {
++ICH4.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -164,7 +164,7 @@ ICH4.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-ICH4.pcm.iec958.0 {
++ICH4.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From ff4fb7f8c98157010c44f7335a32a09e9fc085d6 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:57 +0100
+Subject: [PATCH 29/43] conf: Loopback: define pcm configuration block only one
+ time
+
+There may be multiple Loopback soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Loopback.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conf/cards/Loopback.conf b/src/conf/cards/Loopback.conf
+index 1ae6d4536f87..21c8429c6b1a 100644
+--- a/src/conf/cards/Loopback.conf
++++ b/src/conf/cards/Loopback.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-Loopback.pcm.front.0 {
++Loopback.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ Loopback.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-Loopback.pcm.default {
++Loopback.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From de72d657281c043c8d48d23cb8da9b1c4c5f31de Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:17:57 +0100
+Subject: [PATCH 30/43] conf: Maestro3: define pcm configuration block only one
+ time
+
+There may be multiple Maestro3 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/Maestro3.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conf/cards/Maestro3.conf b/src/conf/cards/Maestro3.conf
+index 94323227d791..a8d89a486480 100644
+--- a/src/conf/cards/Maestro3.conf
++++ b/src/conf/cards/Maestro3.conf
+@@ -2,7 +2,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-Maestro3.pcm.front.0 {
++Maestro3.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -12,7 +12,7 @@ Maestro3.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-Maestro3.pcm.default {
++Maestro3.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From ebb5ab7d846e2702640a7d754127083412b15816 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:06 +0100
+Subject: [PATCH 31/43] conf: NFORCE: define pcm configuration block only one
+ time
+
+There may be multiple NFORCE soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/NFORCE.conf | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/conf/cards/NFORCE.conf b/src/conf/cards/NFORCE.conf
+index 64d15479291b..088cd8ce67bc 100644
+--- a/src/conf/cards/NFORCE.conf
++++ b/src/conf/cards/NFORCE.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-NFORCE.pcm.front.0 {
++NFORCE.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ NFORCE.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-NFORCE.pcm.default {
++NFORCE.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -52,7 +52,7 @@ NFORCE.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-NFORCE.pcm.surround40.0 {
++NFORCE.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -103,7 +103,7 @@ NFORCE.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-NFORCE.pcm.surround51.0 {
++NFORCE.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -174,7 +174,7 @@ NFORCE.pcm.surround51.0 {
+ 
+ <confdir:pcm/surround71.conf>
+ 
+-NFORCE.pcm.surround71.0 {
++NFORCE.pcm.surround71.!0 {
+     @args [ CARD ]
+     @args.CARD {
+         type string
+@@ -247,7 +247,7 @@ NFORCE.pcm.surround71.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-NFORCE.pcm.iec958.0 {
++NFORCE.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 3d636ff5309e3672c0acc784c9539af4396d2dfb Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:06 +0100
+Subject: [PATCH 32/43] conf: PC-Speaker: define pcm configuration block only
+ one time
+
+There may be multiple PC-Speaker soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/PC-Speaker.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/conf/cards/PC-Speaker.conf b/src/conf/cards/PC-Speaker.conf
+index c82654d837fa..8a40a13944ed 100644
+--- a/src/conf/cards/PC-Speaker.conf
++++ b/src/conf/cards/PC-Speaker.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-PC-Speaker.pcm.front.0 {
++PC-Speaker.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -23,7 +23,7 @@ PC-Speaker.pcm.front.0 {
+ }	
+ 
+ # default with dmix & null
+-PC-Speaker.pcm.default {
++PC-Speaker.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From a3028a492a641d5077640294d1fb655c4b4aa84a Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:06 +0100
+Subject: [PATCH 33/43] conf: PMac,PMacToonie: define pcm configuration block
+ only one time
+
+There may be multiple PMac soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/PMac.conf       | 4 ++--
+ src/conf/cards/PMacToonie.conf | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/conf/cards/PMac.conf b/src/conf/cards/PMac.conf
+index d1fdb17bfaf4..00f3bc892047 100644
+--- a/src/conf/cards/PMac.conf
++++ b/src/conf/cards/PMac.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-PMac.pcm.front.0 {
++PMac.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ PMac.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-PMac.pcm.default {
++PMac.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/PMacToonie.conf b/src/conf/cards/PMacToonie.conf
+index 1e0eb59cf253..aff1ea65c3c9 100644
+--- a/src/conf/cards/PMacToonie.conf
++++ b/src/conf/cards/PMacToonie.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-PMacToonie.pcm.front.0 {
++PMacToonie.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -21,7 +21,7 @@ PMacToonie.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol & dsnoop
+-PMacToonie.pcm.default {
++PMacToonie.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 8340b3c6b31a4e4c02f69bf36f3958d390c724b9 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:06 +0100
+Subject: [PATCH 34/43] conf: PS3: define pcm configuration block only one time
+
+There may be multiple PS3 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/PS3.conf | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/conf/cards/PS3.conf b/src/conf/cards/PS3.conf
+index b642f0dc1878..486d790cd4ef 100644
+--- a/src/conf/cards/PS3.conf
++++ b/src/conf/cards/PS3.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-PS3.pcm.front.0 {
++PS3.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -22,7 +22,7 @@ PS3.pcm.front.0 {
+ }	
+ 
+ # default with dmix+softvol
+-PS3.pcm.default {
++PS3.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -47,7 +47,7 @@ PS3.pcm.default {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-PS3.pcm.iec958.0 {
++PS3.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From f03528daf2ee177d2003b4d40824506f3a3558f4 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:15 +0100
+Subject: [PATCH 35/43] conf: RME96[35][26]: define pcm configuration block
+ only one time
+
+There may be multiple RME96[35][26] soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/RME9636.conf | 4 ++--
+ src/conf/cards/RME9652.conf | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/conf/cards/RME9636.conf b/src/conf/cards/RME9636.conf
+index e8dc5fadbaa2..17b3a1ab9b5c 100644
+--- a/src/conf/cards/RME9636.conf
++++ b/src/conf/cards/RME9636.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-RME9636.pcm.front.0 {
++RME9636.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -17,7 +17,7 @@ RME9636.pcm.front.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-RME9636.pcm.iec958.0 {
++RME9636.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/RME9652.conf b/src/conf/cards/RME9652.conf
+index 1147d81065aa..a11e42b22d30 100644
+--- a/src/conf/cards/RME9652.conf
++++ b/src/conf/cards/RME9652.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-RME9652.pcm.front.0 {
++RME9652.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -17,7 +17,7 @@ RME9652.pcm.front.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-RME9652.pcm.iec958.0 {
++RME9652.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 1cd87775c5d9d46e418dc67a4d9c93fe5104ee3f Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:15 +0100
+Subject: [PATCH 36/43] conf: SB-XFi: define pcm configuration block only one
+ time
+
+There may be multiple SB-XFi soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/SB-XFi.conf | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/conf/cards/SB-XFi.conf b/src/conf/cards/SB-XFi.conf
+index eb2218bfdcc7..9ce9c8ac2e1a 100644
+--- a/src/conf/cards/SB-XFi.conf
++++ b/src/conf/cards/SB-XFi.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-SB-XFi.pcm.front.0 {
++SB-XFi.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -16,7 +16,7 @@ SB-XFi.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-SB-XFi.pcm.rear.0 {
++SB-XFi.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -29,7 +29,7 @@ SB-XFi.pcm.rear.0 {
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+-SB-XFi.pcm.center_lfe.0 {
++SB-XFi.pcm.center_lfe.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -42,7 +42,7 @@ SB-XFi.pcm.center_lfe.0 {
+ 
+ <confdir:pcm/side.conf>
+ 
+-SB-XFi.pcm.side.0 {
++SB-XFi.pcm.side.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -66,7 +66,7 @@ SB-XFi.pcm.surround71.0 cards.SB-XFi.pcm.front.0
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-SB-XFi.pcm.iec958.0 {
++SB-XFi.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 51d75e5f072698d6ec03957cf87b735117f05ab4 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:15 +0100
+Subject: [PATCH 37/43] conf: SI7018: define pcm configuration block only one
+ time
+
+There may be multiple SI7018 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/SI7018.conf | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/conf/cards/SI7018.conf b/src/conf/cards/SI7018.conf
+index 02b8fc877ff3..33d190857f92 100644
+--- a/src/conf/cards/SI7018.conf
++++ b/src/conf/cards/SI7018.conf
+@@ -6,7 +6,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-SI7018.pcm.front.0 {
++SI7018.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -18,7 +18,7 @@ SI7018.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-SI7018.pcm.rear.0 {
++SI7018.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -44,7 +44,7 @@ SI7018.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-SI7018.pcm.surround40.0 {
++SI7018.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -83,7 +83,7 @@ SI7018.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-SI7018.pcm.surround51.0 {
++SI7018.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -130,7 +130,7 @@ SI7018.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-SI7018.pcm.iec958.0 {
++SI7018.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 4c74f3a568583744dddab01e4cce5a2e8f207067 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:15 +0100
+Subject: [PATCH 38/43] conf: TRID4DWAVENX: define pcm configuration block only
+ one time
+
+There may be multiple TRID4DWAVENX soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/TRID4DWAVENX.conf | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/conf/cards/TRID4DWAVENX.conf b/src/conf/cards/TRID4DWAVENX.conf
+index 717b14087279..5001297e12c7 100644
+--- a/src/conf/cards/TRID4DWAVENX.conf
++++ b/src/conf/cards/TRID4DWAVENX.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-TRID4DWAVENX.pcm.front.0 {
++TRID4DWAVENX.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -16,7 +16,7 @@ TRID4DWAVENX.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-TRID4DWAVENX.pcm.rear.0 {
++TRID4DWAVENX.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -56,7 +56,7 @@ TRID4DWAVENX.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-TRID4DWAVENX.pcm.surround40.0 {
++TRID4DWAVENX.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -92,7 +92,7 @@ TRID4DWAVENX.pcm.surround40.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-TRID4DWAVENX.pcm.iec958.0 {
++TRID4DWAVENX.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From d6b9d7e0bef5ca8a019881b06de7183528ec5bd5 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:22 +0100
+Subject: [PATCH 39/43] conf: VIA686A,VIA82xx: define pcm configuration block
+ only one time
+
+There may be multiple VIA soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/VIA686A.conf  |  6 +++---
+ src/conf/cards/VIA8233.conf  | 10 +++++-----
+ src/conf/cards/VIA8233A.conf | 10 +++++-----
+ src/conf/cards/VIA8237.conf  | 10 +++++-----
+ 4 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/src/conf/cards/VIA686A.conf b/src/conf/cards/VIA686A.conf
+index e4a06f236591..c53dd71bf0bc 100644
+--- a/src/conf/cards/VIA686A.conf
++++ b/src/conf/cards/VIA686A.conf
+@@ -7,7 +7,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VIA686A.pcm.front.0 {
++VIA686A.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -17,7 +17,7 @@ VIA686A.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-VIA686A.pcm.default {
++VIA686A.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -41,7 +41,7 @@ VIA686A.pcm.default {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VIA686A.pcm.iec958.0 {
++VIA686A.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/VIA8233.conf b/src/conf/cards/VIA8233.conf
+index 9ad321f713a9..3c25a11b396b 100644
+--- a/src/conf/cards/VIA8233.conf
++++ b/src/conf/cards/VIA8233.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VIA8233.pcm.front.0 {
++VIA8233.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ VIA8233.pcm.front.0 {
+ 
+ # default with softvol/dsnoop
+ # VIA8233 supports multi-playback
+-VIA8233.pcm.default {
++VIA8233.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -46,7 +46,7 @@ VIA8233.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-VIA8233.pcm.surround40.0 {
++VIA8233.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -91,7 +91,7 @@ VIA8233.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-VIA8233.pcm.surround51.0 {
++VIA8233.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -146,7 +146,7 @@ VIA8233.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VIA8233.pcm.iec958.0 {
++VIA8233.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/VIA8233A.conf b/src/conf/cards/VIA8233A.conf
+index 679fccf3d06f..c9e56e204630 100644
+--- a/src/conf/cards/VIA8233A.conf
++++ b/src/conf/cards/VIA8233A.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VIA8233A.pcm.front.0 {
++VIA8233A.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -14,7 +14,7 @@ VIA8233A.pcm.front.0 {
+ }	
+ 
+ # default with dmix/dsnoop
+-VIA8233A.pcm.default {
++VIA8233A.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -38,7 +38,7 @@ VIA8233A.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-VIA8233A.pcm.surround40.0 {
++VIA8233A.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -89,7 +89,7 @@ VIA8233A.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-VIA8233A.pcm.surround51.0 {
++VIA8233A.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -150,7 +150,7 @@ VIA8233A.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VIA8233A.pcm.iec958.0 {
++VIA8233A.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/VIA8237.conf b/src/conf/cards/VIA8237.conf
+index 29d8e00f6601..49fd6f2c82e4 100644
+--- a/src/conf/cards/VIA8237.conf
++++ b/src/conf/cards/VIA8237.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VIA8237.pcm.front.0 {
++VIA8237.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ VIA8237.pcm.front.0 {
+ 
+ # default with softvol/dsnoop
+ # VIA8237 supports multi-playback
+-VIA8237.pcm.default {
++VIA8237.pcm.!default {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -46,7 +46,7 @@ VIA8237.pcm.default {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-VIA8237.pcm.surround40.0 {
++VIA8237.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -84,7 +84,7 @@ VIA8237.pcm.surround40.0 {
+ <confdir:pcm/surround50.conf>
+ <confdir:pcm/surround51.conf>
+ 
+-VIA8237.pcm.surround51.0 {
++VIA8237.pcm.surround51.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -136,7 +136,7 @@ VIA8237.pcm.surround51.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VIA8237.pcm.iec958.0 {
++VIA8237.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 4bcd33ef9dc6d8439cc6573575907ecf89271fe2 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:22 +0100
+Subject: [PATCH 40/43] conf: VX222,VXPocket: define pcm configuration block
+ only one time
+
+There may be multiple VX soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/VX222.conf       | 4 ++--
+ src/conf/cards/VXPocket.conf    | 4 ++--
+ src/conf/cards/VXPocket440.conf | 8 ++++----
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/conf/cards/VX222.conf b/src/conf/cards/VX222.conf
+index 3385f25bde98..2c6e2297c74e 100644
+--- a/src/conf/cards/VX222.conf
++++ b/src/conf/cards/VX222.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VX222.pcm.front.0 {
++VX222.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ VX222.pcm.front.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VX222.pcm.iec958.0 {
++VX222.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/VXPocket.conf b/src/conf/cards/VXPocket.conf
+index fe44ff53a83d..90b1334788d5 100644
+--- a/src/conf/cards/VXPocket.conf
++++ b/src/conf/cards/VXPocket.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VXPocket.pcm.front.0 {
++VXPocket.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ VXPocket.pcm.front.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VXPocket.pcm.iec958.0 {
++VXPocket.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+diff --git a/src/conf/cards/VXPocket440.conf b/src/conf/cards/VXPocket440.conf
+index 197c2d6c5efd..87a0855a49ee 100644
+--- a/src/conf/cards/VXPocket440.conf
++++ b/src/conf/cards/VXPocket440.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-VXPocket440.pcm.front.0 {
++VXPocket440.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ VXPocket440.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-VXPocket440.pcm.rear.0 {
++VXPocket440.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ VXPocket440.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-VXPocket440.pcm.surround40.0 {
++VXPocket440.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -64,7 +64,7 @@ VXPocket440.pcm.surround40.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-VXPocket440.pcm.iec958.0 {
++VXPocket440.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 29fa26b4b5e0d3b7ab539b38d6604d83430bf70b Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:18:22 +0100
+Subject: [PATCH 41/43] conf: YMF744: define pcm configuration block only one
+ time
+
+There may be multiple YMF744 soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/YMF744.conf | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/conf/cards/YMF744.conf b/src/conf/cards/YMF744.conf
+index 84dbcbec3e8a..ad1f213214fb 100644
+--- a/src/conf/cards/YMF744.conf
++++ b/src/conf/cards/YMF744.conf
+@@ -4,7 +4,7 @@
+ 
+ <confdir:pcm/front.conf>
+ 
+-YMF744.pcm.front.0 {
++YMF744.pcm.front.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -15,7 +15,7 @@ YMF744.pcm.front.0 {
+ 
+ <confdir:pcm/rear.conf>
+ 
+-YMF744.pcm.rear.0 {
++YMF744.pcm.rear.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -27,7 +27,7 @@ YMF744.pcm.rear.0 {
+ 
+ <confdir:pcm/surround40.conf>
+ 
+-YMF744.pcm.surround40.0 {
++YMF744.pcm.surround40.!0 {
+ 	@args [ CARD ]
+ 	@args.CARD {
+ 		type string
+@@ -63,7 +63,7 @@ YMF744.pcm.surround40.0 {
+ 
+ <confdir:pcm/iec958.conf>
+ 
+-YMF744.pcm.iec958.0 {
++YMF744.pcm.iec958.!0 {
+ 	@args [ CARD AES0 AES1 AES2 AES3 ]
+ 	@args.CARD {
+ 		type string
+-- 
+2.47.3
+
+
+From 17ffe17f0356f333f8bf8734a02ab419bd19cd99 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:25:34 +0100
+Subject: [PATCH 42/43] conf: pistachio-card: define pcm configuration block
+ only one time
+
+There may be multiple pistachio-card soundcards in the system. Overwrite
+the PCM configurations when loaded multiple times.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/pistachio-card.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/conf/cards/pistachio-card.conf b/src/conf/cards/pistachio-card.conf
+index f68865eb0d81..15cfd60bd40b 100644
+--- a/src/conf/cards/pistachio-card.conf
++++ b/src/conf/cards/pistachio-card.conf
+@@ -29,7 +29,7 @@ https://docs.creatordev.io/ci40/guides/hardwaredocs/MIPS_Creator_cXT200_Technica
+ #   Subdevice #0: subdevice #0
+ #
+ 
+-pistachio-card.pcm.default{
++pistachio-card.pcm.!default {
+         @args [ CARD ]
+         @args.CARD {
+                 type string
+-- 
+2.47.3
+
+
+From f30c355278cf9c86420b49ab9efc7eee890b658c Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 10 Dec 2025 16:44:12 +0100
+Subject: [PATCH 43/43] conf: cards: unify whitespace - use tabs and remove
+ trailing spaces
+
+Convert leading spaces to tabs for consistent indentation,
+remove trailing whitespace from all lines, and normalize
+file endings across all card configuration files.
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/conf/cards/AACI.conf           |   2 +-
+ src/conf/cards/ATIIXP-SPDMA.conf   |   2 +-
+ src/conf/cards/ATIIXP.conf         |   2 +-
+ src/conf/cards/AU8810.conf         |   2 +-
+ src/conf/cards/AU8820.conf         |   2 +-
+ src/conf/cards/AU8830.conf         |   2 +-
+ src/conf/cards/Audigy.conf         |   6 +-
+ src/conf/cards/Audigy2.conf        |   4 +-
+ src/conf/cards/Aureon51.conf       |   8 +-
+ src/conf/cards/Aureon71.conf       |   8 +-
+ src/conf/cards/CA0106.conf         |   8 +-
+ src/conf/cards/CMI8338-SWIEC.conf  |   2 +-
+ src/conf/cards/CMI8338.conf        |   2 +-
+ src/conf/cards/CMI8738-MC6.conf    |   6 +-
+ src/conf/cards/CMI8738-MC8.conf    |   8 +-
+ src/conf/cards/CMI8788.conf        |   8 +-
+ src/conf/cards/CS46xx.conf         |   6 +-
+ src/conf/cards/EMU10K1.conf        |   6 +-
+ src/conf/cards/EMU10K1X.conf       |   6 +-
+ src/conf/cards/ENS1370.conf        |   4 +-
+ src/conf/cards/ENS1371.conf        |  10 +--
+ src/conf/cards/ES1968.conf         |   2 +-
+ src/conf/cards/FM801.conf          |   2 +-
+ src/conf/cards/GUS.conf            |   2 +-
+ src/conf/cards/HDA-Intel.conf      |   2 +-
+ src/conf/cards/ICE1712.conf        |   4 +-
+ src/conf/cards/ICE1724.conf        |  10 +--
+ src/conf/cards/ICH.conf            |   2 +-
+ src/conf/cards/ICH4.conf           |   2 +-
+ src/conf/cards/Loopback.conf       |   2 +-
+ src/conf/cards/Maestro3.conf       |   3 +-
+ src/conf/cards/NFORCE.conf         | 138 ++++++++++++++---------------
+ src/conf/cards/PC-Speaker.conf     |   3 +-
+ src/conf/cards/PMac.conf           |   2 +-
+ src/conf/cards/PMacToonie.conf     |   2 +-
+ src/conf/cards/PS3.conf            |   6 +-
+ src/conf/cards/RME9636.conf        |   2 +-
+ src/conf/cards/RME9652.conf        |   2 +-
+ src/conf/cards/SB-XFi.conf         |   8 +-
+ src/conf/cards/SI7018.conf         |   6 +-
+ src/conf/cards/TRID4DWAVENX.conf   |   4 +-
+ src/conf/cards/USB-Audio.conf      |   2 +-
+ src/conf/cards/VIA686A.conf        |   2 +-
+ src/conf/cards/VIA8233.conf        |   2 +-
+ src/conf/cards/VIA8233A.conf       |   2 +-
+ src/conf/cards/VIA8237.conf        |   2 +-
+ src/conf/cards/VX222.conf          |   2 +-
+ src/conf/cards/VXPocket.conf       |   2 +-
+ src/conf/cards/VXPocket440.conf    |   2 +-
+ src/conf/cards/YMF744.conf         |   4 +-
+ src/conf/cards/pistachio-card.conf |  54 +++++------
+ 51 files changed, 190 insertions(+), 192 deletions(-)
+
+diff --git a/src/conf/cards/AACI.conf b/src/conf/cards/AACI.conf
+index ff4778b4412f..2f036dd67125 100644
+--- a/src/conf/cards/AACI.conf
++++ b/src/conf/cards/AACI.conf
+@@ -11,7 +11,7 @@ AACI.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}       
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/ATIIXP-SPDMA.conf b/src/conf/cards/ATIIXP-SPDMA.conf
+index 12c40efc8f34..6d7344e84694 100644
+--- a/src/conf/cards/ATIIXP-SPDMA.conf
++++ b/src/conf/cards/ATIIXP-SPDMA.conf
+@@ -11,7 +11,7 @@ ATIIXP-SPDMA.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ ATIIXP.pcm.!default {
+diff --git a/src/conf/cards/ATIIXP.conf b/src/conf/cards/ATIIXP.conf
+index 13e01c488b31..d2736c3c4e4f 100644
+--- a/src/conf/cards/ATIIXP.conf
++++ b/src/conf/cards/ATIIXP.conf
+@@ -11,7 +11,7 @@ ATIIXP.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ ATIIXP.pcm.!default {
+diff --git a/src/conf/cards/AU8810.conf b/src/conf/cards/AU8810.conf
+index 6b596b68dbd4..46de6dbcb3da 100644
+--- a/src/conf/cards/AU8810.conf
++++ b/src/conf/cards/AU8810.conf
+@@ -11,7 +11,7 @@ AU8810.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/AU8820.conf b/src/conf/cards/AU8820.conf
+index fe2cbc11b6f4..8e262a6feed5 100644
+--- a/src/conf/cards/AU8820.conf
++++ b/src/conf/cards/AU8820.conf
+@@ -11,4 +11,4 @@ AU8820.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+diff --git a/src/conf/cards/AU8830.conf b/src/conf/cards/AU8830.conf
+index 9cd78b3e61fc..a31d8a577826 100644
+--- a/src/conf/cards/AU8830.conf
++++ b/src/conf/cards/AU8830.conf
+@@ -11,7 +11,7 @@ AU8830.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/Audigy.conf b/src/conf/cards/Audigy.conf
+index a353c6242def..d2b54d3bfee7 100644
+--- a/src/conf/cards/Audigy.conf
++++ b/src/conf/cards/Audigy.conf
+@@ -36,7 +36,7 @@ Audigy.pcm.front.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -64,7 +64,7 @@ Audigy.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -100,7 +100,7 @@ Audigy.pcm.center_lfe.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround40.conf>
+diff --git a/src/conf/cards/Audigy2.conf b/src/conf/cards/Audigy2.conf
+index 3c15fd1d4e2e..47d756806a64 100644
+--- a/src/conf/cards/Audigy2.conf
++++ b/src/conf/cards/Audigy2.conf
+@@ -37,7 +37,7 @@ Audigy2.pcm.front.!0 {
+ 
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -65,7 +65,7 @@ Audigy2.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+diff --git a/src/conf/cards/Aureon51.conf b/src/conf/cards/Aureon51.conf
+index db907f82abc4..da7e26dc1e09 100644
+--- a/src/conf/cards/Aureon51.conf
++++ b/src/conf/cards/Aureon51.conf
+@@ -34,7 +34,7 @@ Aureon51.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -47,7 +47,7 @@ Aureon51.pcm.rear.!0 {
+ 	card $CARD
+ 	device 2
+ 	subdevice 1
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -59,7 +59,7 @@ Aureon51.pcm.center_lfe.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/side.conf>
+ 
+@@ -84,7 +84,7 @@ Aureon51.pcm.surround40.!0 {
+ 	type hw
+ 	card $CARD
+ 	channels 4
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+diff --git a/src/conf/cards/Aureon71.conf b/src/conf/cards/Aureon71.conf
+index f29bc2974448..98e65ab0e75e 100644
+--- a/src/conf/cards/Aureon71.conf
++++ b/src/conf/cards/Aureon71.conf
+@@ -34,7 +34,7 @@ Aureon71.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -46,7 +46,7 @@ Aureon71.pcm.rear.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -59,7 +59,7 @@ Aureon71.pcm.center_lfe.!0 {
+ 	card $CARD
+ 	device 2
+ 	subdevice 1
+-}	
++}
+ 
+ <confdir:pcm/side.conf>
+ 
+@@ -84,7 +84,7 @@ Aureon71.pcm.surround40.!0 {
+ 	type hw
+ 	card $CARD
+ 	channels 4
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+diff --git a/src/conf/cards/CA0106.conf b/src/conf/cards/CA0106.conf
+index 1fea79f5b408..bf90c3c6cb69 100644
+--- a/src/conf/cards/CA0106.conf
++++ b/src/conf/cards/CA0106.conf
+@@ -34,7 +34,7 @@ CA0106.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -46,7 +46,7 @@ CA0106.pcm.rear.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 1
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -58,7 +58,7 @@ CA0106.pcm.center_lfe.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/side.conf>
+ 
+@@ -70,7 +70,7 @@ CA0106.pcm.side.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 3
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/CMI8338-SWIEC.conf b/src/conf/cards/CMI8338-SWIEC.conf
+index ca86c46651dd..2a9b777c38a4 100644
+--- a/src/conf/cards/CMI8338-SWIEC.conf
++++ b/src/conf/cards/CMI8338-SWIEC.conf
+@@ -12,7 +12,7 @@ CMI8338-SWIEC.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ CMI8338-SWIEC.pcm.!default {
+diff --git a/src/conf/cards/CMI8338.conf b/src/conf/cards/CMI8338.conf
+index 0f92ad0b9d5d..8bd1159d18c4 100644
+--- a/src/conf/cards/CMI8338.conf
++++ b/src/conf/cards/CMI8338.conf
+@@ -11,7 +11,7 @@ CMI8338.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ CMI8338.pcm.!default {
+diff --git a/src/conf/cards/CMI8738-MC6.conf b/src/conf/cards/CMI8738-MC6.conf
+index 2b1c7d05e81d..6bb17712d453 100644
+--- a/src/conf/cards/CMI8738-MC6.conf
++++ b/src/conf/cards/CMI8738-MC6.conf
+@@ -11,7 +11,7 @@ CMI8738-MC6.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ CMI8738-MC6.pcm.!default {
+@@ -75,7 +75,7 @@ CMI8738-MC6.pcm.surround40.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+@@ -105,7 +105,7 @@ CMI8738-MC6.pcm.surround51.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/CMI8738-MC8.conf b/src/conf/cards/CMI8738-MC8.conf
+index 96cb3f105796..239014d42735 100644
+--- a/src/conf/cards/CMI8738-MC8.conf
++++ b/src/conf/cards/CMI8738-MC8.conf
+@@ -18,7 +18,7 @@ CMI8738-MC8.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ CMI8738-MC8.pcm.!default {
+@@ -102,7 +102,7 @@ CMI8738-MC8.pcm.surround40.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ 
+ <confdir:pcm/surround21.conf>
+@@ -140,7 +140,7 @@ CMI8738-MC8.pcm.surround51.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround71.conf>
+ 
+@@ -174,7 +174,7 @@ CMI8738-MC8.pcm.surround71.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/CMI8788.conf b/src/conf/cards/CMI8788.conf
+index c4ad9f483475..32ab8fb48a67 100644
+--- a/src/conf/cards/CMI8788.conf
++++ b/src/conf/cards/CMI8788.conf
+@@ -11,7 +11,7 @@ CMI8788.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix & dsnoop
+ CMI8788.pcm.!default {
+@@ -46,7 +46,7 @@ CMI8788.pcm.surround40.!0 {
+ 	type hw
+ 	card $CARD
+ 	channels 4
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+@@ -61,7 +61,7 @@ CMI8788.pcm.surround51.!0 {
+ 	type hw
+ 	card $CARD
+ 	channels 6
+-}	
++}
+ 
+ <confdir:pcm/surround71.conf>
+ 
+@@ -73,7 +73,7 @@ CMI8788.pcm.surround71.!0 {
+ 	type hw
+ 	card $CARD
+ 	channels 8
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/CS46xx.conf b/src/conf/cards/CS46xx.conf
+index 478cbf3e0687..ad6a22189c86 100644
+--- a/src/conf/cards/CS46xx.conf
++++ b/src/conf/cards/CS46xx.conf
+@@ -11,7 +11,7 @@ CS46xx.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with plughw
+ # CS46xx supports multi-playback
+@@ -62,7 +62,7 @@ CS46xx.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -74,7 +74,7 @@ CS46xx.pcm.center_lfe.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 3
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/EMU10K1.conf b/src/conf/cards/EMU10K1.conf
+index 5ef12c035f49..c2dc7590d3a7 100644
+--- a/src/conf/cards/EMU10K1.conf
++++ b/src/conf/cards/EMU10K1.conf
+@@ -43,7 +43,7 @@ EMU10K1.pcm.front.!0 {
+ 		type hw
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -74,7 +74,7 @@ EMU10K1.pcm.rear.!0 {
+ 			]
+ 		}
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -139,7 +139,7 @@ EMU10K1.pcm.center_lfe.!0 {
+ 			]
+ 		}
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/EMU10K1X.conf b/src/conf/cards/EMU10K1X.conf
+index 334f897dbca7..7d73ba44cd59 100644
+--- a/src/conf/cards/EMU10K1X.conf
++++ b/src/conf/cards/EMU10K1X.conf
+@@ -34,7 +34,7 @@ EMU10K1X.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -46,7 +46,7 @@ EMU10K1X.pcm.rear.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 1
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -58,7 +58,7 @@ EMU10K1X.pcm.center_lfe.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/ENS1370.conf b/src/conf/cards/ENS1370.conf
+index c65e224f3af0..446c2f7dbd14 100644
+--- a/src/conf/cards/ENS1370.conf
++++ b/src/conf/cards/ENS1370.conf
+@@ -12,7 +12,7 @@ ENS1370.pcm.front.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 1
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ ENS1370.pcm.!default {
+@@ -67,7 +67,7 @@ ENS1370.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/ENS1371.conf b/src/conf/cards/ENS1371.conf
+index 560fda9fe552..549fd7c9ab81 100644
+--- a/src/conf/cards/ENS1371.conf
++++ b/src/conf/cards/ENS1371.conf
+@@ -11,7 +11,7 @@ ENS1371.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ ENS1371.pcm.!default {
+@@ -61,7 +61,7 @@ ENS1371.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+@@ -78,11 +78,11 @@ ENS1371.pcm.surround40.!0 {
+ 				strings [ "cards.ENS1371.pcm.front.0:CARD=" $CARD ]
+ 			}
+ 			channels 2
+-                }
++		}
+ 		{
+ 			pcm {
+ 				@func concat
+-                                strings [ "cards.ENS1371.pcm.rear.0:CARD=" $CARD ]
++				strings [ "cards.ENS1371.pcm.rear.0:CARD=" $CARD ]
+ 			}
+ 			channels 2
+ 		}
+@@ -94,7 +94,7 @@ ENS1371.pcm.surround40.!0 {
+ 		{ slave 1 channel 1 }
+ 	]
+ }
+-                                        
++
+ <confdir:pcm/iec958.conf>
+ 
+ ENS1371.pcm.iec958.!0 {
+diff --git a/src/conf/cards/ES1968.conf b/src/conf/cards/ES1968.conf
+index 296baa131c1b..83dcf93bfe8a 100644
+--- a/src/conf/cards/ES1968.conf
++++ b/src/conf/cards/ES1968.conf
+@@ -9,4 +9,4 @@ ES1968.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+diff --git a/src/conf/cards/FM801.conf b/src/conf/cards/FM801.conf
+index 14cfdbe88ca0..b8bed781ffad 100644
+--- a/src/conf/cards/FM801.conf
++++ b/src/conf/cards/FM801.conf
+@@ -11,7 +11,7 @@ FM801.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ FM801.pcm.!default {
+diff --git a/src/conf/cards/GUS.conf b/src/conf/cards/GUS.conf
+index a1ccd0e92260..42a612a6f295 100644
+--- a/src/conf/cards/GUS.conf
++++ b/src/conf/cards/GUS.conf
+@@ -16,4 +16,4 @@ GUS.pcm.front.!0 {
+ 		type hw
+ 		card $CARD
+ 	}
+-}	
++}
+diff --git a/src/conf/cards/HDA-Intel.conf b/src/conf/cards/HDA-Intel.conf
+index 76775b9753df..cacd2815994b 100644
+--- a/src/conf/cards/HDA-Intel.conf
++++ b/src/conf/cards/HDA-Intel.conf
+@@ -26,7 +26,7 @@ HDA-Intel.pcm.front.!0 {
+ 		type hw
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ HDA-Intel.pcm.!default {
+diff --git a/src/conf/cards/ICE1712.conf b/src/conf/cards/ICE1712.conf
+index 190d2c599052..08b84f303fb2 100644
+--- a/src/conf/cards/ICE1712.conf
++++ b/src/conf/cards/ICE1712.conf
+@@ -53,7 +53,7 @@ ICE1712.pcm.front.!0 {
+ 		}
+ 		slave.channels 12
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+@@ -72,7 +72,7 @@ ICE1712.pcm.surround40.!0 {
+ 		card $CARD
+ 	}
+ 	slave.channels 10
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+diff --git a/src/conf/cards/ICE1724.conf b/src/conf/cards/ICE1724.conf
+index 16045dc439ac..678df41d1540 100644
+--- a/src/conf/cards/ICE1724.conf
++++ b/src/conf/cards/ICE1724.conf
+@@ -34,7 +34,7 @@ ICE1724.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -47,7 +47,7 @@ ICE1724.pcm.rear.!0 {
+ 	card $CARD
+ 	device 2
+ 	subdevice 1
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -59,7 +59,7 @@ ICE1724.pcm.center_lfe.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/side.conf>
+ 
+@@ -93,7 +93,7 @@ ICE1724.pcm.surround40.!0 {
+ 			card $CARD
+ 		}
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround41.conf>
+@@ -114,7 +114,7 @@ ICE1724.pcm.surround51.!0 {
+ 	ttable.5.3 1
+ 	slave {
+ 		channels 6
+-                pcm {
++		pcm {
+ 			type hw
+ 	 		card $CARD
+ 		}
+diff --git a/src/conf/cards/ICH.conf b/src/conf/cards/ICH.conf
+index c35c8d0209c0..573b9e265d14 100644
+--- a/src/conf/cards/ICH.conf
++++ b/src/conf/cards/ICH.conf
+@@ -18,7 +18,7 @@ ICH.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ ICH.pcm.!default {
+diff --git a/src/conf/cards/ICH4.conf b/src/conf/cards/ICH4.conf
+index 11c85a6e08ae..5641c9c4ed2e 100644
+--- a/src/conf/cards/ICH4.conf
++++ b/src/conf/cards/ICH4.conf
+@@ -18,7 +18,7 @@ ICH4.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ ICH4.pcm.!default {
+diff --git a/src/conf/cards/Loopback.conf b/src/conf/cards/Loopback.conf
+index 21c8429c6b1a..3911aed535ac 100644
+--- a/src/conf/cards/Loopback.conf
++++ b/src/conf/cards/Loopback.conf
+@@ -18,7 +18,7 @@ Loopback.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ Loopback.pcm.!default {
+diff --git a/src/conf/cards/Maestro3.conf b/src/conf/cards/Maestro3.conf
+index a8d89a486480..c0e3da319f83 100644
+--- a/src/conf/cards/Maestro3.conf
++++ b/src/conf/cards/Maestro3.conf
+@@ -9,7 +9,7 @@ Maestro3.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ Maestro3.pcm.!default {
+@@ -35,4 +35,3 @@ Maestro3.pcm.!default {
+ 		}
+ 	}
+ }
+-
+diff --git a/src/conf/cards/NFORCE.conf b/src/conf/cards/NFORCE.conf
+index 088cd8ce67bc..aeef6b40d736 100644
+--- a/src/conf/cards/NFORCE.conf
++++ b/src/conf/cards/NFORCE.conf
+@@ -18,7 +18,7 @@ NFORCE.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ NFORCE.pcm.!default {
+@@ -175,74 +175,74 @@ NFORCE.pcm.surround51.!0 {
+ <confdir:pcm/surround71.conf>
+ 
+ NFORCE.pcm.surround71.!0 {
+-    @args [ CARD ]
+-    @args.CARD {
+-        type string
+-    }
+-    type softvol
+-    slave.pcm {
+-        type route
+-        ttable.0.0 1
+-        ttable.1.1 1
+-        ttable.2.4 1
+-        ttable.3.5 1
+-        ttable.4.2 1
+-        ttable.5.3 1
+-        ttable.6.6 1
+-        ttable.7.7 1
+-        slave.pcm {
+-            type hooks
+-            slave.pcm {
+-                type hw
+-                card $CARD
+-                device 0
+-            }
+-            hooks.0 {
+-                type ctl_elems
+-                hook_args [
+-                {
+-                    name "Channel Mode"
+-                    preserve true
+-                    value "8ch"
+-                    lock true
+-                    optional true
+-                }
+-                # for old drivers
+-                {
+-                    name "Line-In As Surround"
+-                    preserve true
+-                    value true
+-                    optional true
+-                }
+-                {
+-                    name "Mic As Center/LFE"
+-                    preserve true
+-                    value true
+-                    optional true
+-                }
+-                {
+-                    name "Surround Down Mix"
+-                    preserve true
+-                    value off
+-                    lock true
+-                    optional true
+-                }
+-                {
+-                    name "Center/LFE Down Mix"
+-                    preserve true
+-                    value off
+-                    lock true
+-                    optional true
+-                }
+-                ]
+-            }
+-        }
+-        slave.channels 8
+-    }
+-    control {
+-        name "PCM Playback Volume"
+-        card $CARD
+-    }
++	@args [ CARD ]
++	@args.CARD {
++		type string
++	}
++	type softvol
++	slave.pcm {
++		type route
++		ttable.0.0 1
++		ttable.1.1 1
++		ttable.2.4 1
++		ttable.3.5 1
++		ttable.4.2 1
++		ttable.5.3 1
++		ttable.6.6 1
++		ttable.7.7 1
++		slave.pcm {
++			type hooks
++			slave.pcm {
++				type hw
++				card $CARD
++				device 0
++			}
++			hooks.0 {
++				type ctl_elems
++				hook_args [
++				{
++					name "Channel Mode"
++					preserve true
++					value "8ch"
++					lock true
++					optional true
++				}
++				# for old drivers
++				{
++					name "Line-In As Surround"
++					preserve true
++					value true
++					optional true
++				}
++				{
++					name "Mic As Center/LFE"
++					preserve true
++					value true
++					optional true
++				}
++				{
++					name "Surround Down Mix"
++					preserve true
++					value off
++					lock true
++					optional true
++				}
++				{
++					name "Center/LFE Down Mix"
++					preserve true
++					value off
++					lock true
++					optional true
++				}
++				]
++			}
++		}
++		slave.channels 8
++	}
++	control {
++		name "PCM Playback Volume"
++		card $CARD
++	}
+ }
+ 
+ <confdir:pcm/iec958.conf>
+diff --git a/src/conf/cards/PC-Speaker.conf b/src/conf/cards/PC-Speaker.conf
+index 8a40a13944ed..97cb0d5dbd22 100644
+--- a/src/conf/cards/PC-Speaker.conf
++++ b/src/conf/cards/PC-Speaker.conf
+@@ -20,7 +20,7 @@ PC-Speaker.pcm.front.!0 {
+ 	}
+ 	min_dB -10.0
+ 	max_dB 20.0
+-}	
++}
+ 
+ # default with dmix & null
+ PC-Speaker.pcm.!default {
+@@ -49,4 +49,3 @@ PC-Speaker.pcm.!default {
+ 		type null
+ 	}
+ }
+-
+diff --git a/src/conf/cards/PMac.conf b/src/conf/cards/PMac.conf
+index 00f3bc892047..67dfabc67f83 100644
+--- a/src/conf/cards/PMac.conf
++++ b/src/conf/cards/PMac.conf
+@@ -11,7 +11,7 @@ PMac.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ PMac.pcm.!default {
+diff --git a/src/conf/cards/PMacToonie.conf b/src/conf/cards/PMacToonie.conf
+index aff1ea65c3c9..c45cf12bfc9b 100644
+--- a/src/conf/cards/PMacToonie.conf
++++ b/src/conf/cards/PMacToonie.conf
+@@ -18,7 +18,7 @@ PMacToonie.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol & dsnoop
+ PMacToonie.pcm.!default {
+diff --git a/src/conf/cards/PS3.conf b/src/conf/cards/PS3.conf
+index 486d790cd4ef..8a165fc3898b 100644
+--- a/src/conf/cards/PS3.conf
++++ b/src/conf/cards/PS3.conf
+@@ -19,7 +19,7 @@ PS3.pcm.front.!0 {
+ 		name "PCM Playback Volume"
+ 		card $CARD
+ 	}
+-}	
++}
+ 
+ # default with dmix+softvol
+ PS3.pcm.!default {
+@@ -34,8 +34,8 @@ PS3.pcm.!default {
+ 			type softvol
+ 			slave.pcm {
+ 				@func concat
+-                                #strings [ "dmix:CARD=" $CARD ]
+-                                strings [ "dmix:CARD=" $CARD ",FORMAT=S16" ]
++				#strings [ "dmix:CARD=" $CARD ]
++				strings [ "dmix:CARD=" $CARD ",FORMAT=S16" ]
+ 			}
+ 			control {
+ 				name "PCM Playback Volume"
+diff --git a/src/conf/cards/RME9636.conf b/src/conf/cards/RME9636.conf
+index 17b3a1ab9b5c..c5c74ee9727e 100644
+--- a/src/conf/cards/RME9636.conf
++++ b/src/conf/cards/RME9636.conf
+@@ -11,7 +11,7 @@ RME9636.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # FIXME: This configuration is not valid for double-speed rates.
+ 
+diff --git a/src/conf/cards/RME9652.conf b/src/conf/cards/RME9652.conf
+index a11e42b22d30..34ef91bb721c 100644
+--- a/src/conf/cards/RME9652.conf
++++ b/src/conf/cards/RME9652.conf
+@@ -11,7 +11,7 @@ RME9652.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # FIXME: This configuration is not valid for double-speed rates.
+ 
+diff --git a/src/conf/cards/SB-XFi.conf b/src/conf/cards/SB-XFi.conf
+index 9ce9c8ac2e1a..64e3d08232ad 100644
+--- a/src/conf/cards/SB-XFi.conf
++++ b/src/conf/cards/SB-XFi.conf
+@@ -12,7 +12,7 @@ SB-XFi.pcm.front.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 0
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -25,7 +25,7 @@ SB-XFi.pcm.rear.!0 {
+ 	card $CARD
+ 	device 1
+ 	hint.device 1
+-}	
++}
+ 
+ <confdir:pcm/center_lfe.conf>
+ 
+@@ -38,7 +38,7 @@ SB-XFi.pcm.center_lfe.!0 {
+ 	card $CARD
+ 	device 2
+ 	hint.device 2
+-}	
++}
+ 
+ <confdir:pcm/side.conf>
+ 
+@@ -51,7 +51,7 @@ SB-XFi.pcm.side.!0 {
+ 	card $CARD
+ 	device 3
+ 	hint.device 3
+-}	
++}
+ 
+ <confdir:pcm/surround21.conf>
+ <confdir:pcm/surround40.conf>
+diff --git a/src/conf/cards/SI7018.conf b/src/conf/cards/SI7018.conf
+index 33d190857f92..3a22107c9ca3 100644
+--- a/src/conf/cards/SI7018.conf
++++ b/src/conf/cards/SI7018.conf
+@@ -14,7 +14,7 @@ SI7018.pcm.front.!0 {
+ 	type hw
+ 	card $CARD
+ 	chmap [ "UNKNOWN" "FL,FR" ]
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -23,7 +23,7 @@ SI7018.pcm.rear.!0 {
+ 	@args.CARD {
+ 		type string
+ 	}
+-        type hooks
++	type hooks
+ 	slave.pcm {
+ 		type hw
+ 		card $CARD
+@@ -40,7 +40,7 @@ SI7018.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/TRID4DWAVENX.conf b/src/conf/cards/TRID4DWAVENX.conf
+index 5001297e12c7..3c25515e28d4 100644
+--- a/src/conf/cards/TRID4DWAVENX.conf
++++ b/src/conf/cards/TRID4DWAVENX.conf
+@@ -12,7 +12,7 @@ TRID4DWAVENX.pcm.front.!0 {
+ 	type hw
+ 	card $CARD
+ 	chmap [ "UNKNOWN" "FL,FR" ]
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -52,7 +52,7 @@ TRID4DWAVENX.pcm.rear.!0 {
+ 			}
+ 		]
+ 	}
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/USB-Audio.conf b/src/conf/cards/USB-Audio.conf
+index 1fc540e2eb4d..33d856f28a0c 100644
+--- a/src/conf/cards/USB-Audio.conf
++++ b/src/conf/cards/USB-Audio.conf
+@@ -47,7 +47,7 @@ USB-Audio.pcm.iec958_device {
+ 	"XONAR U5" 1
+ 	"XONAR SOUND CARD" 1
+ 	"Xonar SoundCard" 2
+-	
++
+ 	# The below don't have digital in/out, so prevent them from being opened.
+ 	"Andrea PureAudio USB-SA Headset" 999
+ 	"Blue Snowball" 999
+diff --git a/src/conf/cards/VIA686A.conf b/src/conf/cards/VIA686A.conf
+index c53dd71bf0bc..40c2f89e8874 100644
+--- a/src/conf/cards/VIA686A.conf
++++ b/src/conf/cards/VIA686A.conf
+@@ -14,7 +14,7 @@ VIA686A.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ VIA686A.pcm.!default {
+diff --git a/src/conf/cards/VIA8233.conf b/src/conf/cards/VIA8233.conf
+index 3c25a11b396b..ccc7fe2fdaad 100644
+--- a/src/conf/cards/VIA8233.conf
++++ b/src/conf/cards/VIA8233.conf
+@@ -11,7 +11,7 @@ VIA8233.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with softvol/dsnoop
+ # VIA8233 supports multi-playback
+diff --git a/src/conf/cards/VIA8233A.conf b/src/conf/cards/VIA8233A.conf
+index c9e56e204630..e566edebf5b6 100644
+--- a/src/conf/cards/VIA8233A.conf
++++ b/src/conf/cards/VIA8233A.conf
+@@ -11,7 +11,7 @@ VIA8233A.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with dmix/dsnoop
+ VIA8233A.pcm.!default {
+diff --git a/src/conf/cards/VIA8237.conf b/src/conf/cards/VIA8237.conf
+index 49fd6f2c82e4..074e342c0b9b 100644
+--- a/src/conf/cards/VIA8237.conf
++++ b/src/conf/cards/VIA8237.conf
+@@ -11,7 +11,7 @@ VIA8237.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ # default with softvol/dsnoop
+ # VIA8237 supports multi-playback
+diff --git a/src/conf/cards/VX222.conf b/src/conf/cards/VX222.conf
+index 2c6e2297c74e..96ea32f61400 100644
+--- a/src/conf/cards/VX222.conf
++++ b/src/conf/cards/VX222.conf
+@@ -11,7 +11,7 @@ VX222.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/VXPocket.conf b/src/conf/cards/VXPocket.conf
+index 90b1334788d5..81260a7df77c 100644
+--- a/src/conf/cards/VXPocket.conf
++++ b/src/conf/cards/VXPocket.conf
+@@ -11,7 +11,7 @@ VXPocket.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/iec958.conf>
+ 
+diff --git a/src/conf/cards/VXPocket440.conf b/src/conf/cards/VXPocket440.conf
+index 87a0855a49ee..6b3aea4048a5 100644
+--- a/src/conf/cards/VXPocket440.conf
++++ b/src/conf/cards/VXPocket440.conf
+@@ -11,7 +11,7 @@ VXPocket440.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+diff --git a/src/conf/cards/YMF744.conf b/src/conf/cards/YMF744.conf
+index ad1f213214fb..974bf791e0d6 100644
+--- a/src/conf/cards/YMF744.conf
++++ b/src/conf/cards/YMF744.conf
+@@ -11,7 +11,7 @@ YMF744.pcm.front.!0 {
+ 	}
+ 	type hw
+ 	card $CARD
+-}	
++}
+ 
+ <confdir:pcm/rear.conf>
+ 
+@@ -23,7 +23,7 @@ YMF744.pcm.rear.!0 {
+ 	type hw
+ 	card $CARD
+ 	device 2
+-}	
++}
+ 
+ <confdir:pcm/surround40.conf>
+ 
+diff --git a/src/conf/cards/pistachio-card.conf b/src/conf/cards/pistachio-card.conf
+index 15cfd60bd40b..d92c019ac7e7 100644
+--- a/src/conf/cards/pistachio-card.conf
++++ b/src/conf/cards/pistachio-card.conf
+@@ -1,10 +1,10 @@
+ #
+ # Configuration for the pistachio chip.
+ #
+-# The data sheet of the chip and technical reference manual can be 
+-found at 
++# The data sheet of the chip and technical reference manual can be
++found at
+ https://docs.creatordev.io/ci40/guides/hardwaredocs/cXT200_datasheet2.p
+-df # and 
++df # and
+ https://docs.creatordev.io/ci40/guides/hardwaredocs/MIPS_Creator_cXT200_Technical_Reference_Manual_1.0.112.pdf.
+ #
+ # The list of hardware devices is as per below:
+@@ -30,30 +30,30 @@ https://docs.creatordev.io/ci40/guides/hardwaredocs/MIPS_Creator_cXT200_Technica
+ #
+ 
+ pistachio-card.pcm.!default {
+-        @args [ CARD ]
+-        @args.CARD {
+-                type string
+-                default "pistachio"
+-        }
+-        @args.DEVICE {
+-                type integer
+-                default 2
+-        }
++	@args [ CARD ]
++	@args.CARD {
++		type string
++		default "pistachio"
++	}
++	@args.DEVICE {
++		type integer
++		default 2
++	}
+ 
+-        type asym
+-        capture.pcm {
+-                type multi
+-                slaves.a.pcm "hw:0,4"
+-                slaves.a.channels 12
+-                bindings.0.slave a
+-                bindings.0.channel 4
+-                bindings.1.slave a
+-                bindings.1.channel 5
+-        }
++	type asym
++	capture.pcm {
++		type multi
++		slaves.a.pcm "hw:0,4"
++		slaves.a.channels 12
++		bindings.0.slave a
++		bindings.0.channel 4
++		bindings.1.slave a
++		bindings.1.channel 5
++	}
+ 
+-        playback.pcm {
+-                type hw
+-                card $CARD
+-                device $DEVICE
+-        }
++	playback.pcm {
++		type hw
++		card $CARD
++		device $DEVICE
++	}
+ }
+-- 
+2.47.3
+


### PR DESCRIPTION
This fixes the "no audio" issue.

Tested on RPi3/4/5 and various users reported it also works on x86 and other devices.

Patch can be dropped at the next alsa-lib update.

Fixes #10775