### PR TITLE
firmware-imx: update to 8.30-3fa84fd

### DIFF
--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="firmware-imx"
-PKG_VERSION="8.29-8741a3b"
-PKG_SHA256="5be89eb8162c84eb45121192e69b73079a466ee6cabdabf3d874188fed60bb85"
+PKG_VERSION="8.30-3fa84fd"
+PKG_SHA256="154b1b5890ddebe45ca280634260a8cdaf38adc5b303aeea28a5ebad504a7912"
 PKG_ARCH="aarch64 arm"
 PKG_LICENSE="other"
 PKG_SITE="http://www.freescale.com"


### PR DESCRIPTION
- RN00210 - i.MX Linux Release Notes
- Rev. LF6.12.49_2.2.0 — 12 December 2025
- https://www.nxp.com/docs/en/release-note/RN00210.pdf