### PR TITLE
systemd: add more BT remotes to 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -110,8 +110,12 @@ evdev:input:b0005v0508p1980*
 evdev:input:b0003v4842p0001*
  KEYBOARD_KEY_c0041=enter
 
-# xaomi remote
+# xiaomi remote
 evdev:input:b0005v2717p32B9e4A4C*
+ KEYBOARD_KEY_c0041=enter
+
+# xiaomi remote 
+evdev:input:b0005v2717p32B9e4A53* 
  KEYBOARD_KEY_c0041=enter
 
 # yyykq remote


### PR DESCRIPTION
Add two more BT remotes from https://forum.libreelec.tv/thread/26261-fix-for-xiaomi-bluetooth-remote-with-nonworking-button/ to `70-local-keyboard.hwdb` and fixup a typo.