### PR TITLE
kodi: update appliance.xml configs for upstream changes

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -18,7 +18,7 @@
           <visible>false</visible>
         </setting>
       </group>
-      <group id="3">
+      <group id="5">
         <setting id="videoscreen.noofbuffers">
           <default>2</default>
         </setting>
@@ -62,9 +62,6 @@
     <category id="epg">
       <group id="2">
         <setting id="epg.preventupdateswhileplayingtv">
-          <default>true</default>
-        </setting>
-        <setting id="epg.ignoredbforclient">
           <default>true</default>
         </setting>
       </group>

--- a/projects/Rockchip/kodi/appliance.xml
+++ b/projects/Rockchip/kodi/appliance.xml
@@ -11,7 +11,7 @@
           <visible>true</visible>
         </setting>
       </group>
-      <group id="4">
+      <group id="5">
         <setting id="videoscreen.noofbuffers">
           <default>2</default>
           <visible>false</visible>


### PR DESCRIPTION
During recent ffmpeg v4l2_request work @Kwiboo spotted a couple of `appliance.xml` differences that result in the number of buffers configuration (and one other item) not being applied correctly in images, so let's fix that.