### PR TITLE
Accept zstd compressed tarballs files for restore process

### DIFF
--- a/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
+++ b/packages/mediacenter/LibreELEC-settings/scripts/backup-restore
@@ -34,7 +34,7 @@ def find_backup_file():
     try:
         # This search should match what the target generator is checking
         for file in os.listdir(BACKUP_DIR):
-            if file.endswith((".tar", ".tar.gz", ".tar.bz2", ".tar.xz")):
+            if file.endswith((".tar", ".tar.bz2", ".tar.gz", ".tar.xz", ".tar.zst")):
                 return f"{BACKUP_DIR}/{file}"
     except OSError as err:
         print(f"Error: Unable to access backup directory: {err}")

--- a/packages/sysutils/busybox/scripts/libreelec-target-generator
+++ b/packages/sysutils/busybox/scripts/libreelec-target-generator
@@ -28,7 +28,7 @@ for arg in $(cat /proc/cmdline); do
   esac
 done
 
-BACKUP_EXTENSION_LIST=".tar .tar.gz .tar.bz2 .tar.xz"
+BACKUP_EXTENSION_LIST=".tar .tar.bz2 .tar.gz .tar.xz .tar.zst"
 for extension in $BACKUP_EXTENSION_LIST; do
   BACKUP_FILE=$(ls -1 /storage/.restore/*${EXTENSION} 2>/dev/null | head -n 1)
   [ -n "${BACKUP_FILE}" ] && break


### PR DESCRIPTION
Python 3.14 gains zstd de/compression support so we can accept .tar.zst files for system restore. This is the image portion change. A similar change will be needed to the addon to accept via GUI.