### PR TITLE
mpd: rebuild addon (2)

### DIFF
--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="mpd"
 PKG_VERSION="0.24.6"
 PKG_SHA256="8ce34a010577feb42999a96d867325c6d38bf7ae1b7a57f878d7e548c1fd1fa9"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"


### PR DESCRIPTION
- rebuild due to bad RPi steamlink-ffmpeg interaction