### PR TITLE
docker: add current Debian and Ubuntu releases

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -5,8 +5,10 @@
   - jammy     (Ubuntu 22.04)
   - noble     (Ubuntu 24.04)
   - questing  (Ubuntu 25.10)
+  - resolute  (Ubuntu 26.04)
 - Debian
   - bookworm  (Debian 12)
+  - trixie    (Debian 13)
 
 **Build docker image**
 
@@ -44,4 +46,4 @@ See https://docs.docker.com/engine/reference/commandline/run/ for details on `do
 Note: `dockerd` is set to send all its logs to journald using the setting `--log-driver=journald` (so if you don't set the `--log-driver none` for your `docker run` these logs will be sent through to your log.
 Refer:
 
-https://github.com/LibreELEC/LibreELEC.tv/blob/140ad28a258167e0e87daf1e474db37215b2caf3/packages/addons/service/docker/source/system.d/service.system.docker.service#L12 
+https://github.com/LibreELEC/LibreELEC.tv/blob/1810c97fb2839486e63f6694dd093428ba24c39a/packages/addons/service/docker/source/system.d/service.system.docker.service#L12

--- a/tools/docker/resolute/Dockerfile
+++ b/tools/docker/resolute/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:resolute
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y locales sudo
+
+RUN locale-gen en_US.UTF-8 \
+ && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN useradd docker -U -G sudo -m -s /bin/bash \
+ && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN apt-get update \
+ && apt-get install -y \
+    curl bash bc gcc-15 cpp-15 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
+      unzip diffutils lzop make file g++-15 xfonts-utils xsltproc default-jre-headless python3 \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
+      golang-1.25-go git openssh-client rsync upx-ucl \
+    --no-install-recommends \
+    && ln -s /usr/lib/go-1.25 /usr/lib/go \
+    && ln -s /usr/lib/go-1.25/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.25/bin/gofmt /usr/bin/gofmt
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+  apt-get install -y libc6-amd64-cross qemu-user-binfmt --no-install-recommends; \
+ fi
+
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100 \
+    --slave /usr/bin/cpp cpp /usr/bin/cpp-15 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-15 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-15
+RUN update-alternatives --config gcc
+
+USER docker

--- a/tools/docker/trixie/Dockerfile
+++ b/tools/docker/trixie/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:trixie
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y locales sudo
+
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+ && locale-gen en_US.UTF-8 \
+ && update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+RUN useradd docker -U -G sudo -m -s /bin/bash \
+ && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN sed -i 's/\(Suites: trixie trixie-updates\)/\1 trixie-backports/' /etc/apt/sources.list.d/debian.sources
+
+RUN apt-get update \
+ && apt-get install -y \
+    curl bash bc gcc sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
+      unzip diffutils lzop make file g++ xfonts-utils xsltproc default-jre-headless python3 \
+      libc6-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
+      golang-1.24-go git openssh-client rsync \
+    --no-install-recommends \
+    && ln -s /usr/lib/go-1.24 /usr/lib/go \
+    && ln -s /usr/lib/go-1.24/bin/go /usr/bin/go \
+    && ln -s /usr/lib/go-1.24/bin/gofmt /usr/bin/gofmt
+
+RUN rm -rf /var/lib/apt/lists/*
+
+USER docker


### PR DESCRIPTION
- do not change build host / default from noble at the time.
- Resolute (which will be LTS) has been tested build current LE master successfully.