### PR TITLE
linux: add patches to fix Amlogic S905D network issues

### DIFF
--- a/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0052-EXT-arm64-dts-meson-p230-fix-IRQ-for-external-PHY.patch
+++ b/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0052-EXT-arm64-dts-meson-p230-fix-IRQ-for-external-PHY.patch
@@ -1,0 +1,27 @@
+From db90e07847de535d60a027abe1fa05afb56d3793 Mon Sep 17 00:00:00 2001
+From: Gabor Dee <dee.gabor@gmail.com>
+Date: Sun, 4 Jan 2026 12:59:27 +0100
+Subject: [PATCH] arm64: dts: meson: p230: fix IRQ for external PHY
+
+IRQ #29 was used by the GXBB, but this is not appropriate for the GXL.
+The S905D is the only SoC in the GXL family that is RGMII-capable,
+and the MDIO layout is inherited from the S912 (GXM).
+
+Signed-off-by: Gabor Dee <dee.gabor@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
+index 7dffeb5..8606f7f 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
+@@ -84,7 +84,7 @@
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+-		interrupts = <29 IRQ_TYPE_LEVEL_LOW>;
++		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+ 		eee-broken-1000t;
+ 	};
+ };

--- a/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0053-EXT-arm64-dts-meson-vero4k-plus-rework-and-cleanup.patch
+++ b/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0053-EXT-arm64-dts-meson-vero4k-plus-rework-and-cleanup.patch
@@ -1,0 +1,169 @@
+From ecc9a4d0623c646f9b0122cf1462afcff573bdd1 Mon Sep 17 00:00:00 2001
+From: Gabor Dee <dee.gabor@gmail.com>
+Date: Sun, 4 Jan 2026 16:45:39 +0100
+Subject: [PATCH] arm64: dts: meson: vero4k-plus: rework and cleanup
+
+In the previous solution, Ethernet was completely broken, so it was reworked.
+In addition, untracked modifications in similar device trees were also included.
+
+List of changes:
+- Power button removed, because there is none on this device.
+- Change PHY mode to RGMII and set TX delay to 4ns.
+- Disable EEE for 1Gbps connection.
+- Remove Ethernet IRQ pin entry.
+- Add HDMI_TX and CEC related records.
+- Remove SDIO Broadcom specific entries.
+- Remove standalone USB entries.
+
+Signed-off-by: Gabor Dee <dee.gabor@gmail.com>
+---
+ .../amlogic/meson-gxl-s905d-vero4k-plus.dts   | 81 +++++++++----------
+ 1 file changed, 38 insertions(+), 43 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-vero4k-plus.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-vero4k-plus.dts
+index 595b490..66654b0 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-vero4k-plus.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-vero4k-plus.dts
+@@ -1,30 +1,20 @@
+ // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ /*
+  * Author: Christian Hewitt <christianshewitt@gmail.com>
++ * Author: Gabor Dee <dee.gabor@gmail.com>
+  */
+ 
+ /dts-v1/;
+ 
++#include <dt-bindings/leds/common.h>
++
+ #include "meson-gxl-s905d.dtsi"
+ #include "meson-gx-p23x-q20x.dtsi"
+-#include <dt-bindings/input/input.h>
+-#include <dt-bindings/leds/common.h>
+ 
+ / {
+ 	compatible = "osmc,vero4k-plus", "amlogic,s905d", "amlogic,meson-gxl";
+ 	model = "OSMC Vero 4K Plus";
+ 
+-	gpio-keys-polled {
+-		compatible = "gpio-keys-polled";
+-		poll-interval = <20>;
+-
+-		button {
+-			label = "power";
+-			linux,code = <KEY_POWER>;
+-			gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
+-		};
+-	};
+-
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -36,55 +26,74 @@
+ 			panic-indicator;
+ 		};
+ 	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++};
++
++&cec_AO {
++	status = "okay";
++	pinctrl-0 = <&ao_cec_pins>;
++	pinctrl-names = "default";
++	hdmi-phandle = <&hdmi_tx>;
+ };
+ 
+ &ethmac {
+ 	pinctrl-0 = <&eth_pins>;
+ 	pinctrl-names = "default";
+ 
+-	phy-mode = "rgmii-txid";
+ 	phy-handle = <&external_phy>;
+ 
+-	amlogic,tx-delay-ns = <0>;
++	amlogic,tx-delay-ns = <4>;
++
++	/* External PHY is in RGMII */
++	phy-mode = "rgmii";
+ };
+ 
+ &external_mdio {
+ 	external_phy: ethernet-phy@0 {
+ 		/* Realtek RTL8211F (0x001cc916) */
+-		pinctrl-0 = <&eth_phy_irq_pin>;
+-		pinctrl-names = "default";
+-
+ 		reg = <0>;
+ 		max-speed = <1000>;
+ 
++		/* External PHY reset is shared with internal PHY Led signal */
+ 		reset-assert-us = <10000>;
+ 		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+ 		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
++		eee-broken-1000t;
+ 	};
+ };
+ 
+-&pinctrl_periphs {
+-	/* Ensure the phy irq pin is properly configured as input */
+-	eth_phy_irq_pin: eth-phy-irq {
+-		mux {
+-			groups = "GPIOZ_15";
+-			function = "gpio_periphs";
+-			bias-disable;
+-			output-disable;
+-		};
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmi_hpd_pins>, <&hdmi_i2c_pins>;
++	pinctrl-names = "default";
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
+ 	};
+ };
+ 
+ &sd_emmc_a {
+-	brcmf: wifi@1 {
++	sdio: wifi@1 {
+ 		reg = <1>;
+-		compatible = "brcm,bcm4329-fmac";
+ 	};
+ };
+ 
++/* This is connected to the Bluetooth module: AP6255 */
+ &uart_A {
+ 	status = "okay";
+ 	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
+@@ -99,17 +108,3 @@
+ 		clock-names = "lpo";
+ 	};
+ };
+-
+-&usb {
+-	dr_mode = "host";
+-};
+-
+-&usb2_phy0 {
+-	/* HDMI_5V also supplies the USB VBUS */
+-	phy-supply = <&hdmi_5v>;
+-};
+-
+-&usb2_phy0 {
+-	/* HDMI_5V also supplies the USB VBUS */
+-	phy-supply = <&hdmi_5v>;
+-};


### PR DESCRIPTION
The following patches fix several issues in the device tree related to networking for the S905D SoC.

Detailed descriptions can be found in the header of the patches.