### PR TITLE
Sync game add-ons with upstream libretro

### DIFF
--- a/packages/emulation/libretro-2048/package.mk
+++ b/packages/emulation/libretro-2048/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-2048"
-PKG_VERSION="86e02d3c2dd76858db7370f5df1ccfc33b3abee1"
-PKG_SHA256="1288de5aa6c88b1bf710f62b7bdd9908c72781890bf6c34e8864a5bbeb67bb1d"
+PKG_VERSION="e70c3f82d2b861c64943aaff7fcc29a63013997d"
+PKG_SHA256="07d51892d173d85715d0cddd5963c50c2308e2d92401c4e79208544bc95f6f19"
 PKG_LICENSE="Public domain"
 PKG_SITE="https://github.com/libretro/libretro-2048"
 PKG_URL="https://github.com/libretro/libretro-2048/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-atari800/package.mk
+++ b/packages/emulation/libretro-atari800/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-atari800"
-PKG_VERSION="6a18cb23cc4a7cecabd9b16143d2d7332ae8d44b"
-PKG_SHA256="0fa8456f611975f80e0edba37a9cb4935918a94d30f6d42f8fa0679e76a9971a"
+PKG_VERSION="d1d0d425458e6b5a2e51ad5f1507bdf97e857c95"
+PKG_SHA256="250291312ca10a20643699f8ac506766cad5792e70fc924818a496bfe7ce11cb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-atari800"
 PKG_URL="https://github.com/libretro/libretro-atari800/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-pce-fast/package.mk
+++ b/packages/emulation/libretro-beetle-pce-fast/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-pce-fast"
-PKG_VERSION="d5c2b28ee6931ae43a4a79455937693ae8ccc8a1"
-PKG_SHA256="3e2c410fba2abd46c62d5f43f4b8914e459a0927c8c56df48af440890ef403c4"
+PKG_VERSION="52675734da114a19b3705f03906b1455f3d76644"
+PKG_SHA256="783a2cdb8c94ff7194fefc415a04c3a75b24a79cbac1ca93ace946810cd57002"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-pce-fast-libretro"
 PKG_URL="https://github.com/libretro/beetle-pce-fast-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-psx/package.mk
+++ b/packages/emulation/libretro-beetle-psx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-psx"
-PKG_VERSION="3ca0580ec7b49260559eb8d5dd771f7a8924cdbd"
-PKG_SHA256="ea819af9f4edbaf0f660c6420527a0ddef3dd082069fe6d64f83a2c08b567991"
+PKG_VERSION="fe0b72c4b93e42a46cd062febd7de292d828248e"
+PKG_SHA256="4a7df78025b4f9f273b438cb71d390f3a807bc5de563cae78891c7be55716d7c"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"
 PKG_URL="https://github.com/libretro/beetle-psx-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-saturn/package.mk
+++ b/packages/emulation/libretro-beetle-saturn/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-saturn"
-PKG_VERSION="ccba5265f60f8e64a1984c9d14d383606193ea6a"
-PKG_SHA256="f6d23a233a4b66038d20ba13f7b13666bab258478d9e62a4ebfac6dd8eefe2d8"
+PKG_VERSION="b4df47a9f0f30d09eb95b07a4435d0f435a2e95d"
+PKG_SHA256="156ec3f764da825989d1c3d2ca288048e03f3e9e272326fc61fba9dde3fe9f5e"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-saturn-libretro"
 PKG_URL="https://github.com/libretro/beetle-saturn-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-beetle-vb/package.mk
+++ b/packages/emulation/libretro-beetle-vb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-beetle-vb"
-PKG_VERSION="8f837ebc077afdd6652efb2827fd8308a07113ca"
-PKG_SHA256="d2733026bde2b8049b8258f68d49954687ab43e2639d6a879c79cca68e91dea6"
+PKG_VERSION="65debc7c4c7b85e2fd988d2be53496c2cf0b5f44"
+PKG_SHA256="7a7e1a4a2defb1d6ee149560349c8af2dd6ddb153fe6f6758fe25d06c6bf8399"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-vb-libretro"
 PKG_URL="https://github.com/libretro/beetle-vb-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bluemsx/package.mk
+++ b/packages/emulation/libretro-bluemsx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bluemsx"
-PKG_VERSION="06a85a3db4a009b28f5643961340711541864ede"
-PKG_SHA256="6d5ff2d4d77f1005f5a445c5513ea7bf1ce96342cd333ff71d782c152326d6af"
+PKG_VERSION="036376d6679c9e153712dbbb3fdca774afc49706"
+PKG_SHA256="91931e2d71ada346ca5a1c7c89010c1bca878ab54a07ad8bd999d629485a85ef"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"
 PKG_URL="https://github.com/libretro/blueMSX-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bsnes-hd/package.mk
+++ b/packages/emulation/libretro-bsnes-hd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bsnes-hd"
-PKG_VERSION="0bb7b8645e22ea2476cabd58f32e987b14686601"
-PKG_SHA256="f7c498b927daca8c7d69124369670e749a4e13422411cf7136da695e60da3dc7"
+PKG_VERSION="fc26b25ea236f0f877f0265d2a2c37dfd93dfde9"
+PKG_SHA256="0cf48d8ef4846ce2b0b26fac4068cfbe2ab4c90794ede1af66c343fbfe079b2f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/DerKoun/bsnes-hd"
 PKG_URL="https://github.com/DerKoun/bsnes-hd/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-bsnes/package.mk
+++ b/packages/emulation/libretro-bsnes/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-bsnes"
-PKG_VERSION="57155d8037463346307123daabeaa27298e0f956"
-PKG_SHA256="26f305da3ed21dd675cedc256ce1e22c956fcda02893e3e1ca5a214bfa72b340"
+PKG_VERSION="d0a61b2c679bc73286be5471b222b1f1ebfb67b9"
+PKG_SHA256="ad8ee455b8214a7ea88941e29333a26fe4cde8626ce04f95d938ca98c2870127"
 PKG_LICENSE="GPLv3/ISC"
 PKG_SITE="https://github.com/libretro/bsnes"
 PKG_URL="https://github.com/libretro/bsnes-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-cap32/package.mk
+++ b/packages/emulation/libretro-cap32/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-cap32"
-PKG_VERSION="a5d96c5ebbda3bc89a3bd1c1691a20f5eacc232d"
-PKG_SHA256="c9010df18c86ab98ea77c1960b17ddde381f2ac57120792c266a87b518d0b86b"
+PKG_VERSION="54eabbb210a6149496b1d023bebddb3f0120bc33"
+PKG_SHA256="e0362204c73f9e5d59dbd663faae939d9ad50248622248c92a4b4c84e18d9784"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-cap32"
 PKG_URL="https://github.com/libretro/libretro-cap32/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-dinothawr/package.mk
+++ b/packages/emulation/libretro-dinothawr/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dinothawr"
-PKG_VERSION="e57e780a963372b89736620d7e3b8608190f7581"
-PKG_SHA256="e969f14628a0b7c49609bc98b5ddf6344b3fa4ad3389de77f59da2d2b6160480"
+PKG_VERSION="d66dde551be8e68e47c05e88838b4f1c6b114c99"
+PKG_SHA256="a9dc2fcdc276943ed6fbab1c724ca20162499a3da0f2001a6d41de12596fc3a7"
 PKG_LICENSE="CC-BY-NC-SA-3.0"
 PKG_SITE="https://github.com/libretro/Dinothawr"
 PKG_URL="https://github.com/libretro/Dinothawr/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-dosbox-pure/package.mk
+++ b/packages/emulation/libretro-dosbox-pure/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-dosbox-pure"
-PKG_VERSION="d743cfd9342c083ef6d3cecfc08c9af28a1481c8"
-PKG_SHA256="22bc51eb9cd7c846c2ae10e13b25707ee8ae24a33c11f822e82c9b70df260bfc"
+PKG_VERSION="693833edb4e382df783c8676a4a402e8c05e14b1"
+PKG_SHA256="3ed2f95eb38ae8d2edee601b8628f6e851fa58002f4c20f54e87e3e2ea292cae"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dosbox-pure"
 PKG_URL="https://github.com/libretro/dosbox-pure/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-fbneo/package.mk
+++ b/packages/emulation/libretro-fbneo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-fbneo"
-PKG_VERSION="78dcc8a994ad9b51e487d4e52671f7a6ae20b5c2"
-PKG_SHA256="d8e7e66ce43524596177da6f6cdbf7df44b895f907f64dcc65fa6041f7af1463"
+PKG_VERSION="8d2b25cc067d6e822160d87fa27733811d349f7f"
+PKG_SHA256="05761af3617d18c328177c435f0173d740d52d8c7fde2621e894d53e02cceb2d"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/fbneo"
 PKG_URL="https://github.com/libretro/FBNeo/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-gambatte/package.mk
+++ b/packages/emulation/libretro-gambatte/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-gambatte"
-PKG_VERSION="b75225203ffea8b65124bb31acb598e91e7f22d9"
-PKG_SHA256="52352417d719221ae2813b3dec8277508319171fe74e35196a9765881fb109bd"
+PKG_VERSION="9fe223d9c4b615c55840170c6e85e6e9fa4bd1d2"
+PKG_SHA256="302470f26dac743d9d26bbbcd5b059dc6ebefe1b777a970fe1e21b1758a308f8"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"
 PKG_URL="https://github.com/libretro/gambatte-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-genplus/package.mk
+++ b/packages/emulation/libretro-genplus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-genplus"
-PKG_VERSION="cecccacf767b1c8e86af3e315223b052a7f81b95"
-PKG_SHA256="8a3fa4dada19046a953f7ed65be9ff0f5eb47e169a917fe6e3616b5cf187acc7"
+PKG_VERSION="c858c9c5eebef46ea1a69427091853f9f1edbd23"
+PKG_SHA256="0d7c8037ffe6a4c5aaec1166464a7f610960ebf465be8f609b2b07d7f1b8e79c"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/ekeeke/Genesis-Plus-GX"
 PKG_URL="https://github.com/libretro/Genesis-Plus-GX/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mame2003_plus/package.mk
+++ b/packages/emulation/libretro-mame2003_plus/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mame2003_plus"
-PKG_VERSION="870e8ba3fa4e6635e2eb9d85c939589498659c32"
-PKG_SHA256="1240e641302ec7941d4879c88e162afae3a7347b67e8b0f2c826f70b23ea5166"
+PKG_VERSION="e9249b97a836f98c03c32f62f54eb096ba76cbec"
+PKG_SHA256="a9150e6088f7a698e64400cb8201edfd7bda671cb9e7482c929c83924bdc321b"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
 PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-mupen64plus-nx/package.mk
+++ b/packages/emulation/libretro-mupen64plus-nx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-mupen64plus-nx"
-PKG_VERSION="222acbd3f98391458a047874d0372fe78e14fe94"
-PKG_SHA256="9e55fa83f2313f9b80a369d77457ec216e5774ef2d486083ad8661aa94a4dbd1"
+PKG_VERSION="c0101c54047a7e854a9067e36ea27fc2230cf877"
+PKG_SHA256="269c798d4cef90612f42f07f5910548ebcfe9cd57c7298b3dcc6be72daf6e133"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mupen64plus-libretro-nx"
 PKG_URL="https://github.com/kodi-game/mupen64plus-libretro-nx/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-nestopia/package.mk
+++ b/packages/emulation/libretro-nestopia/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-nestopia"
-PKG_VERSION="e9429844f2e16a284a8cdf663589634fd4c6345f"
-PKG_SHA256="5d145e4171bd3381def8ba6d4f08a79d04d3a09c0d53e0b89266b7aa89402990"
+PKG_VERSION="473d3072be67fa2542ca833c274ef6682cf0f0bc"
+PKG_SHA256="0acbb6c53d87721f9065eed6c3b654a06704cbb500290c4e9d82aa0298d16c5b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/nestopia"
 PKG_URL="https://github.com/libretro/nestopia/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-opera/package.mk
+++ b/packages/emulation/libretro-opera/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-opera"
-PKG_VERSION="67a29e60a4d194b675c9272b21b61eaa022f3ba3"
-PKG_SHA256="e4135d62160f84d3bc287d165ef514a3e4ea31b759888ee29bde05e8c899b666"
+PKG_VERSION="1eee72f640e4da6f1b8ca68f70b51db22cc474c8"
+PKG_SHA256="689650ddbfcd5232e08b5def5346cf68614ad83383658d3e542bf62a8ee8f6bb"
 PKG_LICENSE="LGPL with additional notes"
 PKG_SITE="https://github.com/libretro/opera-libretro"
 PKG_URL="https://github.com/libretro/opera-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-pcsx-rearmed/package.mk
+++ b/packages/emulation/libretro-pcsx-rearmed/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-pcsx-rearmed"
-PKG_VERSION="228c14e10e9a8fae0ead8adf30daad2cdd8655b9"
-PKG_SHA256="0530dc5772466c31900a5bb8b412b67f82a01d8cbf771e07fe25d5799c161f0a"
+PKG_VERSION="5a8cedf59569a9f99caf5fda3b6d0b46a5d376a4"
+PKG_SHA256="b4658f68047348c68b74380e04a45b57b28210b3a257866966855de034b712a2"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"
 PKG_URL="https://github.com/libretro/pcsx_rearmed/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-prboom/package.mk
+++ b/packages/emulation/libretro-prboom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-prboom"
-PKG_VERSION="b3e5f8b2e8855f9c6fc7ff7a0036e4e61379177d"
-PKG_SHA256="e4a7eb96ab547027e0fbd9d27d0057d522b19e604656a0b34f00853795a4cc47"
+PKG_VERSION="93c8e7a2074e4fd8410398e3d571c6d9afec1d84"
+PKG_SHA256="4ba4d80792ac32941538e069060dd1db59269313e5eff2360d460e9bcb44d9b0"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-prboom"
 PKG_URL="https://github.com/libretro/libretro-prboom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-stella/package.mk
+++ b/packages/emulation/libretro-stella/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-stella"
-PKG_VERSION="749a21f653cf85fcedf4fe514ac8df1ad308be8e"
-PKG_SHA256="57f641936267bebaf182147e60a1cf04c1cc6288cbfbc8e3b4ea80f81076f621"
+PKG_VERSION="e0e8857f986bce1200881928193629a2105ae65d"
+PKG_SHA256="714a9a2da615f42cf46842f5a4592f9f234d7decd41a4084c304754bef4e966b"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/stella-emu/stella"
 PKG_URL="https://github.com/stella-emu/stella/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-tyrquake/package.mk
+++ b/packages/emulation/libretro-tyrquake/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-tyrquake"
-PKG_VERSION="dfdae65c0ab5cf5d459155e8fefe796105229959"
-PKG_SHA256="9c4b07794357293b874ac46e18f3929a16baf8b958cbb41e47dbe55bb151c671"
+PKG_VERSION="471f2a72d2a7b0416f6a21eb945e5af831df06a4"
+PKG_SHA256="007fa4f1574cd40643ecbf7ddbfcbfdab4c098756771ffb8aaa9a07740921ac9"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/tyrquake"
 PKG_URL="https://github.com/libretro/tyrquake/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-uae/package.mk
+++ b/packages/emulation/libretro-uae/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-uae"
-PKG_VERSION="9e2aa770a9b6b0a4e1f4fc05eb0db6c8e7aba8ee"
-PKG_SHA256="b7a4975800f413bd333f999572515aef0467261a366d7f5c61de1c7825ac2edf"
+PKG_VERSION="f0aad6a05695565acd44998c958f36301f215b11"
+PKG_SHA256="b84c0b1f4ea38894ce26e34f4418660d7548746d27effefc4c75ef9e9d3e06eb"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"
 PKG_URL="https://github.com/libretro/libretro-uae/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vbam/package.mk
+++ b/packages/emulation/libretro-vbam/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vbam"
-PKG_VERSION="d4be8da8dff03eb6a8d221f5cd4c0e899268a8bd"
-PKG_SHA256="5275a27a6131b8d2a86df5439323b6f55e4ff90907eb43bf90240bfbd619f129"
+PKG_VERSION="146cf91d43d1cc1e7616486e191a4e1780d94aa2"
+PKG_SHA256="90b23eb8e69b65f51bf4f2230a09729ed6a4e8a2b1d511f642f4ac794e7c7811"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/visualboyadvance-m/visualboyadvance-m"
 PKG_URL="https://github.com/visualboyadvance-m/visualboyadvance-m/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vecx/package.mk
+++ b/packages/emulation/libretro-vecx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vecx"
-PKG_VERSION="841229a6a81a0461d08af6488f252dcec5266c6a"
-PKG_SHA256="d564413e9611b16e49e076cadd719587b6712c3cb435eaf90597c2db157546f4"
+PKG_VERSION="eacee1f6f029688b043ed802cece29dd3c320e21"
+PKG_SHA256="f8dfd3da427b101b8d3e4fb187eea3bb326ad924942d3c09f3388fc879e08ba3"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/libretro-vecx"
 PKG_URL="https://github.com/libretro/libretro-vecx/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_x128/package.mk
+++ b/packages/emulation/libretro-vice_x128/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_x128"
-PKG_VERSION="e9f8ac034ddef3025f0567768f7af8219f7cfdb8"
-PKG_SHA256="83c68b33ba42d2cf885705f8b703112ed5c35593bac0618f062f704957ab6c9f"
+PKG_VERSION="b3a5d5c6e49a382bb107db9fbe20b9a9f39f96ac"
+PKG_SHA256="c54fe2b1a3c01a7402bb2666564a6a073947b5d24be96dd26e686bef44decf6f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_xplus4/package.mk
+++ b/packages/emulation/libretro-vice_xplus4/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_xplus4"
-PKG_VERSION="e9f8ac034ddef3025f0567768f7af8219f7cfdb8"
-PKG_SHA256="83c68b33ba42d2cf885705f8b703112ed5c35593bac0618f062f704957ab6c9f"
+PKG_VERSION="b3a5d5c6e49a382bb107db9fbe20b9a9f39f96ac"
+PKG_SHA256="c54fe2b1a3c01a7402bb2666564a6a073947b5d24be96dd26e686bef44decf6f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-vice_xvic/package.mk
+++ b/packages/emulation/libretro-vice_xvic/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-vice_xvic"
-PKG_VERSION="e9f8ac034ddef3025f0567768f7af8219f7cfdb8"
-PKG_SHA256="83c68b33ba42d2cf885705f8b703112ed5c35593bac0618f062f704957ab6c9f"
+PKG_VERSION="b3a5d5c6e49a382bb107db9fbe20b9a9f39f96ac"
+PKG_SHA256="c54fe2b1a3c01a7402bb2666564a6a073947b5d24be96dd26e686bef44decf6f"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"
 PKG_URL="https://github.com/libretro/vice-libretro/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-yabause/package.mk
+++ b/packages/emulation/libretro-yabause/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-yabause"
-PKG_VERSION="c35712c5ed33e18d77097f2059a036e19d1d66f2"
-PKG_SHA256="2c2485bf76de138cf8a46fa8dd460f46f21b3abb38a432578c7f18b46fa6807e"
+PKG_VERSION="65af22e96beb6d9b0b9a50a81a39c86a6d604c1c"
+PKG_SHA256="d0787d5b1d161ce519393f570074ebd0f0a7a777a089a5a3fe172e241eeaa944"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"
 PKG_URL="https://github.com/libretro/yabause/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.2048/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.2048"
-PKG_VERSION="1.0.0.150-Omega"
-PKG_SHA256="72fd0073a8b8eafb32420e1b4b51317b8170600f2e8db3a6ecf9f79d307673a1"
-PKG_REV="2"
+PKG_VERSION="1.0.0.151-Omega"
+PKG_SHA256="11a79a6c28fe638ff459952bf4f3e6fa8c6907b67f74d08cb69b0e699e6b021c"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.2048"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.atari800/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.atari800"
-PKG_VERSION="3.1.0.40-Omega"
-PKG_SHA256="cfa7b9d15aa7fe8dadb9841811ea6d41ffc2a989dffd7b23b6432bd43bd6446b"
-PKG_REV="2"
+PKG_VERSION="3.1.0.42-Omega"
+PKG_SHA256="2f6214303e3497728d43b5946bf73c5a0fcca87832f1ff44db9d34a70186dd17"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.atari800"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-pce-fast/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-pce-fast"
-PKG_VERSION="1.31.0.58-Omega"
-PKG_SHA256="7e7ef6e4a70fc09a74e4573171a78cbe91b4a999bc5837ce897e801292e632be"
-PKG_REV="2"
+PKG_VERSION="1.31.0.60-Omega"
+PKG_SHA256="f535aca839df99c97628851a61e7cbda2a094d91beb5c707bc7dba0ba31ff288"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-pce-fast"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-psx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-psx"
-PKG_VERSION="0.9.44.72-Omega"
-PKG_SHA256="5f09e7489189455f39ea413ce54689034759c5a50737ccb01c156b105da3bad7"
-PKG_REV="3"
+PKG_VERSION="0.9.44.75-Omega"
+PKG_SHA256="38a1abc421c9b20168d85d3f4b867177608f41963c8f6f72b2a99306ff923ad4"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-psx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-saturn/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-saturn"
-PKG_VERSION="1.29.0.53-Omega"
-PKG_SHA256="fc8d28378f9976d33c16ade6d7c96ddbb2bb5433b419285544ef6e299a649bd2"
-PKG_REV="2"
+PKG_VERSION="1.29.0.54-Omega"
+PKG_SHA256="a046473216b9be958f2ef0de22d0ef94a1bb8d0039ac70ae9350100beb7bcca0"
+PKG_REV="1"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-saturn"
 PKG_URL="https://github.com/kodi-game/game.libretro.beetle-saturn/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.beetle-vb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.beetle-vb"
-PKG_VERSION="1.31.0.41-Omega"
-PKG_SHA256="adfe38babe96ffe91efd8b5cc96cbb71b636d8ca400065a21a58df5408866390"
-PKG_REV="2"
+PKG_VERSION="1.31.0.42-Omega"
+PKG_SHA256="6e262f20454ff1c9992059d3379ef2b9ab01dbcb8d4625b8a7284e98a00eb695"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.beetle-vb"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bluemsx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bluemsx"
-PKG_VERSION="0.0.1.46-Omega"
-PKG_SHA256="d079a9a6949e37638c934ceb43468d780aa01a4f30d625634e8abc35fe62a1cc"
-PKG_REV="2"
+PKG_VERSION="0.0.1.48-Omega"
+PKG_SHA256="53004cd6dfa5ef006eed495d7a8723529b7d3f9f61c13c009f046e4b02456166"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bluemsx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-hd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-hd/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes-hd"
-PKG_VERSION="10.6.0.15-Omega"
-PKG_SHA256="679e6d3d61473f4b6416f6e1f2cb9139884b4b62dc9552d7c9cb8fbeeaf784ca"
-PKG_REV="2"
+PKG_VERSION="10.6.0.16-Omega"
+PKG_SHA256="9a08d62194a562ad30d9207a785d318e1faff1530c98c0abb45f4ad956c6e675"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes-hd"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.bsnes"
-PKG_VERSION="115.0.0.22-Omega"
-PKG_SHA256="469ff4af7bfa8428680af69b4ae125e3603b7549c7a8029f4887cc3f9a2175af"
-PKG_REV="2"
+PKG_VERSION="115.0.0.23-Omega"
+PKG_SHA256="5bf39e6c151050af8b8b797e9a9e67743216aec39b6a656a6deeb92748d5515f"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/kodi-game/game.libretro.bsnes"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cap32/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.cap32"
-PKG_VERSION="4.5.4.47-Omega"
-PKG_SHA256="2523f396bcd5d5f608b895a4e27075a8acf386855b4e6f3d5c17ec15426e7640"
-PKG_REV="2"
+PKG_VERSION="4.5.4.48-Omega"
+PKG_SHA256="3bdc060d937d8ad97b19e861ea3d574f707ca07c264488a691a7ed139ce783f4"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.cap32"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dinothawr/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dinothawr"
-PKG_VERSION="1.0.0.41-Omega"
-PKG_SHA256="47069a7d5dffeb0046e09f0c58cd299b593bb29e077677785afdf363d7eb20e0"
-PKG_REV="2"
+PKG_VERSION="1.0.0.42-Omega"
+PKG_SHA256="ce85462f056a0c268eb0b876f4cc2fd6822b48a9cf9fd166d337451dec6f61dc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dinothawr"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dosbox-pure/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.dosbox-pure"
-PKG_VERSION="1.0.0.38-Omega"
-PKG_SHA256="1851715f27bfa302b7d720890551b61434188d59d07ebabf054e852b5521e21a"
-PKG_REV="2"
+PKG_VERSION="1.0.0.40-Omega"
+PKG_SHA256="e67654fc56a41fb82f0fcfd8f8f444f149949e122f19140b91aa6a5f5c4608fc"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.dosbox-pure"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.fbneo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.fbneo/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.fbneo"
-PKG_VERSION="1.0.0.88-Omega"
-PKG_SHA256="4475cb2a2e08a3e51b7d8b1139ecf321435f9b842e3651a252cb184f21e5147e"
-PKG_REV="2"
+PKG_VERSION="1.0.0.92-Omega"
+PKG_SHA256="c7d14dbacef6eb78fcce51eba52f02e5933259e8bee64eb11e8ad0f092c11bcd"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.fbneo"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.gambatte/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.gambatte"
-PKG_VERSION="0.5.0.60-Omega"
-PKG_SHA256="18c4f0e4ea6ac237c7522ff357e07f7ef472f3e4ebe403314991561660dc4ba7"
-PKG_REV="2"
+PKG_VERSION="0.5.0.61-Omega"
+PKG_SHA256="3207cd36f04a74b024646a32f382761b7a6a15fea437175cc7b68c6761e8b1f3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.gambatte"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.genplus/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.genplus"
-PKG_VERSION="1.7.4.71-Omega"
-PKG_SHA256="e2fdf279d57712000d3248ae123fcb234390afe1865787c4a55e7b27a464b639"
-PKG_REV="2"
+PKG_VERSION="1.7.4.73-Omega"
+PKG_SHA256="008e9a178aa221329167d4bcb4ac87f92925be71e1728105a7f69f0d42d04d9d"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.genplus"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mame2003_plus/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mame2003_plus"
-PKG_VERSION="0.0.1.92-Omega"
-PKG_SHA256="20166e2485a31cf006844fc98df294421afc86eec0067d44bd97254ac5e0015e"
-PKG_REV="2"
+PKG_VERSION="0.0.1.94-Omega"
+PKG_SHA256="25072e4c01124a80a04aad98a374e3441bc11e1ed785a8332f5a493288b2cebc"
+PKG_REV="1"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.mame2003_plus"
 PKG_URL="https://github.com/kodi-game/game.libretro.mame2003_plus/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus-nx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.mupen64plus-nx/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.mupen64plus-nx"
-PKG_VERSION="914c98d9db4c5ec9d2fd51ab3f2ec4ec9d17ae3f"
-PKG_SHA256="a9713229540e69ef9c0e6cc310380ec511077383ffecc40a78ae97c06ef7d20d"
+PKG_VERSION="2.8.0.53-Omega"
+PKG_SHA256="4c7d3f4b0768222523e8a76ec5406e9628a7ff82efafd5c0bb96b23d447f39b8"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.nestopia/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.nestopia"
-PKG_VERSION="1.53.2.55-Omega"
-PKG_SHA256="d518375f928c986e0106db0d55c75054e62d423e4f5755cb9dcb0cfb6eadc836"
-PKG_REV="2"
+PKG_VERSION="1.53.2.56-Omega"
+PKG_SHA256="6a52c4524284ce5a576457c40708c19f59ea9febfcd46081098cdba1245683e3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.nestopia"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.opera/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.opera"
-PKG_VERSION="1.0.0.49-Omega"
-PKG_SHA256="6371c328f408d147d8d778249ba9cce43cbd040fd70c853a99b00cdd98e0321f"
-PKG_REV="2"
+PKG_VERSION="1.0.0.51-Omega"
+PKG_SHA256="1ad42a29498c1bbeec73f4a0d8ca74ac6638d4776bb4a4012b405d9d9fe969d8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.opera"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.pcsx-rearmed/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.pcsx-rearmed"
-PKG_VERSION="25.0.0.68-Omega"
-PKG_SHA256="38474ef182958d030d13a7fc75ecccec64eb600552030149cd5a0c72d1cdb327"
-PKG_REV="2"
+PKG_VERSION="25.0.0.70-Omega"
+PKG_SHA256="f127c455dd14471ab9a54df25ba6e3081a8b3842d839c05030081b8f20bddcf6"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.pcsx-rearmed"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.prboom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.prboom"
-PKG_VERSION="2.5.0.53-Omega"
-PKG_SHA256="814450940a23631383c99a0c3f3efab9aa23f251c1ea53719ca69e3851246070"
-PKG_REV="2"
+PKG_VERSION="2.5.0.54-Omega"
+PKG_SHA256="c2fcbfc74a462c26f1f62ad5696ee32e5380af2374619617ee68bd59bd92a7bd"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.prboom"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.stella/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.stella"
-PKG_VERSION="8.0.0.72-Omega"
-PKG_SHA256="d7cb481149d39ca06ea6f606b7e9186d584275201c27df2e361437ab2e93bbdb"
-PKG_REV="2"
+PKG_VERSION="8.0.0.76-Omega"
+PKG_SHA256="fee1a04fd0ce7f11200625659a9597a25b089014492d1a219e912e7dcf35dae3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.stella"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.tyrquake/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.tyrquake"
-PKG_VERSION="0.62.0.50-Omega"
-PKG_SHA256="e19861167d30abae8fa989bd8e85fdac656a57c270ee604b5c4086a74ad6eb19"
-PKG_REV="2"
+PKG_VERSION="0.62.0.51-Omega"
+PKG_SHA256="8445ad91158fbefbd287e31a2aa23ac66e81fb0abdc24e304eeac6467d1ffd23"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.tyrquake"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.uae"
-PKG_VERSION="5.3.0.83-Omega"
-PKG_SHA256="4cf9256728909ce5d5fb97105a969cd78645f98e5321765ca7f063852c481bca"
-PKG_REV="2"
+PKG_VERSION="5.3.1.85-Omega"
+PKG_SHA256="2065a33ee6e04ccf25ef52b730f2ca8e1e0d6abb63d3f81c491a860319140054"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.uae"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vbam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vbam"
-PKG_VERSION="2.2.3.58-Omega"
-PKG_SHA256="9e939592a32b9c899dfd24d3dab618febedab26625aa7278b396079361096063"
-PKG_REV="2"
+PKG_VERSION="2.2.3.63-Omega"
+PKG_SHA256="4b61e351dc9c67db3b6df4749ffb730b7f93e71bb4c8bf24728996fb9ca4d453"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vbam"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vecx/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vecx"
-PKG_VERSION="1.2.0.47-Omega"
-PKG_SHA256="a791b212a5e4c11e6b0a090b494b7d6c44cbeb55a665af6d9f72e7ab417fda6f"
-PKG_REV="2"
+PKG_VERSION="1.2.0.48-Omega"
+PKG_SHA256="a2d5428a11b39a353db9cb09fc8149867114a676fdf68d26df5bb283550caea6"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vecx"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x128/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x128/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_x128"
-PKG_VERSION="3.9.0.29-Omega"
-PKG_SHA256="15fb5ed2d31f9874a06237b512cce91b1d57014454e605f34ee1aa1d1a2da68f"
-PKG_REV="2"
+PKG_VERSION="3.9.0.30-Omega"
+PKG_SHA256="723ee4c051dac96aaa200a63738084ddd495da2b612b9a80c948642e0a3314c7"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vice_x128"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x64/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_x64/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_x64"
-PKG_VERSION="3.9.0.67-Omega"
-PKG_SHA256="2a305834e1041592d6fd6efd310fd26f7ce5d319a1aa3ff0d357d938aa408885"
+PKG_VERSION="3.9.0.68-Omega"
+PKG_SHA256="839488ebc08446a096a893996ed23eac321ac166724cd8c5d9092057834d2d79"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xplus4/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xplus4/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_xplus4"
-PKG_VERSION="3.9.0.30-Omega"
-PKG_SHA256="392ba7b88fb0a9f4c9710c5084bdc82c0e296a5fe81a965f4f3720a38c4e81a4"
-PKG_REV="2"
+PKG_VERSION="3.9.0.31-Omega"
+PKG_SHA256="3ca622a170b136c7cf1fd13eba0fe03b73b3c03f57c880eb4a06a7247d855dfe"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vice_xplus4"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xvic/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.vice_xvic/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.vice_xvic"
-PKG_VERSION="3.9.0.29-Omega"
-PKG_SHA256="be9b4c8ee8a52e8c70a539e31bdca10a32b9bc807f7ae581c6a1ddba975fd899"
-PKG_REV="2"
+PKG_VERSION="3.9.0.30-Omega"
+PKG_SHA256="97d704153c61558aea9bfb4e97c59dc02adc5e2d87ca591f232bf648f64f69d3"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/kodi-game/game.libretro.vice_xvic"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabause/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.yabause"
-PKG_VERSION="0.9.15.63-Omega"
-PKG_SHA256="f7b25683714ada914f2fcd48d82103475d54bf63a54909b847c90fef7134e99e"
-PKG_REV="2"
+PKG_VERSION="0.9.15.64-Omega"
+PKG_SHA256="d3923c8ee1961be99edd97f712a89f4c63e8e616d37284ecf5f8fbaf431818b8"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/kodi-game/game.libretro.yabause"


### PR DESCRIPTION
## Description

I updated all game add-ons to their master libretro branch. This PR syncs the new versions with LE 13 in preparation for Alpha 3.

Note that all binary add-ons now must be bumped due to the potential API changes. I scrutinized and tested and the ABI is the same for Linux. Moreover, game add-ons use the libretro API, not Kodi's API, and _never_ need to be bumped for Kodi add-on API changes (totally isolated). But the global API min version might get baked into the addon.xml files, preventing them from loading on Alpha 3.

UPDATE: Kodi min API version doesn't affect game add-ons, FYI. So no need to bump all.

## How has this been tested?

Confirmed most updated add-ons build for my Generic system. Running a full compile test now.