### PR TITLE
net-snmp: fix net-snmp-config path, default to readonly access

### DIFF
--- a/packages/addons/service/net-snmp/source/default.py
+++ b/packages/addons/service/net-snmp/source/default.py
@@ -61,6 +61,8 @@ def writeconfig():
     if snmpversion == "v3":
         snmppassword = __addon__.getSetting("SNMPPASSWORD")
         snmpuser = __addon__.getSetting("SNMPUSER")
+        snmpauthproto = __addon__.getSetting("SNMPAUTHPROTO")
+        snmpprivproto = __addon__.getSetting("SNMPPRIVPROTO")
         snmppriv = __addon__.getSetting("SNMPPRIV")
         accesslevel = "priv" if snmppriv == "true" else "auth"
         file.write('includeFile ../../snmpd.conf\n')
@@ -72,9 +74,9 @@ def writeconfig():
 
         os.environ["PATH"] += os.pathsep + os.path.join(__addonpath__, "bin")
         if snmpwrite == "true":
-            os.system(f"net-snmp-config --create-snmpv3-user -a SHA-512 -A {quote(snmppassword)} -x AES -X {quote(snmppassword)} {quote(snmpuser)}")
+            os.system(f"net-snmp-config --create-snmpv3-user -a {quote(snmpauthproto)} -A {quote(snmppassword)} -x {quote(snmpprivproto)} -X {quote(snmppassword)} {quote(snmpuser)}")
         else:
-            os.system(f"net-snmp-config --create-snmpv3-user -ro -a SHA-512 -A {quote(snmppassword)} -x AES -X {quote(snmppassword)} {quote(snmpuser)}")
+            os.system(f"net-snmp-config --create-snmpv3-user -ro -a {quote(snmpauthproto)} -A {quote(snmppassword)} -x {quote(snmpprivproto)} -X {quote(snmppassword)} {quote(snmpuser)}")
 
     os.system("systemctl start service.net-snmp.service")
 

--- a/packages/addons/service/net-snmp/source/default.py
+++ b/packages/addons/service/net-snmp/source/default.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
+import os
 import xbmc
 import xbmcvfs
 import xbmcaddon
-from os import system
 
 
 class MyMonitor(xbmc.Monitor):
@@ -26,11 +26,12 @@ persistent = xbmcvfs.translatePath(__addonhome__ + 'snmpd.conf')
 
 
 def writeconfig():
-    system("systemctl stop service.net-snmp.service")
+    os.system("systemctl stop service.net-snmp.service")
     community = __addon__.getSetting("COMMUNITY")
     location = __addon__.getSetting("LOCATION")
     contact = __addon__.getSetting("CONTACT")
     snmpversion = __addon__.getSetting("SNMPVERSION")
+    snmpwrite = __addon__.getSetting("SNMPWRITE")
     cputemp = __addon__.getSetting("CPUTEMP")
     gputemp = __addon__.getSetting("GPUTEMP")
 
@@ -40,7 +41,10 @@ def writeconfig():
     file = xbmcvfs.File(config, 'w')
     file.write('com2sec local default {}\n'.format(community))
     file.write('group localgroup {} local\n'.format(snmpversion))
-    file.write('access localgroup "" any noauth exact all all none\n')
+    if snmpwrite == "true":
+        file.write('access localgroup "" any noauth exact all all none\n')
+    else:
+        file.write('access localgroup "" any noauth exact all none none\n')
     file.write('view all included .1 80\n')
     file.write('syslocation {}\n'.format(location))
     file.write('syscontact {}\n'.format(contact))
@@ -56,10 +60,15 @@ def writeconfig():
         file.write('includeFile ../../snmpd.conf\n')
         snmppassword = __addon__.getSetting("SNMPPASSWORD")
         snmpuser = __addon__.getSetting("SNMPUSER")
-        system("net-snmp-config --create-snmpv3-user -a MD5 -A {0} {1}".format(snmppassword,snmpuser))
+        os.environ["PATH"] += os.pathsep + os.path.join(__addonpath__, "bin")
+        if snmpwrite == "true":
+            os.system("net-snmp-config --create-snmpv3-user -a MD5 -A {0} {1}".format(snmppassword,snmpuser))
+        else:
+            os.system("net-snmp-config --create-snmpv3-user -ro -a MD5 -A {0} {1}".format(snmppassword,snmpuser))
+        file.write(f'group localgroup usm {snmpuser}\n')
 
     file.close()
-    system("systemctl start service.net-snmp.service")
+    os.system("systemctl start service.net-snmp.service")
 
 
 if not xbmcvfs.exists(config):

--- a/packages/addons/service/net-snmp/source/default.py
+++ b/packages/addons/service/net-snmp/source/default.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 import os
+from shlex import quote
 import xbmc
 import xbmcvfs
 import xbmcaddon
@@ -39,15 +40,10 @@ def writeconfig():
         xbmcvfs.delete(persistent)
 
     file = xbmcvfs.File(config, 'w')
-    file.write('com2sec local default {}\n'.format(community))
-    file.write('group localgroup {} local\n'.format(snmpversion))
-    if snmpwrite == "true":
-        file.write('access localgroup "" any noauth exact all all none\n')
-    else:
-        file.write('access localgroup "" any noauth exact all none none\n')
-    file.write('view all included .1 80\n')
-    file.write('syslocation {}\n'.format(location))
-    file.write('syscontact {}\n'.format(contact))
+    file.write('view allview included .1 80\n')
+    writeview = 'allview' if snmpwrite == 'true' else 'none'
+    file.write(f'syslocation {location}\n')
+    file.write(f'syscontact {contact}\n')
     file.write('dontLogTCPWrappersConnects yes\n')
 
     if cputemp == "true":
@@ -56,18 +52,30 @@ def writeconfig():
     if gputemp == "true":
         file.write('extend gputemp "/usr/bin/gputemp"\n')
 
+    if snmpversion != "v3":
+        file.write(f'com2sec local default {community}\n')
+        file.write(f'group localgroup {snmpversion} local\n')
+        file.write(f'access localgroup "" any noauth exact allview {writeview} none\n')
+        file.close()
+
     if snmpversion == "v3":
-        file.write('includeFile ../../snmpd.conf\n')
         snmppassword = __addon__.getSetting("SNMPPASSWORD")
         snmpuser = __addon__.getSetting("SNMPUSER")
+        snmppriv = __addon__.getSetting("SNMPPRIV")
+        accesslevel = "priv" if snmppriv == "true" else "auth"
+        file.write('includeFile ../../snmpd.conf\n')
+        file.write(f'access v3group "" any {accesslevel} exact allview {writeview} none\n')
+        file.write(f'group v3group usm {snmpuser}\n')
+
+        # net-snmp-config modifies snmpd.conf, so we need to stop writing here
+        file.close()
+
         os.environ["PATH"] += os.pathsep + os.path.join(__addonpath__, "bin")
         if snmpwrite == "true":
-            os.system("net-snmp-config --create-snmpv3-user -a MD5 -A {0} {1}".format(snmppassword,snmpuser))
+            os.system(f"net-snmp-config --create-snmpv3-user -a SHA-512 -A {quote(snmppassword)} -x AES -X {quote(snmppassword)} {quote(snmpuser)}")
         else:
-            os.system("net-snmp-config --create-snmpv3-user -ro -a MD5 -A {0} {1}".format(snmppassword,snmpuser))
-        file.write(f'group localgroup usm {snmpuser}\n')
+            os.system(f"net-snmp-config --create-snmpv3-user -ro -a SHA-512 -A {quote(snmppassword)} -x AES -X {quote(snmppassword)} {quote(snmpuser)}")
 
-    file.close()
     os.system("systemctl start service.net-snmp.service")
 
 

--- a/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
@@ -56,3 +56,11 @@ msgstr ""
 msgctxt "#32012"
 msgid "Require encryption"
 msgstr ""
+
+msgctxt "#32013"
+msgid "Authentication protocol"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Privacy protocol"
+msgstr ""

--- a/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
@@ -52,3 +52,7 @@ msgstr ""
 msgctxt "#32011"
 msgid "Write access"
 msgstr ""
+
+msgctxt "#32012"
+msgid "Require encryption"
+msgstr ""

--- a/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/service/net-snmp/source/resources/language/resource.language.en_gb/strings.po
@@ -48,3 +48,7 @@ msgstr ""
 msgctxt "#32010"
 msgid "Expose gputemp"
 msgstr ""
+
+msgctxt "#32011"
+msgid "Write access"
+msgstr ""

--- a/packages/addons/service/net-snmp/source/resources/settings.xml
+++ b/packages/addons/service/net-snmp/source/resources/settings.xml
@@ -36,6 +36,11 @@
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+				<setting id="SNMPWRITE" type="boolean" label="32011" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 			</group>
 			<group id="2" label="32007">
 				<setting id="SNMPUSER" type="string" label="32005" help="">

--- a/packages/addons/service/net-snmp/source/resources/settings.xml
+++ b/packages/addons/service/net-snmp/source/resources/settings.xml
@@ -57,6 +57,33 @@
 						<heading>32006</heading>
 					</control>
 				</setting>
+				<setting id="SNMPAUTHPROTO" type="string" label="32013" help="">
+					<level>0</level>
+					<default>SHA-512</default>
+					<constraints>
+						<options>
+							<option label="SHA-512">SHA-512</option>
+							<option label="SHA-384">SHA-384</option>
+							<option label="SHA-256">SHA-256</option>
+							<option label="SHA-224">SHA-224</option>
+							<option label="SHA-1">SHA</option>
+							<option label="MD5">MD5</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="SNMPPRIVPROTO" type="string" label="32014" help="">
+					<level>0</level>
+					<default>AES128</default>
+					<constraints>
+						<options>
+							<option label="AES128">AES128</option>
+							<option label="AES">AES</option>
+							<option label="DES">DES</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
 				<setting id="SNMPPRIV" type="boolean" label="32012" help="">
 					<level>0</level>
 					<default>true</default>

--- a/packages/addons/service/net-snmp/source/resources/settings.xml
+++ b/packages/addons/service/net-snmp/source/resources/settings.xml
@@ -57,6 +57,11 @@
 						<heading>32006</heading>
 					</control>
 				</setting>
+				<setting id="SNMPPRIV" type="boolean" label="32012" help="">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
 			</group>
 			<group id="3" label="32008">
 				<setting id="CPUTEMP" type="boolean" label="32009" help="">


### PR DESCRIPTION
1) Trying to set net-snmp to use v3 was failing with `kodi.sh[3390844]: sh: net-snmp-config: not found`, because `net-snmp-config` and the `net-snmp-create-v3-user` it calls are in the addon's `bin` folder. This adds that folder to the script's path, and snmp v3 access works now.

2) SNMP write access was enabled by default. This makes it an option that defaults to off for safety.
