### PR TITLE
v4l-utils: backport libdvbv5 DVB-T2 descriptor patch

### DIFF
--- a/packages/sysutils/v4l-utils/patches/v4l-utils-999-pending-t2-descriptor.patch
+++ b/packages/sysutils/v4l-utils/patches/v4l-utils-999-pending-t2-descriptor.patch
@@ -1,0 +1,34 @@
+Subject: libdvbv5: modify T2 delivery system descriptor
+Author:  Martin Vallevand <mvallevand@gmail.com>
+Date:    Fri Jan 2 18:50:48 2026 -0500
+
+ETSI EN 300 468 6.4.4.3 specifies the frequency loop length in the T2
+delivery system descriptor in bytes but libdvbv5 populates  it as the
+number of frequencies in the descriptor.
+
+This change ensures that the byte length is correctly converted
+to the frequency count, preventing potential memory corruption
+and buffer overflows.
+
+Signed-off-by: Martin Vallevand <mvallevand@gmail.com>
+Signed-off-by: Hans Verkuil <hverkuil+cisco@kernel.org>
+
+ lib/libdvbv5/descriptors/desc_t2_delivery.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+---
+
+http://git.linuxtv.org/cgit.cgi/v4l-utils.git/commit/?id=95ad25f6a77a0a6650f5f657ac2c5046efcd04a0
+diff --git a/lib/libdvbv5/descriptors/desc_t2_delivery.c b/lib/libdvbv5/descriptors/desc_t2_delivery.c
+index f88718d350db..5d245cc973c5 100644
+--- a/lib/libdvbv5/descriptors/desc_t2_delivery.c
++++ b/lib/libdvbv5/descriptors/desc_t2_delivery.c
+@@ -76,7 +76,7 @@ int dvb_desc_t2_delivery_init(struct dvb_v5_fe_parms *parms,
+		p += sizeof(uint16_t);
+
+		if (d->tfs_flag) {
+-			d->cell[d->num_cell].num_freqs = *p;
++			d->cell[d->num_cell].num_freqs = *p / sizeof(*d->centre_frequency);
+			p++;
+		}
+		else


### PR DESCRIPTION
This patch is required for parsing T2 descriptors in libdvbv5 otherwise memory corruption could occur

Here is patch on v4-utils.git https://git.linuxtv.org/v4l-utils.git/commit/?id=95ad25f6a77a0a6650f5f657ac2c5046efcd04a0

Discussed with @chewitt who also noted this should be dropped in 7.1 or max 7.2

Sorry for the build issues confirmed patch

```
PROJECT=Generic DEVICE=Generic ARCH=x86_64 scripts/build v4l-utils
UNPACK      v4l-utils
    APPLY PATCH (common)      packages/sysutils/v4l-utils/patches/v4l-utils-003-enable-bpf-without-clang.patch
patching file meson.build
patching file utils/keytable/meson.build
    APPLY PATCH (common)      packages/sysutils/v4l-utils/patches/v4l-utils-999-pending-t2-descriptor.patch
patching file lib/libdvbv5/descriptors/desc_t2_delivery.c
BUILD      v4l-utils (target)
    TOOLCHAIN      meson (auto-detect)
```
