### PR TITLE
pvr.waipu: update to 22.9.0-Piers with nlohmann-json

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.waipu/package.mk
@@ -2,14 +2,14 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.waipu"
-PKG_VERSION="22.8.1-Piers"
-PKG_SHA256="56e3782d7aee99d70c912ef645d89f34abc99c3ff6d8c0e821feacf89a40e530"
+PKG_VERSION="22.9.0-Piers"
+PKG_SHA256="3352e018b6f1ff9d00759508d0ac893c84ad0943005dd4389c0f743007edd22e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/flubshi/pvr.waipu"
 PKG_URL="https://github.com/flubshi/pvr.waipu/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain kodi-platform rapidjson"
+PKG_DEPENDS_TARGET="toolchain kodi-platform nlohmann-json"
 PKG_SECTION=""
 PKG_SHORTDESC="pvr.waipu"
 PKG_LONGDESC="pvr.waipu"


### PR DESCRIPTION
- https://github.com/flubshi/pvr.waipu/issues/418 
- https://github.com/flubshi/pvr.waipu/pull/502

Progressive removal of rapidjson, only 2 references remain.
- https://github.com/rbuehlma/pvr.teleboy/issues/99
- https://github.com/rbuehlma/pvr.zattoo/issues/224