### PR TITLE
p8-platform: drop unused CMAKE_INSTALL_PREFIX_TOOLCHAIN build option

### DIFF
--- a/packages/mediacenter/p8-platform/package.mk
+++ b/packages/mediacenter/p8-platform/package.mk
@@ -12,7 +12,6 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Platform support library used by libCEC and binary add-ons for Kodi"
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_INSTALL_LIBDIR:STRING=lib \
-                       -DCMAKE_INSTALL_PREFIX_TOOLCHAIN=${SYSROOT_PREFIX}/usr \
                        -DBUILD_SHARED_LIBS=0"
 
 post_makeinstall_target() {


### PR DESCRIPTION
- fixes #11175 