### PR TITLE
Support newstyle NBD handshake with export name

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -121,10 +121,13 @@ mount_common() {
 mount_nbd() {
 # Mount NBD device
   NBD_SERVER="${1%%:*}"
-  NBD_PORT="${1#*:}"
+  NBD_REMAIN="${1#*:}"
+  NBD_PORT="${NBD_REMAIN%%:*}"
+  NBD_NAME=""
+  [ "$NBD_REMAIN" != "$NBD_PORT" ] && NBD_NAME="-N ${NBD_REMAIN#*:}"
   NBD_DEV="/dev/nbd$NBD_DEVS"
 
-  nbd-client $NBD_SERVER $NBD_PORT $NBD_DEV >&$SILENT_OUT 2>&1 || error "nbd-client" "Could not connect to NBD server $1"
+  nbd-client $NBD_NAME $NBD_SERVER $NBD_PORT $NBD_DEV >&$SILENT_OUT 2>&1 || error "nbd-client" "Could not connect to NBD server $1"
 
   mount_common "$NBD_DEV" "$2" "$3" "$4"
 


### PR DESCRIPTION
Modern NBD servers multiplex multiple devices through a single port, and use export names to distinguish them. This adds support for specifying an export name while still being backwards compatible with the oldstyle handshake.

Example kernel command line:
boot=NBD=192.168.2.6:10809:le-boot disk=NBD=192.168.2.6:10809:le-storage