### PR TITLE
mesa: update to 26.0.5

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="26.0.4"
-PKG_SHA256="6d91541e086f29bb003602d2c81070f2be4c0693a90b181ca91e46fa3953fe78"
+PKG_VERSION="26.0.5"
+PKG_SHA256="d229c9937d9a25ca0a8958c59f425174563d300ec42acbea2dbe84a055023368"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/26.0.5.rst