### PR TITLE
kodi: update to githash 66a63a8

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="364219ea7cb01c1ee627c56c88c0178d310505a1"
-PKG_SHA256="1e95ef3a8622e7e200dc37076f51e4ddae9a3e262f7e0bb58da6a3028cf69bf2"
+PKG_VERSION="66a63a8378e2808e4dac24096275fc9f1eae4724"
+PKG_SHA256="eb05e2d9e8cf4c4347b9488626d64ab10308164cd3459b1a180e38b8b96230b6"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/364219ea7cb01c1ee627c56c88c0178d310505a1...66a63a8378e2808e4dac24096275fc9f1eae4724
