### PR TITLE
kodi: update to githash c35e1ca

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="66a63a8378e2808e4dac24096275fc9f1eae4724"
-PKG_SHA256="eb05e2d9e8cf4c4347b9488626d64ab10308164cd3459b1a180e38b8b96230b6"
+PKG_VERSION="c35e1ca4bb72fb8abd19bdc84156864e1b4b7433"
+PKG_SHA256="43de8f1efb60ac7639e516faa2517eb676904b37c42f6e619a1219628e02eba2"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/xbmc/xbmc/compare/66a63a8378e2808e4dac24096275fc9f1eae4724...c35e1ca4bb72fb8abd19bdc84156864e1b4b7433
