### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.60.0"
-PKG_SHA256="80e50c1a97d8fd660a3fadb02ca35876df881c266d3d6108fc5b4c113614cb99"
+PKG_VERSION="2.60.1"
+PKG_SHA256="f99b87e3c1674f5fbc417cc9c1d9e261c0f29aab0550ad6369805031d12f6852"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/chrome-depends/cups/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/cups/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cups"
-PKG_VERSION="2.4.16"
-PKG_SHA256="051f4bbfa10924ea399e2a8bef2d94fa3cd8dc8876c5fb4e0a57d23396203395"
+PKG_VERSION="2.4.17"
+PKG_SHA256="382d70da64557362c288ee356525dfb1e674a64a0fb7c0fc028926da58913b73"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.cups.org"
 PKG_URL="https://github.com/openprinting/cups/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="cc347f0246975cde09da43831c227ccae3b73d0953389d0963e6aa04af6de6a1"
+PKG_SHA256="b45d935ab8f5faff8b0a03eb6c5c658636f47bc8170d892152b8eb57f5931315"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="9d7ad9ff180b43ae5577d048a7bac1159ce7bacf"
+export PKG_GIT_COMMIT="055a478ea9010a19d0d4674c0d0e87ade37a4223"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.2.2"
-PKG_SHA256="d6e8e6424c544cdab9b51cae320c3a9aa5590e8e1ffbd1f862eb395fd8c5bc28"
+PKG_VERSION="2.2.3"
+PKG_SHA256="b97780bde4b01ed3596b0b0c6f55bfb130794a3db4e6fe2e0fc9719244933945"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="301b2dac98f15c27117da5c8af12118a041a31d9"
+export PKG_GIT_COMMIT="77c84241c7cbdd9b4eca2591793e3d4f4317c590"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.4.0"
-PKG_SHA256="5c72d84b3dc5558b8520a6687c6d7ee4f13b95edc351a408717e314616a5bfd8"
+PKG_VERSION="29.4.1"
+PKG_SHA256="89ef4a0f681ae2c9f7449591243e1e932d86e6086ac3392a47da80c10b1a3d58"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="daa0cb7f23594cdbcce5002e370027d3fd36ffd7"
+export PKG_GIT_COMMIT="6c91b92cc71077b70c779c510da125301a8e40f3"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/browser/chrome/package.mk
+++ b/packages/addons/browser/chrome/package.mk
@@ -4,8 +4,8 @@
 PKG_NAME="chrome"
 PKG_VERSION="1.0"
 # curl -s http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages | grep -B 1 Version
-PKG_VERSION_NUMBER="147.0.7727.55"
-PKG_REV="2"
+PKG_VERSION_NUMBER="147.0.7727.101"
+PKG_REV="3"
 PKG_ARCH="x86_64"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.google.com/chrome"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/filebrowser/package.mk
+++ b/packages/addons/service/filebrowser/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="filebrowser"
-PKG_VERSION="2.63.1"
-PKG_REV="3"
+PKG_VERSION="2.63.2"
+PKG_REV="4"
 PKG_LICENSE="Apache License 2.0"
 PKG_SITE="https://filebrowser.org"
 PKG_DEPENDS_TARGET="toolchain:host"
@@ -15,15 +15,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="5fda7ad30c54df9ac28bb11a375523a7ed5f11ddaed4001a4f38f9530bf3bde3"
+    PKG_SHA256="246938e22a1d44caae43f114eb087a8553f4fa008fb01155e1acd89a80d257f1"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-arm64-filebrowser.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="12d4c38b4ca4f2bb4401187b5be89666c50cbda4edc0440553256dd99d7ee2e3"
+    PKG_SHA256="efaba5e47fb34441148b42ba5dd5c7f9fd24309f92c037d967f24293eaa0ff2c"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-armv7-filebrowser.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="298a491ae48ae929a2bf10f6fe6f4a63057f8535810244414f078b4e336e859b"
+    PKG_SHA256="5a6bb687af0a4cf6148a6e09b6fc45f60e8d4b159db37b7138f81fc97033a9bb"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-amd64-filebrowser.tar.gz"
     ;;
 esac

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11949"
-PKG_SHA256="c9d27f2d16829fd3a71dd0b2e10275fd4c212f72ebbbffa44c0ca62fbac56ca4"
-PKG_REV="2"
+PKG_VERSION="11952"
+PKG_SHA256="0ebcac71783694952151c9f19ffc4f2344aefacfc52478f5bfb35c16c60599de"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"
@@ -57,12 +57,17 @@ PKG_CMAKE_OPTS_TARGET="\
   -DCW_CYCLE_CHECK=ON \
   -DHAVE_DVBAPI=1 \
   -DHAVE_LIBCRYPTO=1 \
+  -DSTATIC_LIBCRYPTO=0 \
+  -DHAVE_LIBUSB=1 \
   -DSTATIC_LIBUSB=1 \
+  -DHAVE_PCSC=1 \
+  -DSTATIC_PCSC=0 \
   -DWEBIF=1 \
   -DWEBIF_LIVELOG=1 \
   -DWEBIF_JQUERY=1 \
   -DWITH_DEBUG=0 \
   -DWITH_SSL=1 \
+  -DSTATIC_SSL=0 \
   -DWITH_STAPI=0"
 
 makeinstall_target() {

--- a/packages/addons/service/oscam/patches/oscam-0001-link-with-ludev.patch
+++ b/packages/addons/service/oscam/patches/oscam-0001-link-with-ludev.patch
@@ -12,15 +12,15 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 4b08cfc0..2eadd8e2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -640,7 +640,7 @@ else (NOT USE_COMPRESS EQUAL 1)
- 	set (exe_name "oscam-upx")
- endif (NOT USE_COMPRESS EQUAL 1)
- add_executable (${exe_name} ${exe_srcs} ${exe_hdrs})
--target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo)
-+target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo udev)
+@@ -742,7 +742,7 @@
+ if (OSCamOperatingSystem MATCHES "Mac OS X")
+ 	target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo)
+ else (OSCamOperatingSystem MATCHES "Mac OS X")
+-	target_link_libraries (${exe_name} -Wl,--start-group ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt -Wl,--end-group minilzo)
++	target_link_libraries (${exe_name} -Wl,--start-group ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt -Wl,--end-group minilzo udev)
+ endif (OSCamOperatingSystem MATCHES "Mac OS X")
  if (WITH_SIGNING EQUAL 1)
  	SIGN_COMMAND_OSCAM()
- endif (WITH_SIGNING EQUAL 1)
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
 index 49649863..1c368dac 100644
 --- a/utils/CMakeLists.txt

--- a/packages/addons/service/oscam/patches/oscam-0002-pcsc-pthread.patch
+++ b/packages/addons/service/oscam/patches/oscam-0002-pcsc-pthread.patch
@@ -11,14 +11,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 2eadd8e2..9e8b0fc9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -709,6 +709,7 @@ if (HAVE_PCSC)
- if (NOT OSCamOperatingSystem MATCHES "Mac OS X")
- if (NOT OSCamOperatingSystem MATCHES "Windows/Cygwin")
- 	target_link_libraries (${exe_name} pcsclite)
-+	target_link_libraries (${exe_name} pthread)
+@@ -815,6 +815,7 @@
+ 		target_link_libraries (${exe_name} imp_pcsclite)
+ 	else (PCSCDIR OR STATICPCSC)
+ 		target_link_libraries (${exe_name} pcsclite)
++		target_link_libraries (${exe_name} pthread)
+ 	endif (PCSCDIR OR STATICPCSC)
  endif (NOT OSCamOperatingSystem MATCHES "Windows/Cygwin")
  endif (NOT OSCamOperatingSystem MATCHES "Mac OS X")
- endif (HAVE_PCSC)
 -- 
 2.51.0
 

--- a/packages/python/devel/lxml/package.mk
+++ b/packages/python/devel/lxml/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lxml"
-PKG_VERSION="6.0.4"
-PKG_SHA256="4137516be2a90775f99d8ef80ec0283f8d78b5d8bd4630ff20163b72e7e9abf2"
+PKG_VERSION="6.1.0"
+PKG_SHA256="bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://lxml.de"
 PKG_URL="https://github.com/lxml/lxml/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- oscam: update to 11952 and addon (3)
- filebrowser: update to 2.63.2 and addon (4)
- chrome: update to 147.0.7727.101 and addon (3)
  - at-spi2-core: update to 2.60.1
  - cups: update to 2.4.17
  - lxml: update to 6.1.0
- docker: update to 29.4.1 and addon (3)
  - cli: update to 29.4.1
  - moby: update to 29.4.1
  - containerd: update to 2.2.3