### PR TITLE
nextpvr: Update to 7.0.5

### DIFF
--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nextpvr"
-PKG_VERSION="7.0.4"
+PKG_VERSION="7.0.5"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"


### PR DESCRIPTION
Update to 7.0.5  https://forums.nextpvr.com/showthread.php?tid=66893 and includes sdt patch here https://forums.nextpvr.com/showthread.php?tid=66919&pid=607140#pid607140

Testing shows we cannot use the system libdvbv5.so.0  .kodi/addons/service.nextpvr/nextpvr-bin/DeviceHost/x64/DeviceHostLinux: Symbol `delivery_system_name' has different size in shared object, consider re-linking
