### PR TITLE
[le12.2] nextpvr: Update to 7.0.5

### DIFF
--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nextpvr"
-PKG_VERSION="7.0.4"
+PKG_VERSION="7.0.5"
 PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="NextPVR"


### PR DESCRIPTION
LE 12 version of PR #10625 and PR #11198

Upgrade version only LE 12.2 does not include updated libdvbv5
