### PR TITLE
Package updates

### DIFF
--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11953"
-PKG_SHA256="9b271fd04e8696667a5a4333b60cad00ee3ab6bccd034b0fae30d19d5e510a95"
-PKG_REV="4"
+PKG_VERSION="11955"
+PKG_SHA256="57113f6044a85d2cd7146617780ba383dbb3ae2d62f12f587556a5d26c73bba5"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="espeak-ng"
-PKG_VERSION="0d451f8c1c6ae837418b823bd9c4cbc574ea9ff5"
-PKG_SHA256="e0c9737c57f07bf351d3ae85d8c1e90faae36302d697ba2d646780e2b2e8f41a"
+PKG_VERSION="724808c5a83f9ef95fdd0db886ba7ba537ff224a"
+PKG_SHA256="7d8ebd78201923a443245362a928999977d1721c3eeba596eafc6ea8db7e243c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/espeak-ng/espeak-ng"
 PKG_URL="https://github.com/espeak-ng/espeak-ng/archive/${PKG_VERSION}.tar.gz"
@@ -15,11 +15,13 @@ PKG_BUILD_FLAGS="+pic"
 PKG_CMAKE_OPTS_HOST="-DBUILD_SHARED_LIBS=OFF \
                      -DCOMPILE_INTONATIONS=OFF \
                      -DENABLE_TESTS=OFF \
+                     -DESPEAK_COMPAT=OFF \
                      -DUSE_LIBSONIC=ON"
 
 PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=ON \
                        -DCOMPILE_INTONATIONS=ON \
                        -DENABLE_TESTS=OFF \
+                       -DESPEAK_COMPAT=OFF \
                        -DUSE_LIBSONIC=ON \
                        -DNativeBuild_DIR=${TOOLCHAIN}/bin"
 

--- a/packages/graphics/lcms2/package.mk
+++ b/packages/graphics/lcms2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lcms2"
-PKG_VERSION="2.18"
-PKG_SHA256="ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347"
+PKG_VERSION="2.19"
+PKG_SHA256="49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216"
 PKG_LICENSE="MIT/GPLv3"
 PKG_SITE="http://www.littlecms.com"
 PKG_URL="https://github.com/mm2/Little-CMS/releases/download/lcms${PKG_VERSION}/lcms2-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pypackaging/package.mk
+++ b/packages/python/devel/pypackaging/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pypackaging"
-PKG_VERSION="26.1"
-PKG_SHA256="f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+PKG_VERSION="26.2"
+PKG_SHA256="ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/build/"
 PKG_URL="https://files.pythonhosted.org/packages/source/p/packaging/packaging-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/python-pathspec/package.mk
+++ b/packages/python/devel/python-pathspec/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="python-pathspec"
-PKG_VERSION="1.0.4"
-PKG_SHA256="7612ec6e67f4ea83b9987367a3bbd76bf3e7466bf33769a8810509774b26862d"
+PKG_VERSION="1.1.0"
+PKG_SHA256="5293f467f198f66e16351eb221a7eea0955b15820d4006601d79741fc21d3485"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://github.com/cpburnz/python-pathspec"
 PKG_URL="https://github.com/cpburnz/python-pathspec/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpg-error"
-PKG_VERSION="1.59"
-PKG_SHA256="a19bc5087fd97026d93cb4b45d51638d1a25202a5e1fbc3905799f424cfa6134"
+PKG_VERSION="1.60"
+PKG_SHA256="11b2a738e212f3eab0fe8637bc341d3181ca964e97bb2654de91aab7dae4ce09"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libgpg-error/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.123"
-PKG_SHA256="4108c1467923b0dfbcc373da986792439a3c12cb1c294b646c31c55424717bfe"
+PKG_VERSION="3.123.1"
+PKG_SHA256="6f5acfed6b76ce29ef2b8d44515f08d0e122500ddc03e16d060f4693a004d500"
 PKG_LICENSE="Mozilla Public License"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.7.5"
-PKG_SHA256="1032dfef4ff17f70464827daa28369b20f6584d108bc36f17ab1676e1edd2f91"
+PKG_VERSION="2.8.0"
+PKG_SHA256="a37bfae0aa9775bd8521ebd85dc456d486f0ff31138f6c91fd902ea732624542"
 PKG_LICENSE="OSS"
 PKG_SITE="https://libexpat.github.io"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="d9d1e5f686b0c2b766c7174d4937905414505326"
-PKG_SHA256="8c106d1451d0ea463db3613299a404450db7afa7cf99a11bca3e142d63535efd"
+PKG_VERSION="d74d6da1c20a300e5fec7827fe75b5d1b2a337ff"
+PKG_SHA256="f4782e49606ad1ed8a7616a5dcb67027cff3e4914832169f1473008fe9ae0358"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"

--- a/packages/wayland/weston/package.mk
+++ b/packages/wayland/weston/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="weston"
-PKG_VERSION="15.0.0"
-PKG_SHA256="58c6186d29a5d2f0be0dec4882af71cc190a11da803f6ed1bf0b2c74120da973"
+PKG_VERSION="15.0.1"
+PKG_SHA256="551d039bfb0c837ba5a4d027cdb8ee16bded0eedb789821f8025d8a64b791f6d"
 PKG_LICENSE="MIT"
 PKG_SITE="https://wayland.freedesktop.org/"
 PKG_URL="https://gitlab.freedesktop.org/wayland/weston/-/releases/${PKG_VERSION}/downloads/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- bcm2835-utils: update to githash d74d6da
- weston: update to 15.0.1
- expat: update to 2.8.0
- nss: update to 3.123.1
- python-pathspec: update to 1.1.0
- oscam: update to 11955 and addon (5)
- lcms2: update to 2.19
- libgpg-error: update to 1.60
- pypackaging: update to 26.2
- espeak-ng: update to githash 724808c