### PR TITLE
wireless-regdb: update to 2026.03.18

### DIFF
--- a/packages/network/wireless-regdb/package.mk
+++ b/packages/network/wireless-regdb/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireless-regdb"
-PKG_VERSION="2026.02.04"
-PKG_SHA256="0ff48a5cd9e9cfe8e815a24e023734919e9a3b7ad2f039243ad121cf5aabf6c6"
+PKG_VERSION="2026.03.18"
+PKG_SHA256="5fc0000475d8c5368ccc5222827c16aef98b1eb6a69c9b5a3e7b7e98528945ac"
 PKG_LICENSE="GPL"
 PKG_SITE="https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb"
 PKG_URL="https://www.kernel.org/pub/software/network/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
Release notes:
- https://git.kernel.org/pub/scm/linux/kernel/git/wens/wireless-regdb.git