### PR TITLE
game.libretro.puae2021: introduce puae2021 emulator

### DIFF
--- a/packages/emulation/libretro-uae2021/package.mk
+++ b/packages/emulation/libretro-uae2021/package.mk
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-uae2021"
+PKG_VERSION="f6502b1990a26ec86328c18c9e8586bbfa2f38c5"
+PKG_SHA256="b0ba2bc5e3941702d0a7e83f052fb3a5771705905bf76f4bba52fed8adc9f3db"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/libretro/libretro-uae"
+PKG_URL="https://github.com/libretro/libretro-uae/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Portable Commodore Amiga Emulator (2021)"
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="puae2021_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="UAE_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+
+  mkdir -p ${SYSROOT_PREFIX}/usr/share/retroarch/system/uae_data
+  cp -vR ${PKG_BUILD}/sources/uae_data/* ${SYSROOT_PREFIX}/usr/share/retroarch/system/uae_data/
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.uae2021/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.uae2021/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.uae2021"
+PKG_VERSION="6faa6c5ed8ef7e51b6232227ddeff7f92103a5aa"
+PKG_SHA256="e3ab7626d1e2e807f0df3f8b37ee04e43ef9c7cdcca1feb3b5fb8085aa40af69"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/kodi-game/game.libretro.uae2021"
+PKG_URL="https://github.com/kodi-game/game.libretro.uae2021/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform libretro-uae2021"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.uae2021: uae emulator for Kodi (2021 version)"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
this emulator uses 2.6.1 branch of the libretro-uae core

This PR requires [this](https://github.com/mczerski/game.libretro.uae2021) repo to be added to https://github.com/kodi-game project

The rationale for this emulation core is that the libretro-uae from 2.6.1 branch requires much less CPU power to run smoothly. As example using this core it is actually possible to play amiga games on amlogic gxl platform which is impossible using master branch of libretro-uae