### PR TITLE
gcc: update to 16.1.0

### DIFF
--- a/packages/compress/7-zip/patches/7-zip-0008-Fix-Globally-suppress-GCC-16-Warray-bounds-false-pos.patch
+++ b/packages/compress/7-zip/patches/7-zip-0008-Fix-Globally-suppress-GCC-16-Warray-bounds-false-pos.patch
@@ -1,0 +1,70 @@
+From: YOKOTA Hiroshi <yokota.hgml@gmail.com>
+Date: Sun, 29 Mar 2026 15:08:33 +0900
+Subject: Fix: Globally suppress GCC 16+ -Warray-bounds false positives
+ (Closes: #1132057)
+
+Forwarded: https://sourceforge.net/p/sevenzip/bugs/2604/
+
+[ Description ]
+Switching from local pragma fixes to global suppression for the
+'-Warray-bounds' warning on GCC 16 and newer.
+
+[ Technical Visualization ]
+The following diagram illustrates why the compiler's static analysis
+fails to correctly map the object boundaries in 7-Zip's architecture:
+
+1. ALLOCATION:
+   An object (e.g., CHandler) is allocated with a fixed size (N bytes).
+
+2. MULTIPLE INHERITANCE / COM CASTING:
+   The object inherits from multiple interfaces. When accessed via a
+   specific interface pointer, the "vtable" and "member offsets"
+   shift relative to the base pointer.
+
+3. OPTIMIZER MISINTERPRETATION:
+   +-------------------------------------------------------+
+   | [VTable A] | [VTable B] | [_m_RefCount] | [Data...]   |
+   +-------------------------------------------------------+
+   ^            ^            ^
+   |            |            |
+   |            |            +-- GCC Flags: "Access here is out of bounds!"
+   |            |                (Based on an incorrect inferred size)
+   |            +-- Interface B Pointer
+   +-- Interface A Pointer / Original Object
+
+[ Reason for Global Suppression ]
+While local pragmas (push/pop) are generally preferred, the recurring
+nature of this error across various modules (HandlerCont.cpp,
+RarHandler.cpp, FilterCoder.h, etc.) indicates a systemic conflict
+between 7-Zip's COM-like architecture and modern GCC's devirtualization
+logic.
+
+Globally ignoring this specific warning for GCC 16+ is the most
+maintainable solution to ensure build stability without refactoring
+the entire interface system.
+
+Ref: GCC Bugzilla #101476 (False positive bounds check in devirt)
+---
+ CPP/Common/MyCom.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/CPP/Common/MyCom.h b/CPP/Common/MyCom.h
+index a177900..2c8c9ab 100644
+--- a/CPP/Common/MyCom.h
++++ b/CPP/Common/MyCom.h
+@@ -6,6 +6,15 @@
+ #include "MyWindows.h"
+ #include "MyTypes.h"
+ 
++/* * GCC 16+ False Positive Fix:
++ * Global suppression of -Warray-bounds for COM-like interface structures.
++ * This prevents erroneous "out of bounds" warnings triggered by
++ * devirtualization optimizations in multiple inheritance scenarios.
++ */
++#if defined(__GNUC__) && (__GNUC__ >= 16)
++  #pragma GCC diagnostic ignored "-Warray-bounds"
++#endif
++
+ template <class T>
+ class CMyComPtr
+ {

--- a/packages/devel/binutils/patches/binutils-03-libctf-gcc-16.patch
+++ b/packages/devel/binutils/patches/binutils-03-libctf-gcc-16.patch
@@ -1,0 +1,13 @@
+--- a/include/ctf.h	2025-11-10 00:00:00.000000000 +0000
++++ b/include/ctf.h	2025-11-16 22:34:45.000000000 +0000
+@@ -423,6 +423,10 @@
+ #define CTF_K_CONST	12	/* ctt_type is base type.  */
+ #define CTF_K_RESTRICT	13	/* ctt_type is base type.  */
+ #define CTF_K_SLICE	14	/* Variant data is a ctf_slice_t.  */
++#define CTF_K_DECL_TAG	15	/* Declaration tag.  Internal use only.
++				   Not valid externally until CTF V4.  */
++#define CTF_K_TYPE_TAG	16	/* Type tag.  Internal use only.
++				   Not valid externally until CTF V4.  */
+ 
+ #define CTF_K_MAX	63	/* Maximum possible (V2) CTF_K_* value.  */
+ 

--- a/packages/emulation/libretro-cannonball/patches/libretro-cannonball-0041-Set-the-c--17-standard.patch
+++ b/packages/emulation/libretro-cannonball/patches/libretro-cannonball-0041-Set-the-c--17-standard.patch
@@ -1,0 +1,23 @@
+From 685d64b157686a19b4fecc88fc0eacd64134e054 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 2 Jan 2026 23:41:38 +1100
+Subject: [PATCH] Set the C++17 standard
+
+Code does not compile with -std=c++20 so set the standard to c++17 for Unix platforms.
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 83629b66..2d3f6bc0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -83,6 +83,8 @@ ifneq (,$(findstring unix,$(platform)))
+       endif
+    endif
+ 
++   CXXFLAGS += --std=c++17
++
+ # OS X
+ else ifeq ($(platform), osx)
+    TARGET := $(TARGET_NAME)_libretro.dylib

--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gcc"
-PKG_VERSION="15.2.0"
-PKG_SHA256="438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
+PKG_VERSION="16.1.0"
+PKG_SHA256="50efb4d94c3397aff3b0d61a5abd748b4dd31d9d3f2ab7be05b171d36a510f79"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://gcc.gnu.org/"
-PKG_URL="https://ftpmirror.gnu.org/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://ftpmirror.gnu.org/gnu/gcc/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_BOOTSTRAP="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host glibc libxcrypt"

--- a/tools/docker/resolute/Dockerfile
+++ b/tools/docker/resolute/Dockerfile
@@ -17,8 +17,8 @@ RUN useradd docker -U -G sudo -m -s /bin/bash \
 
 RUN apt-get update \
  && apt-get install -y \
-    curl bash bc gcc-15 cpp-15 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
-      unzip diffutils lzop make file g++-15 xfonts-utils xsltproc default-jre-headless python3 \
+    curl bash bc gcc-16 cpp-16 sed patch patchutils tar bzip2 gzip xz-utils zstd perl gawk gperf zip \
+      unzip diffutils lzop make file g++-16 xfonts-utils xsltproc default-jre-headless python3 \
       libc6-dev libcrypt-dev libncurses5-dev libjson-perl libxml-parser-perl libparse-yapp-perl rdfind \
       golang-1.26-go git openssh-client rsync upx-ucl \
     --no-install-recommends \
@@ -32,10 +32,10 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100 \
-    --slave /usr/bin/cpp cpp /usr/bin/cpp-15 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-15 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-15
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100 \
+    --slave /usr/bin/cpp cpp /usr/bin/cpp-16 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-16 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-16
 RUN update-alternatives --config gcc
 
 USER docker


### PR DESCRIPTION
## Draft

LibreELEC master has been building with GCC 16 since around November 2025. This change updates the toolchain to the official GCC 16.1 release (expected 30 April 2026).

Commits:

- tools/docker/resolute: use gcc-16 as host compiler
- gcc: update to 16.1.0-RC-20260424
- binutils: allow gcc-16 build
- libretro-cannonball: build with -std=c++17 as the code does not build with -std=c++20
  - https://github.com/libretro/cannonball/issues/40
  - https://github.com/libretro/cannonball/pull/41
- 7-zip: fix gcc-16 build
  - https://sourceforge.net/p/sevenzip/bugs/2604/

Reference:
- GCC mailing list (April 2026 thread): https://gcc.gnu.org/pipermail/gcc/2026-April/thread.html