### PR TITLE
Package updates

### DIFF
--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11955"
-PKG_SHA256="57113f6044a85d2cd7146617780ba383dbb3ae2d62f12f587556a5d26c73bba5"
-PKG_REV="5"
+PKG_VERSION="11958"
+PKG_SHA256="0a305c6871260d79a2f928c5d72835206bd20aa3a3fddaf4130f77ffa1600d5a"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/devel/ccache/package.mk
+++ b/packages/devel/ccache/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccache"
-PKG_VERSION="4.13.4"
-PKG_SHA256="4a7ef278b39d031b9ec524c0778d24bdb3e761940ed368060b54594f15559537"
+PKG_VERSION="4.13.5"
+PKG_SHA256="7a8945f4ac7d4bb79c0055cd3db7857a6934c2b7ab3d80bb11a0f5271e36fd94"
 PKG_LICENSE="GPL"
 PKG_SITE="https://ccache.dev/download.html"
 PKG_URL="https://github.com/ccache/ccache/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/python-pathspec/package.mk
+++ b/packages/python/devel/python-pathspec/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="python-pathspec"
-PKG_VERSION="1.1.0"
-PKG_SHA256="5293f467f198f66e16351eb221a7eea0955b15820d4006601d79741fc21d3485"
+PKG_VERSION="1.1.1"
+PKG_SHA256="7befd398baeb84cd3872bcb84926e688361012d21c8c157dcc2f9f64684b9147"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://github.com/cpburnz/python-pathspec"
 PKG_URL="https://github.com/cpburnz/python-pathspec/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/x11/app/xrandr/package.mk
+++ b/packages/x11/app/xrandr/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xrandr"
-PKG_VERSION="1.5.3"
-PKG_SHA256="f8dd7566adb74147fab9964680b6bbadee87cf406a7fcff51718a5e6949b841c"
+PKG_VERSION="1.5.4"
+PKG_SHA256="2cafccb2aaf2491a4068676117a0d4f90ab307724b96fffc54cd1da953779400"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/app/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/x11/font/font-util/package.mk
+++ b/packages/x11/font/font-util/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="font-util"
-PKG_VERSION="1.4.1"
-PKG_SHA256="5c9f64123c194b150fee89049991687386e6ff36ef2af7b80ba53efaf368cc95"
+PKG_VERSION="1.4.2"
+PKG_SHA256="02e4f8afdcf03cc8372ca9c37aa104b1e36b47722dbc79531be08f0a4c622999"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.X.org"
 PKG_URL="https://xorg.freedesktop.org/archive/individual/font/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- oscam: update to 11958 and addon (6)
- python-pathspec: update to 1.1.1
- ccache: update to 4.13.5
- font-util: update to 1.4.2
- xrandr: update to 1.5.4