### PR TITLE
snapclient: Support whitespace in "Host ID" field

### DIFF
--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -26,9 +26,9 @@ case "$DISTRO_ARCH" in
     ;;
 esac
 
-[ -n "$sc_h" ] && sc_H="--hostID $sc_h"
-[ -n "$sc_s" ] && sc_S="--soundcard $sc_s"
-[ -n "$sc_addr" ] && HOST="--host $sc_addr"
+[ -n "$sc_h" ] && sc_H="--hostID '$sc_h'"
+[ -n "$sc_s" ] && sc_S="--soundcard '$sc_s'"
+[ -n "$sc_addr" ] && HOST="--host '$sc_addr'"
 
 HOME="$ADDON_HOME" \
 nice -n "$sc_n" \


### PR DESCRIPTION
Fix the bug reported in the main post of #10746.

Does *not* tackle the [follow-up in the first comment](https://github.com/LibreELEC/LibreELEC.tv/issues/10746#issuecomment-3603157450):

> If this is picked up, probably makes sense to update the command more thoroughly since hostname and port params are deprecated in favor of unnamed param for server url. So my examples above would become
>
> `snapclient --hostID 'libre elec' --latency 0 tcp://127.0.0.1:1704`

Probably it makes sense to split out that comment into a separate issue.