### PR TITLE
[le12.0] kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.teleboy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.teleboy"
-PKG_VERSION="21.0.2-Omega"
-PKG_SHA256="d6fa3bfc7b241b092360ddf00f32175e020176c54f3aba9f740066919de01e32"
+PKG_VERSION="21.0.3-Omega"
+PKG_SHA256="d65e3ad48823880ecaa3127046ca31ff8624bc35223d7f2e8c560980071643db"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.zattoo/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.zattoo"
-PKG_VERSION="21.0.6-Omega"
-PKG_SHA256="f6df1fa29ec3778f591281f57190099bf5a510c293c711ea978497556765352f"
+PKG_VERSION="21.0.7-Omega"
+PKG_SHA256="d57efceff2f451cc8864d429abed6c7d808ea5092fddf3ece3f598d4a5e26b1f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- pvr.teleboy: update 21.0.2-Omega to 21.0.3-Omega
- pvr.zattoo: update 21.0.6-Omega to 21.0.7-Omega