### PR TITLE
iptables: drop --reject-with from REJECT rules for nf_tables compatib…

### DIFF
--- a/packages/network/iptables/config/home.v4
+++ b/packages/network/iptables/config/home.v4
@@ -27,7 +27,7 @@
 -A private-subnets -s 10.0.0.0/8 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
 -A private-subnets -s 172.16.0.0/12 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
 -A private-subnets -s 192.168.0.0/16 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
--A private-subnets -j REJECT --reject-with icmp-port-unreachable
+-A private-subnets -j REJECT
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]

--- a/packages/network/iptables/config/home.v6
+++ b/packages/network/iptables/config/home.v6
@@ -17,7 +17,7 @@
 -A private-subnets -s fc00::/7 -i wl+ -m conntrack --ctstate NEW -j ACCEPT
 -A private-subnets -s fc00::/7 -i tether -m conntrack --ctstate NEW -j ACCEPT
 -A private-subnets -s fc00::/7 -i docker+ -m conntrack --ctstate NEW -j ACCEPT
--A private-subnets -j REJECT --reject-with icmp6-port-unreachable
+-A private-subnets -j REJECT
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]

--- a/packages/network/iptables/config/public.v4
+++ b/packages/network/iptables/config/public.v4
@@ -14,7 +14,7 @@
 -A FORWARD -o tether -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 # Block DOCKER
 -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
--A DOCKER-USER -j REJECT --reject-with icmp-port-unreachable
+-A DOCKER-USER -j REJECT
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]

--- a/packages/network/iptables/config/public.v6
+++ b/packages/network/iptables/config/public.v6
@@ -1,4 +1,4 @@
-# Netfilter Rules for trusted home networks.
+# Netfilter rules for public "untrusted" networks
 *filter
 :INPUT DROP [0:0]
 :FORWARD DROP [0:0]
@@ -13,7 +13,7 @@
 -A FORWARD -i tether -s fc00::/7 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 -A FORWARD -o tether -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A DOCKER-USER -j REJECT --reject-with icmp6-port-unreachable
+-A DOCKER-USER -j REJECT
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]


### PR DESCRIPTION
…ility

iptables-restore (nf_tables backend) does not support the --reject-with option. Remove it from all four rule files, as the default behaviour is identical (icmp-port-unreachable for IPv4, icmp6-port-unreachable for IPv6).

Also fix copy-paste error in public.v6 comment which said "trusted home networks" instead of "untrusted public networks".

- fixes https://forum.libreelec.tv/thread/30424-firewall-not-working/