### PR TITLE
Package updates

### DIFF
--- a/packages/network/ethtool/package.mk
+++ b/packages/network/ethtool/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ethtool"
-PKG_VERSION="6.19"
-PKG_SHA256="1c2114ab6e0c0d2aa67d699960eb11df4f341e2403139cdf28ae9da858a6025f"
+PKG_VERSION="7.0"
+PKG_SHA256="660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.kernel.org/pub/software/network/ethtool/"
 PKG_URL="https://www.kernel.org/pub/software/network/ethtool/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/Mako/package.mk
+++ b/packages/python/devel/Mako/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="Mako"
-PKG_VERSION="1.3.11"
-PKG_SHA256="071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069"
+PKG_VERSION="1.3.12"
+PKG_SHA256="9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://pypi.org/project/Mako"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/mako-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/trove-classifiers/package.mk
+++ b/packages/python/devel/trove-classifiers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="trove-classifiers"
-PKG_VERSION="2026.1.14.14"
-PKG_SHA256="aad9b7b24472eda66c29566d546804ac5eaf625ceed359a16fd25e3351766102"
+PKG_VERSION="2026.4.28.13"
+PKG_SHA256="aed0cb5c0a0e6616d369eb1407ba235c971f4cd28bc9e58bb8a6b75e1da4734d"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/pypa/trove-classifiers"
 PKG_URL="https://github.com/pypa/trove-classifiers/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- trove-classifiers: update to 2026.4.28.13
- Mako: update to 1.3.12
- ethtool: update to 7.0