### PR TITLE
media-driver: fix build with gcc-16

### DIFF
--- a/packages/multimedia/media-driver/patches/media-driver-1974-suppress-dangling-pointer-warning-in-mhw_state_heap_g8.patch
+++ b/packages/multimedia/media-driver/patches/media-driver-1974-suppress-dangling-pointer-warning-in-mhw_state_heap_g8.patch
@@ -1,0 +1,12 @@
+--- a/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c	2025-11-27 10:21:23.000000000 +0000
++++ b/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c	2025-11-27 10:21:23.000000000 +0000
+@@ -831,7 +831,9 @@
+         mhw_state_heap_g8_X::SAMPLER_STATE_CMD          unormSampler;
+         mhw_state_heap_g8_X::SAMPLER_INDIRECT_STATE_CMD indirectState;
+ 
++#pragma GCC diagnostic ignored "-Wdangling-pointer"
+         pParam->Unorm.pIndirectState = &indirectState;
++#pragma GCC diagnostic warning "-Wdangling-pointer"
+ 
+         MHW_MI_CHK_STATUS(SetSamplerState(&unormSampler, pParam));
+ 


### PR DESCRIPTION
- missed this in #11218

- https://github.com/intel/media-driver/issues/1974

fix(media-driver): suppress dangling-pointer warning in mhw_state_heap_g8

GCC 12+ treats -Wdangling-pointer as an error, causing build failures when storing the address of local variable 'indirectState' in pParam.

Add pragma to suppress the warning around the assignment on line 834 of mhw_state_heap_g8.c as the pointer is consumed before the function returns.