### PR TITLE
kodi: fix build with GCC 16.1 on armv7

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -14,6 +14,10 @@ PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."
 PKG_BUILD_FLAGS="+speed"
 
+if [ "${TARGET_ARCH}" = "arm" ]; then
+  PKG_BUILD_FLAGS+=" -gold"
+fi
+
 configure_package() {
   # Single threaded LTO is very slow so rely on Kodi for parallel LTO support
   if [ "${LTO_SUPPORT}" = "yes" ] && ! build_with_debug; then
@@ -313,6 +317,9 @@ makeinstall_host() {
 
 pre_configure_target() {
   export LIBS="${LIBS} -lncurses"
+  if [ "${TARGET_ARCH}" = "arm" ]; then
+    LDFLAGS+=" -Wl,--allow-shlib-undefined"
+  fi
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
GCC 16.1 incorrectly marks std::string special member functions with hidden visibility during armv7 LTO partitioning, causing ld.gold to reject them as "hidden symbol not defined locally" in discarded COMDAT sections. This does not affect x86-64 or aarch64 builds.

Fix by disabling ld.gold for armv7 targets, falling back to ld.bfd which handles GCC 16.1's incorrect symbol visibility more leniently.

Also add -Wl,--allow-shlib-undefined for armv7 to handle Samba private library transitive dependencies (libtevent-private-samba.so etc.) which ld.bfd treats as hard errors rather than warnings.

No LTO settings required to change.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125125