### PR TITLE
gcc: fix static linking with libatomic on ARMv7 for GCC 16

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -13,6 +13,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_HOST="ccache:host autoconf:host binutils:host gmp:host mpfr:host mpc:host zstd:host glibc libxcrypt"
 PKG_DEPENDS_INIT="toolchain"
 PKG_LONGDESC="This package contains the GNU Compiler Collection."
+PKG_BUILD_FLAGS="-cfg-libs:host"
 
 if [ "${MOLD_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_HOST+=" mold:host"
@@ -21,9 +22,11 @@ fi
 case ${TARGET_ARCH} in
   arm | riscv64)
     OPTS_LIBATOMIC="--enable-libatomic"
+    OPTS_STATIC="--enable-static"
     ;;
   *)
     OPTS_LIBATOMIC="--disable-libatomic"
+    OPTS_STATIC="--disable-static"
     ;;
 esac
 
@@ -74,7 +77,7 @@ PKG_CONFIGURE_OPTS_HOST="${GCC_COMMON_CONFIGURE_OPTS} \
                          --enable-decimal-float \
                          --enable-tls \
                          --enable-shared \
-                         --disable-static \
+                         ${OPTS_STATIC} \
                          --enable-long-long \
                          --enable-threads=posix \
                          --disable-libstdcxx-pch \


### PR DESCRIPTION
This was identified in the addon builds for ARMv7 where there are packages (e.g. tini) that want to link against a static libatomic


GCC 16 introduced a new libatomic_asneeded mechanism via a spec entry that injects -latomic_asneeded into the link for ARM targets. The upstream fix in commit r16-6892 [1] creates libatomic_asneeded.a as a symlink to libatomic.a, but this symlink is only created conditionally when libatomic.a exists:

  if test -f libatomic.a; then rm -f libatomic_asneeded.a; \
  $(LN_S) libatomic.a libatomic_asneeded.a; fi

The default build harness injects --disable-static --enable-shared into all host configure invocations. This prevents libatomic.a from being built, causing the upstream conditional symlink creation to silently do nothing, breaking all static builds on ARM targets.

Fix this by adding PKG_BUILD_FLAGS="-cfg-libs:host" to disable the build harness injection for the gcc package, and conditionally passing --enable-static for ARM targets (the same architectures that enable libatomic) and --disable-static for all other targets, preserving the existing behaviour for non-affected architectures.

With --enable-static in effect, libatomic.a is built by GCC's libatomic sub-build, the upstream if test -f libatomic.a condition succeeds, and libatomic_asneeded.a is correctly created as a symlink to libatomic.a in both the GCC object directory and the toolchain sysroot.

This was not an issue with GCC 15 which did not have the libatomic_asneeded mechanism.

[1] https://gcc.gnu.org/pipermail/gcc-cvs/2026-January/448098.html