### PR TITLE
linux: fixed Vol+/Vol-/Mute panel buttons not working in iMON VFD HID…

### DIFF
--- a/packages/linux/patches/default/linux-070-add_keys_imon_vfd_hid_oem_v1_2.patch
+++ b/packages/linux/patches/default/linux-070-add_keys_imon_vfd_hid_oem_v1_2.patch
@@ -1,0 +1,13 @@
+--- linux-7.0.1/drivers/media/rc/imon.c	2026-05-01 09:57:24.692719350 +0200
++++ linux-7.0.1.patch/drivers/media/rc/imon.c	2026-05-01 10:45:45.332755831 +0200
+@@ -290,6 +290,10 @@ static const struct imon_usb_dev_descr i
+ 		{ 0x000100000000ffeell, KEY_VOLUMEUP },
+ 		{ 0x010000000000ffeell, KEY_VOLUMEDOWN },
+ 		{ 0x000000000100ffeell, KEY_MUTE },
++		/* iMON VFD HID OEM v1.2 */
++		{ 0x000000000a00ffeell, KEY_VOLUMEUP },
++		{ 0x000000000b00ffeell, KEY_VOLUMEDOWN },
++		{ 0x000000000c00ffeell, KEY_MUTE },
+ 		/* 0xffdc iMON MCE VFD */
+ 		{ 0x00010000ffffffeell, KEY_VOLUMEUP },
+ 		{ 0x01000000ffffffeell, KEY_VOLUMEDOWN },


### PR DESCRIPTION
This patch fix an issue with one version of the iMON VFD where three front panel button events are not detected:
Event code 113 (KEY_MUTE)
Event code 114 (KEY_VOLUMEDOWN)
Event code 115 (KEY_VOLUMEUP)

This version, identified as iMON VFD HID OEM v1.2, is present in the Thermaltake Mozart Sx case.
Device is iMON Panel, Knob, and Mouse (15c2:0036).
I performed an investigation by capturing packets sent by the module on the USB port and found the following differences:
Button Mute = 00000000 0c00.... vs. 00000000 0100....
Button + = 00000000 0a00.... vs. 01000000 0000....
Button - = 00000000 0b00.... vs. 00010000 0000....

My simple solution is to add the three missing codes to the key_table in imon.c:
/* iMON VFD HID OEM v1.2 */
{ 0x000000000a00ffeell, KEY_VOLUMEUP },
{ 0x000000000b00ffeell, KEY_VOLUMEDOWN },
{ 0x000000000c00ffeell, KEY_MUTE },

After the change, I successfully verified that all events of front panel and remote control were working (with evtest).
