### PR TITLE
tools.externalhelper: add default.py which opens addon settings

### DIFF
--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""

--- a/packages/addons/tools/externalhelper/source/addon.xml
+++ b/packages/addons/tools/externalhelper/source/addon.xml
@@ -7,7 +7,9 @@
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.python.module" library="resources/lib/" />
-  <extension point="xbmc.python.script" library="default.py" />
+  <extension point="xbmc.python.script" library="default.py">
+    <provides>executable</provides>
+  </extension>
   <extension point="xbmc.addon.metadata">
     <summary>@PKG_SHORTDESC@</summary>
     <description>

--- a/packages/addons/tools/externalhelper/source/default.py
+++ b/packages/addons/tools/externalhelper/source/default.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+if __name__ == '__main__':
+    import xbmcaddon
+    xbmcaddon.Addon().openSettings()


### PR DESCRIPTION
This fixes the "Not executing non-existing script" error when trying to start the externalhelper addon