### PR TITLE
tools.externalhelper: fix extensionpoint order in addon.xml

### DIFF
--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""

--- a/packages/addons/tools/externalhelper/source/addon.xml
+++ b/packages/addons/tools/externalhelper/source/addon.xml
@@ -6,10 +6,10 @@
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
-  <extension point="xbmc.python.module" library="resources/lib/" />
   <extension point="xbmc.python.script" library="default.py">
     <provides>executable</provides>
   </extension>
+  <extension point="xbmc.python.module" library="resources/lib/" />
   <extension point="xbmc.addon.metadata">
     <summary>@PKG_SHORTDESC@</summary>
     <description>


### PR DESCRIPTION
script with provides executable needs to come before module, otherwise the addon will not show up in the repo list or and in "My addons"