### PR TITLE
Generic: add reardonia patches, 10-bit Intel GPU workaround, and bump kernel to Linux 7.0.5

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,8 +37,8 @@ case "${LINUX}" in
     PKG_PATCH_DIRS="default rockchip"
     ;;
   *)
-    PKG_VERSION="7.0.1"
-    PKG_SHA256="b2c935a36d24980e11e59bed3ca558ea6d67619ec0065faa335cdc0b64d887bf"
+    PKG_VERSION="7.0.5"
+    PKG_SHA256="965fb0a1c1675399fc60c6063b227c0523041b5f9a662b66462f1212c438ac3c"
     PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
     PKG_PATCH_DIRS="default"
     case ${DEVICE} in

--- a/packages/linux/patches/default/linux-99.999-i915-10bit-hack.patch
+++ b/packages/linux/patches/default/linux-99.999-i915-10bit-hack.patch
@@ -1,0 +1,32 @@
+From 2d2294e56285288a25189135760fefb7ad5512f5 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Fri, 10 Apr 2026 13:54:06 +0000
+Subject: [PATCH] drm/i915/hdmi: force 10-bit output hack
+
+Force 10-bit output to avoid HDMI bandwidth issues when playing
+media at 4K@23.976 with HBR audio. The reason for this is still
+unknown but being investigated upstream.
+
+Link: https://gitlab.freedesktop.org/drm/i915/kernel/-/work_items/10199
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/gpu/drm/i915/display/intel_hdmi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_hdmi.c b/drivers/gpu/drm/i915/display/intel_hdmi.c
+index 055e68810d0d..5c0e54f60d23 100644
+--- a/drivers/gpu/drm/i915/display/intel_hdmi.c
++++ b/drivers/gpu/drm/i915/display/intel_hdmi.c
+@@ -1941,7 +1941,7 @@ static bool intel_hdmi_source_bpc_possible(struct intel_display *display, int bp
+ {
+ 	switch (bpc) {
+ 	case 12:
+-		return !HAS_GMCH(display);
++		return !HAS_GMCH(display) && DISPLAY_VER(display) <= 10;
+ 	case 10:
+ 		return DISPLAY_VER(display) >= 11;
+ 	case 8:
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -63,6 +63,7 @@ configure_package() {
                    -DWAYLANDPP_SCANNER=${TOOLCHAIN}/bin/wayland-scanner++ \
                    -DWAYLANDPP_PROTOCOLS_DIR=${SYSROOT_PREFIX}/usr/share/waylandpp/protocols"
   else # GBM
+    PKG_PATCH_DIRS+=" reardonia" # temp for testing
     if [ ! "${KODIPLAYER_DRIVER}" = "default" ]; then
       PKG_DEPENDS_TARGET+=" ${KODIPLAYER_DRIVER}"
     fi

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-GBM-EGL-enable-10-bit-framebuffer-with-dynamic-plane.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-GBM-EGL-enable-10-bit-framebuffer-with-dynamic-plane.patch
@@ -1,0 +1,85 @@
+From 8d1ce3052b4df0ff53ead5fd437dd3fe2edc2d81 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 24 Mar 2026 23:23:11 -0400
+Subject: [PATCH 01/25] GBM/EGL: enable 10-bit framebuffer with dynamic planes
+
+Add 10-bit GUI format entries (ARGB2101010, XRGB2101010) to
+m_gui_formats after the existing 8-bit entries. The 8-bit formats
+are selected by default, ensuring Direct-to-Plane compositing works
+(requires full 8-bit alpha). The 10-bit entries are available for
+on-demand upgrade when single-plane 10-bit rendering is needed.
+
+Dynamic plane selection in FindVideoAndGuiPlane() handles the
+Direct-to-Plane case at playback time -- when RendererDRMPRIME
+activates, it re-selects the GUI plane with proper alpha for DRM
+hardware compositing. No settings check needed at init time.
+
+Fix alpha check in FindVideoAndGuiPlane() to reject formats with
+less than 8-bit alpha (e.g. ARGB2101010 has only 2-bit alpha) from
+Direct-to-Plane compositing, preventing GUI overlay banding.
+
+Also request EGL_OPENGL_ES3_BIT for 10-bit texture support, with
+fallback to ES2 for devices that don't support GLES 3.0.
+
+Builds on top of #27402 (dynamic plane selection).
+---
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp | 9 +++++++--
+ xbmc/windowing/gbm/drm/DRMUtils.cpp            | 2 +-
+ xbmc/windowing/gbm/drm/DRMUtils.h              | 6 +++++-
+ 3 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index 56b71f04ea..9318e9b4ec 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -61,9 +61,14 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
+   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGLES);
+   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
+ 
+-  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
++  // GLES 3.0 required for 10-bit texture format support (GL_RGB10_A2, GL_R16UI, etc.)
++  // Fall back to GLES 2.0 for devices that don't support GLES 3.0 (e.g. lima driver)
++  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES3_BIT, EGL_OPENGL_ES_API))
+   {
+-    return false;
++    if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
++    {
++      return false;
++    }
+   }
+ 
+   bool general, deepColor;
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.cpp b/xbmc/windowing/gbm/drm/DRMUtils.cpp
+index 5c30f295c2..db6bae83ff 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
++++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
+@@ -297,7 +297,7 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
+   {
+     if (output_format.drm != m_gui_plane->GetFormat())
+       continue;
+-    if (!output_format.alpha)
++    if (output_format.alpha < 8)
+     {
+       CLog::LogF(LOGWARNING,
+                  "GUI plane format {} can not do alpha blending, "
+diff --git a/xbmc/windowing/gbm/drm/DRMUtils.h b/xbmc/windowing/gbm/drm/DRMUtils.h
+index 1fc03e0bd4..653d01f40f 100644
+--- a/xbmc/windowing/gbm/drm/DRMUtils.h
++++ b/xbmc/windowing/gbm/drm/DRMUtils.h
+@@ -125,8 +125,12 @@ private:
+   std::vector<std::unique_ptr<CDRMConnector>> m_connectors;
+   std::vector<std::unique_ptr<CDRMEncoder>> m_encoders;
+   std::vector<std::unique_ptr<CDRMCrtc>> m_crtcs;
++  // 8-bit formats first: Direct-to-Plane needs full 8-bit alpha for GUI overlay.
++  // 10-bit formats are available for single-plane HDR rendering when requested.
+   std::vector<outputformat> m_output_formats = {{DRM_FORMAT_ARGB8888, 8, 8, false, {}},
+-                                                {DRM_FORMAT_XRGB8888, 8, 0, false, {}}};
++                                          {DRM_FORMAT_XRGB8888, 8, 0, false, {}},
++                                          {DRM_FORMAT_ARGB2101010, 10, 2, false, {}},
++                                          {DRM_FORMAT_XRGB2101010, 10, 0, false, {}}};
+ };
+ 
+ } // namespace GBM
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-GBM-EGL-extend-SetVideoOutput-to-manage-output-surfa.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-GBM-EGL-extend-SetVideoOutput-to-manage-output-surfa.patch
@@ -1,0 +1,229 @@
+From 70fc77f1f0cadac3f5a15d2cc319706730248ca2 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 24 Mar 2026 23:23:58 -0400
+Subject: [PATCH 02/25] GBM/EGL: extend SetVideoOutput to manage output surface
+ bit depth
+
+Split ChooseEGLConfig out of InitWindowSystemEGL so the EGL config
+can be re-selected at runtime without reinitializing DRM or the EGL
+display. ChooseEGLConfig now takes int bitDepth instead of a bool:
+when bitDepth > 8, only formats with bpp >= 10 are considered (never
+silently falls back to 8-bit). Candidates are sorted descending by
+bpp so the highest matching depth wins.
+
+CWinSystemGbmEGLContext gains a SetVideoOutput override that, before
+deferring to the base for plane-role tracking, rebuilds the EGL/GBM
+output surface at the target bit depth derived from
+videoPicture->colorBits (or 8 when reverting to gui). Surface
+recreation destroys the current EGL surface, looks up modifiers for
+the new format, creates a new GBM and EGL surface, rebinds the
+context, and swaps buffers. The EGL context survives -- no shader
+recompilation or modeset required. The override then chains to
+CWinSystemGbm::SetVideoOutput which calls FindVideoPlane (when a
+videoPicture is provided) or FindGuiPlane (when reverting).
+
+m_renderableType is captured at init time so ChooseEGLConfig can be
+invoked at runtime with the same renderable type.
+
+Single-plane video renderers already call SetVideoOutput at
+Configure (with picture) and UnInit (nullptr) per the renderer-side
+wiring landed earlier in this stack. With this commit, single-plane
+10-bit content drives an output surface rebuild from AR24 (8-bit)
+to XR30 (10-bit) on video start, and reverts to AR24 on video end.
+Direct-to-Plane (DRMPRIME) rendering uses the video plane for
+10-bit content natively and is not affected.
+
+Builds on top of #27402 (dynamic plane selection).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp | 126 ++++++++++++++++--
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.h   |   5 +
+ 2 files changed, 121 insertions(+), 10 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index 05b9225bb0..862256c8fe 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include "OptionalsReg.h"
+ #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
++#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+ #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+ #include "utils/log.h"
+ 
+@@ -33,16 +34,9 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+     return false;
+   }
+ 
+-  // InitWindowSystemEGL runs only at boot for GUI init, so the output
+-  // surface is always the gui surface here.
+-  auto guiformats = m_DRM->GetOutputFormats();
+-  if (!std::ranges::any_of(guiformats,
+-                           [&](struct outputformat format)
+-                           {
+-                             return format.active &&
+-                                    m_eglContext.ChooseConfig(renderableType, format.drm, false,
+-                                                              format.alpha);
+-                           }))
++  m_renderableType = renderableType;
++
++  if (!ChooseEGLConfig(renderableType))
+   {
+     return false;
+   }
+@@ -74,6 +68,35 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+   return true;
+ }
+ 
++bool CWinSystemGbmEGLContext::ChooseEGLConfig(EGLint renderableType, int bitDepth)
++{
++  // Pick the highest active output format whose bpp is in range for the
++  // requested bit depth. Policy: when bitDepth > 8, accept only entries
++  // with bpp >= 10 and bpp <= bitDepth (do not silently fall back to 8).
++  // When bitDepth <= 8, accept entries with bpp <= 8.
++  auto outputformats = m_DRM->GetOutputFormats();
++
++  std::vector<outputformat> candidates;
++  std::ranges::copy_if(outputformats, std::back_inserter(candidates),
++                       [bitDepth](const outputformat& format)
++                       {
++                         if (!format.active)
++                           return false;
++                         if (bitDepth > 8)
++                           return format.bpp >= 10 && format.bpp <= bitDepth;
++                         return format.bpp <= 8;
++                       });
++  std::ranges::sort(candidates, std::greater<>{}, &outputformat::bpp);
++
++  for (const auto& format : candidates)
++  {
++    if (m_eglContext.ChooseConfig(renderableType, format.drm, false, format.alpha))
++      return true;
++  }
++
++  return false;
++}
++
+ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
+                                               bool fullScreen,
+                                               RESOLUTION_INFO& res)
+@@ -165,6 +188,89 @@ bool CWinSystemGbmEGLContext::DestroyWindow()
+   return true;
+ }
+ 
++bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
++{
++  // Decide target bit depth: video picture's colorBits if set, default 8
++  // when reverting to gui (videoPicture == nullptr).
++  const int bitDepth = videoPicture ? videoPicture->colorBits : 8;
++
++  // Rebuild the EGL/GBM output surface if the current bit depth differs
++  // from the target.
++  uint32_t currentFormat = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
++
++  if (!ChooseEGLConfig(m_renderableType, bitDepth))
++  {
++    CLog::LogF(LOGERROR, "failed to choose EGL config for {}-bit", bitDepth);
++    return false;
++  }
++
++  uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
++
++  if (format != currentFormat)
++  {
++    m_eglContext.DestroySurface();
++
++    std::vector<uint64_t> fallbackModifiers = {DRM_FORMAT_MOD_LINEAR};
++    std::vector<uint64_t>* modifiers = &fallbackModifiers;
++
++    for (auto& fmt : m_DRM->GetOutputFormats())
++    {
++      if (fmt.drm == format && fmt.active)
++      {
++        modifiers = &fmt.modifiers;
++        break;
++      }
++    }
++
++    if (!m_GBM->GetDevice().CreateSurface(m_nWidth, m_nHeight, format, modifiers->data(),
++                                          modifiers->size()))
++    {
++      CLog::LogF(LOGERROR, "failed to create GBM surface");
++      return false;
++    }
++
++    if (!m_eglContext.CreatePlatformSurface(
++            m_GBM->GetDevice().GetSurface().Get(),
++            reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice().GetSurface().Get())))
++    {
++      return false;
++    }
++
++    if (!m_eglContext.BindContext())
++    {
++      return false;
++    }
++
++    if (!m_eglContext.TrySwapBuffers())
++    {
++      return false;
++    }
++
++    CLog::LogF(LOGINFO, "Output surface recreated at {}-bit", bitDepth);
++
++    // Refresh the active plane's cached format/modifier so the chained
++    // base SetVideoOutput sees the just-recreated surface (otherwise the
++    // base reads stale values from the previous format).
++    if (auto* plane = m_DRM->GetGuiPlane() ? m_DRM->GetGuiPlane() : m_DRM->GetVideoPlane())
++    {
++      if (struct gbm_bo* bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get())
++      {
++        plane->SetFormat(gbm_bo_get_format(bo));
++#if defined(HAS_GBM_MODIFIERS)
++        plane->SetModifier(gbm_bo_get_modifier(bo));
++#else
++        plane->SetModifier(DRM_FORMAT_MOD_LINEAR);
++#endif
++      }
++    }
++  }
++
++  // Chain to base for the plane-find part: routes through FindVideoPlane
++  // (videoPicture set) or FindGuiPlane (nullptr) using the now-current
++  // cached format/modifier on the active plane.
++  return CWinSystemGbm::SetVideoOutput(videoPicture);
++}
++
+ bool CWinSystemGbmEGLContext::DestroyWindowSystem()
+ {
+   CDVDFactoryCodec::ClearHWAccels();
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+index 387beb210a..b8f2796de8 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+@@ -42,6 +42,8 @@ public:
+   bool UnbindTextureUploadContext() override;
+   bool HasContext() override;
+ 
++  bool SetVideoOutput(const VideoPicture* videoPicture) override;
++
+ protected:
+   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)
+     : CWinSystemEGL{platform, platformExtension}
+@@ -53,8 +55,11 @@ protected:
+    * and call this function there with appropriate parameters
+    */
+   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
++  bool ChooseEGLConfig(EGLint renderableType, int bitDepth = 8);
+   virtual bool CreateContext() = 0;
+ 
++  EGLint m_renderableType{0};
++
+   std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
+ 
+   struct delete_CVaapiProxy
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-WinSystemGbmEGLContext-fix-ES3-ES2-fallback-for-GLES.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-WinSystemGbmEGLContext-fix-ES3-ES2-fallback-for-GLES.patch
@@ -1,0 +1,79 @@
+From 363d4598d6a6dad1154154ebb8fe1b13c17591bc Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 23 Mar 2026 22:30:43 -0400
+Subject: [PATCH 03/25] WinSystemGbmEGLContext: fix ES3->ES2 fallback for GLES
+ 2.0-only GPUs
+
+InitWindowSystemEGL did not clean up EGL state on failure, leaving
+m_eglDisplay set. The ES2 retry called InitWindowSystem again which
+failed to acquire DRM master because the old GBM device still held
+the previous DRM fd.
+
+Fix by:
+- Skipping InitWindowSystem if DRM is already initialized (m_DRM check)
+- Calling m_eglContext.Destroy() on all failure paths after display
+  creation so the ES2 retry starts with clean EGL state
+- Requesting EGL_CONTEXT_CLIENT_VERSION 3 when ES3 config was selected,
+  matching the renderable type to the actual context version
+
+Fixes crash on Mali 450 (lima driver, GLES 2.0 only) where ES3 config
+selection fails and the ES2 fallback could not recover.
+---
+ xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp  | 5 ++++-
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp | 4 +++-
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+index 862256c8fe..777aab3992 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+@@ -19,7 +19,7 @@ using namespace KODI::WINDOWING::LINUX;
+ 
+ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
+ {
+-  if (!CWinSystemGbm::InitWindowSystem())
++  if (!m_DRM && !CWinSystemGbm::InitWindowSystem())
+   {
+     return false;
+   }
+@@ -31,6 +31,7 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+ 
+   if (!m_eglContext.InitializeDisplay(apiType))
+   {
++    m_eglContext.Destroy();
+     return false;
+   }
+ 
+@@ -38,11 +39,13 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint
+ 
+   if (!ChooseEGLConfig(renderableType))
+   {
++    m_eglContext.Destroy();
+     return false;
+   }
+ 
+   if (!CreateContext())
+   {
++    m_eglContext.Destroy();
+     return false;
+   }
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index 9318e9b4ec..a0232ff595 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -188,8 +188,10 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+ 
+ bool CWinSystemGbmGLESContext::CreateContext()
+ {
++  const EGLint version = (m_renderableType == EGL_OPENGL_ES3_BIT) ? 3 : 2;
++
+   CEGLAttributesVec contextAttribs;
+-  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
++  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, version}});
+ 
+   if (!m_eglContext.CreateContext(contextAttribs))
+   {
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-GBM-GLES-add-10-bit-software-decode-support.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-GBM-GLES-add-10-bit-software-decode-support.patch
@@ -1,0 +1,300 @@
+From 36b14ffb7aca94629f62c9463558d8618f3c445a Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 28 Apr 2026 21:12:49 -0400
+Subject: [PATCH 04/25] GBM/GLES: add 10-bit software decode support
+
+Add >8-bit YUV420P format support for the GBM platform, fixing a
+longstanding gap where GBM was the only platform without a
+GetRenderFormats override. Previously, 10-bit software decoded content
+was silently downconverted to 8-bit by ffmpeg because the renderer
+never advertised >8-bit format support.
+
+ProcessInfoGBM: override GetRenderFormats to advertise YUV420P 9/10/12/
+14/16-bit formats and NV12, matching other platforms (X11, Wayland,
+Windows, macOS). Both GL and GLES renderers on GBM benefit.
+
+LinuxRendererGLES: add >8-bit YV12 texture support using GL_R16_EXT
+(from GL_EXT_texture_norm16) with GL_RED format and GL_UNSIGNED_SHORT
+upload. Runtime extension check cached in m_hasTextureNorm16. Devices
+without the extension fall back to 8-bit textures. Fix LoadPlane to
+use correct data type (GL_UNSIGNED_SHORT) for >8-bit content and fix
+GL_UNPACK_ROW_LENGTH to pass stride in pixels not bytes.
+
+YUV2RGBShaderGLES: add SHADER_YV12_9/10/12/14/16 support with new
+XBMC_YV12_HI shader define for three-plane GL_R16_EXT sampling.
+
+GLUtils: move GL_RED and GL_RG out of HAS_GL guard since both are
+available in GLES 3.0 core and used by the GLES renderer.
+
+Fixes shader format mismatch where colorBits reported 10-bit but
+videoBuffer format was 8-bit, causing unnecessary surface format
+bouncing between AR24 and AR30.
+---
+ .../shaders/GLES/2.0/gles_yuv2rgb_basic.frag  |  7 ++
+ .../Process/gbm/ProcessInfoGBM.cpp            | 18 +++++
+ .../VideoPlayer/Process/gbm/ProcessInfoGBM.h  |  1 +
+ .../VideoRenderers/LinuxRendererGLES.cpp      | 75 ++++++++++++-------
+ .../VideoRenderers/LinuxRendererGLES.h        |  2 +
+ .../VideoShaders/YUV2RGBShaderGLES.cpp        |  3 +
+ xbmc/utils/GLUtils.cpp                        |  8 +-
+ 7 files changed, 83 insertions(+), 31 deletions(-)
+
+diff --git a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+index d76a3b89e4..565396e4dd 100644
+--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
++++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+@@ -50,6 +50,13 @@ void main()
+              texture2D(m_sampV, m_cordV).a,
+              1.0);
+ 
++#elif defined(XBMC_YV12_HI)
++
++  yuv = vec4(texture2D(m_sampY, m_cordY).r,
++             texture2D(m_sampU, m_cordU).r,
++             texture2D(m_sampV, m_cordV).r,
++             1.0);
++
+ #elif defined(XBMC_NV12_RRG)
+ 
+   yuv = vec4(texture2D(m_sampY, m_cordY).r,
+diff --git a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+index d849a7ac3f..726912d9a1 100644
+--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
++++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+@@ -40,3 +40,21 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
+   return CProcessInfo::GetFallbackDeintMethod();
+ #endif
+ }
++
++std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
++{
++  // clang-format off
++  return {
++      AV_PIX_FMT_NV12,
++      AV_PIX_FMT_YUV420P,
++      AV_PIX_FMT_YUV420P9,
++      AV_PIX_FMT_YUV420P10,
++      AV_PIX_FMT_YUV420P12,
++      AV_PIX_FMT_YUV420P14,
++      AV_PIX_FMT_YUV420P16,
++      // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
++      // AV_PIX_FMT_YUYV422,
++      // AV_PIX_FMT_UYVY422,
++  };
++  // clang-format on
++}
+diff --git a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+index 0524d6e89b..518a310442 100644
+--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
++++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+@@ -22,6 +22,7 @@ public:
+ 
+   CProcessInfoGBM();
+   EINTERLACEMETHOD GetFallbackDeintMethod() override;
++  std::vector<AVPixelFormat> GetRenderFormats() override;
+ };
+ 
+ } // namespace VIDEOPLAYER
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index fea56f94ea..675f3248a6 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -66,6 +66,9 @@ CLinuxRendererGLES::CLinuxRendererGLES()
+     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
+   }
+ #endif
++
++  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
++    m_hasTextureNorm16 = true;
+ }
+ 
+ CLinuxRendererGLES::~CLinuxRendererGLES()
+@@ -328,7 +331,8 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
+       pixelData = m_planeBuffer;
+     }
+   }
+-  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
++  GLenum datatype = (bpp == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
++  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, datatype, pixelData);
+ 
+   if (m_pixelStoreKey > 0 && pixelStoreChanged)
+     glPixelStorei(m_pixelStoreKey, 0);
+@@ -336,17 +340,13 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
+   // check if we need to load any border pixels
+   if (height < plane.texheight)
+   {
+-    glTexSubImage2D(m_textureTarget, 0,
+-                    0, height, width, 1,
+-                    type, GL_UNSIGNED_BYTE,
++    glTexSubImage2D(m_textureTarget, 0, 0, height, width, 1, type, datatype,
+                     static_cast<const unsigned char*>(pixelData) + stride * (height - 1));
+   }
+ 
+   if (width  < plane.texwidth)
+   {
+-    glTexSubImage2D(m_textureTarget, 0,
+-                    width, 0, 1, height,
+-                    type, GL_UNSIGNED_BYTE,
++    glTexSubImage2D(m_textureTarget, 0, width, 0, 1, height, type, datatype,
+                     static_cast<const unsigned char*>(pixelData) + bps * (width - 1));
+   }
+ 
+@@ -1456,22 +1456,32 @@ bool CLinuxRendererGLES::UploadYV12Texture(int source)
+ 
+   VerifyGLState();
+ 
+-  glPixelStorei(GL_UNPACK_ALIGNMENT,1);
++  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
++
++  if (im->bpp == 2)
++  {
++    // >8-bit: three separate GL_R16_EXT planes
++    LoadPlane(buf.fields[FIELD_FULL][0], GL_RED, im->width, im->height, im->stride[0], im->bpp,
++              im->plane[0]);
++
++    LoadPlane(buf.fields[FIELD_FULL][1], GL_RED, im->width >> im->cshift_x,
++              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
+ 
+-  // load Y plane
+-  LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE,
+-            im->width, im->height,
+-            im->stride[0], im->bpp, im->plane[0]);
++    LoadPlane(buf.fields[FIELD_FULL][2], GL_RED, im->width >> im->cshift_x,
++              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
++  }
++  else
++  {
++    // 8-bit: GL_LUMINANCE for Y/U, GL_ALPHA for V
++    LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE, im->width, im->height, im->stride[0],
++              im->bpp, im->plane[0]);
+ 
+-  // load U plane
+-  LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE,
+-            im->width >> im->cshift_x, im->height >> im->cshift_y,
+-            im->stride[1], im->bpp, im->plane[1]);
++    LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE, im->width >> im->cshift_x,
++              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
+ 
+-  // load V plane
+-  LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA,
+-            im->width >> im->cshift_x, im->height >> im->cshift_y,
+-            im->stride[2], im->bpp, im->plane[2]);
++    LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA, im->width >> im->cshift_x,
++              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
++  }
+ 
+   VerifyGLState();
+ 
+@@ -1516,7 +1526,8 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
+ {
+   // since we also want the field textures, pitch must be texture aligned
+   unsigned p;
+-  YuvImage &im = m_buffers[index].image;
++  CPictureBuffer& buf = m_buffers[index];
++  YuvImage& im = buf.image;
+ 
+   DeleteYV12Texture(index);
+ 
+@@ -1524,7 +1535,11 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
+   im.width = m_sourceWidth;
+   im.cshift_x = 1;
+   im.cshift_y = 1;
+-  im.bpp = 1;
++
++  // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
++  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
++  buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
++  im.bpp = (m_hasTextureNorm16 && buf.m_srcTextureBits > 8) ? 2 : 1;
+ 
+   im.stride[0] = im.bpp * im.width;
+   im.stride[1] = im.bpp * (im.width >> im.cshift_x);
+@@ -1581,17 +1596,23 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
+ 
+       glBindTexture(m_textureTarget, plane.id);
+ 
+-      GLint format;
+-      if (p == 2) // V plane needs an alpha texture
++      if (im.bpp == 2)
+       {
+-        format = GL_ALPHA;
++        glTexImage2D(m_textureTarget, 0, GL_R16_EXT, plane.texwidth, plane.texheight, 0, GL_RED,
++                     GL_UNSIGNED_SHORT, nullptr);
+       }
+       else
+       {
+-        format = GL_LUMINANCE;
++        GLint format;
++        if (p == 2) // V plane needs an alpha texture
++          format = GL_ALPHA;
++        else
++          format = GL_LUMINANCE;
++
++        glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format,
++                     GL_UNSIGNED_BYTE, nullptr);
+       }
+ 
+-      glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format, GL_UNSIGNED_BYTE, nullptr);
+       glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+       glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+       glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+index ce3f6e351d..70aa00b516 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+@@ -23,6 +23,7 @@
+ 
+ extern "C" {
+ #include <libavutil/mastering_display_metadata.h>
++#include <libavutil/pixdesc.h>
+ }
+ 
+ class CRenderCapture;
+@@ -150,6 +151,7 @@ protected:
+   bool m_reloadShaders{false};
+   CRenderSystemGLES *m_renderSystem{nullptr};
+   GLenum m_pixelStoreKey{0};
++  bool m_hasTextureNorm16{false};
+ 
+   struct CYuvPlane
+   {
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+index 55dd35c717..b27d5be71f 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+@@ -43,6 +43,9 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
+ 
+   if (m_format == SHADER_YV12)
+     m_defines += "#define XBMC_YV12\n";
++  else if (m_format == SHADER_YV12_9 || m_format == SHADER_YV12_10 || m_format == SHADER_YV12_12 ||
++           m_format == SHADER_YV12_14 || m_format == SHADER_YV12_16)
++    m_defines += "#define XBMC_YV12_HI\n";
+   else if (m_format == SHADER_NV12)
+     m_defines += "#define XBMC_NV12\n";
+   else if (m_format == SHADER_NV12_RRG)
+diff --git a/xbmc/utils/GLUtils.cpp b/xbmc/utils/GLUtils.cpp
+index f27c6fdbd6..148a4d2b86 100644
+--- a/xbmc/utils/GLUtils.cpp
++++ b/xbmc/utils/GLUtils.cpp
+@@ -257,15 +257,15 @@ int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
+ #ifdef HAS_GL
+   case GL_BGRA:
+     return 4;
+-  case GL_RED:
+-    return 1;
+   case GL_GREEN:
+     return 1;
+-  case GL_RG:
+-    return 2;
+   case GL_BGR:
+     return 3;
+ #endif
++  case GL_RED:
++    return 1;
++  case GL_RG:
++    return 2;
+   case GL_RGBA:
+     return 4;
+   case GL_RGB:
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-GBM-GLES-gate-8-bit-formats-on-GL_EXT_texture_norm16.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-GBM-GLES-gate-8-bit-formats-on-GL_EXT_texture_norm16.patch
@@ -1,0 +1,112 @@
+From b7f3ab7389c74c902d4c16611e97525a8125a0c5 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 28 Apr 2026 21:13:15 -0400
+Subject: [PATCH 05/25] GBM/GLES: gate >8-bit formats on GL_EXT_texture_norm16
+ at runtime
+
+Move the GL_EXT_texture_norm16 check from the renderer into
+GetRenderFormats so that GLES 2.0 devices never receive >8-bit
+frames they cannot render. Remove m_hasTextureNorm16 from
+LinuxRendererGLES since GetRenderFormats now gates the formats.
+---
+ .../Process/gbm/ProcessInfoGBM.cpp            | 33 +++++++++++++++----
+ .../VideoRenderers/LinuxRendererGLES.cpp      |  5 +--
+ .../VideoRenderers/LinuxRendererGLES.h        |  1 -
+ 3 files changed, 28 insertions(+), 11 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+index 726912d9a1..b1bb4bf65a 100644
+--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
++++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+@@ -10,8 +10,10 @@
+ 
+ #include "ServiceBroker.h"
+ #include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
++#include "rendering/RenderSystem.h"
+ #include "settings/Settings.h"
+ #include "settings/SettingsComponent.h"
++#include "utils/log.h"
+ 
+ using namespace VIDEOPLAYER;
+ 
+@@ -44,17 +46,36 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
+ std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
+ {
+   // clang-format off
+-  return {
++  std::vector<AVPixelFormat> formats = {
+       AV_PIX_FMT_NV12,
+       AV_PIX_FMT_YUV420P,
+-      AV_PIX_FMT_YUV420P9,
+-      AV_PIX_FMT_YUV420P10,
+-      AV_PIX_FMT_YUV420P12,
+-      AV_PIX_FMT_YUV420P14,
+-      AV_PIX_FMT_YUV420P16,
+       // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
+       // AV_PIX_FMT_YUYV422,
+       // AV_PIX_FMT_UYVY422,
+   };
+   // clang-format on
++
++  // For software decode, the ffmpeg codec queries GetRenderFormats before any
++  // renderer is created. Since GLES 2.0 vs 3.0+ is a runtime (not compile-time)
++  // issue, this method gates >8-bit formats on behalf of the eventual renderer.
++  // >8-bit requires GL_EXT_texture_norm16; without it, ffmpeg downconverts to
++  // 8-bit, preserving existing behavior.
++#if defined(HAS_GLES)
++  auto renderSystem = CServiceBroker::GetRenderSystem();
++  if (!renderSystem)
++  {
++    CLog::Log(LOGERROR, "CProcessInfoGBM::GetRenderFormats: render system not initialized");
++    return formats;
++  }
++  if (renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
++#endif
++  {
++    formats.push_back(AV_PIX_FMT_YUV420P9);
++    formats.push_back(AV_PIX_FMT_YUV420P10);
++    formats.push_back(AV_PIX_FMT_YUV420P12);
++    formats.push_back(AV_PIX_FMT_YUV420P14);
++    formats.push_back(AV_PIX_FMT_YUV420P16);
++  }
++
++  return formats;
+ }
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index 675f3248a6..b9d1bd3216 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -66,9 +66,6 @@ CLinuxRendererGLES::CLinuxRendererGLES()
+     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
+   }
+ #endif
+-
+-  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+-    m_hasTextureNorm16 = true;
+ }
+ 
+ CLinuxRendererGLES::~CLinuxRendererGLES()
+@@ -1539,7 +1536,7 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
+   // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
+   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
+   buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
+-  im.bpp = (m_hasTextureNorm16 && buf.m_srcTextureBits > 8) ? 2 : 1;
++  im.bpp = (buf.m_srcTextureBits > 8) ? 2 : 1;
+ 
+   im.stride[0] = im.bpp * im.width;
+   im.stride[1] = im.bpp * (im.width >> im.cshift_x);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+index 70aa00b516..727f2a7337 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+@@ -151,7 +151,6 @@ protected:
+   bool m_reloadShaders{false};
+   CRenderSystemGLES *m_renderSystem{nullptr};
+   GLenum m_pixelStoreKey{0};
+-  bool m_hasTextureNorm16{false};
+ 
+   struct CYuvPlane
+   {
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-GBM-GLES-FBO-based-GUI-compositing-for-HDR-passthrou.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-GBM-GLES-FBO-based-GUI-compositing-for-HDR-passthrou.patch
@@ -1,0 +1,676 @@
+From df4a3655adbb436a19de0e74b8da08d367ee0cf8 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Sat, 14 Mar 2026 14:08:44 -0400
+Subject: [PATCH 06/25] GBM/GLES: FBO-based GUI compositing for HDR passthrough
+
+When HDR video is passed through to the display, the TV applies PQ
+EOTF to the entire frame. This makes the SDR GUI (menus, OSD, etc.)
+look incorrect because it was not encoded in PQ. On platforms with a
+compositor (Windows, macOS, Android), the OS handles SDR-to-HDR
+conversion automatically. On Linux GBM with no compositor, Kodi must
+do it itself.
+
+This commit renders the GUI to an off-screen FBO, then composites it
+onto the video backbuffer with an sRGB-to-PQ tone mapping shader:
+  sRGB -> linear (pow 2.2) -> BT.709 to BT.2020 gamut matrix ->
+  scale to PQ luminance range (100/10000 nits) -> forward ST2084
+
+The compositing is only active during HDR passthrough on single-plane
+GLES renderers (VAAPI+GLES, DRMPRIMEGLES). Dual-plane DRMPRIME
+rendering is unaffected. On platforms where the windowing system does
+not support FBO compositing (e.g. Wayland), SetGuiCompositing returns
+false and the render split is not activated.
+
+Key changes:
+- Add HasVideoPlane() virtual to BaseRenderer, decoupling render pass
+  separation from DRM plane management. LinuxRendererGLES overrides
+  to always return false (single-plane).
+- Remove dead IsVideoLayer() from RenderManager.
+- Fix UpdateGuiRender to keep GUI dirty regions active when there is
+  no video plane, preventing page flip stalls.
+- Add GUI compositing virtuals to CWinSystemBase (SetGuiCompositing,
+  BeginGuiComposite, EndGuiComposite, CompositeGui). SetGuiCompositing
+  returns bool so the renderer can gate the render split on whether
+  the windowing system actually supports compositing.
+- Implement FBO lifecycle and sRGB-to-PQ compositing in
+  WinSystemGbmGLESContext.
+- Add CGuiCompositeShaderGLES in rendering/gles/ so any GLES-based
+  windowing system can reuse it.
+- Hook compositing into Application::Render().
+
+Depends on 10-bit framebuffer support from the GBM/EGL 10-bit commit.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+---
+ .../shaders/GLES/2.0/gles_gui_composite.frag  |  53 ++++++++
+ .../shaders/GLES/2.0/gles_gui_composite.vert  |  20 +++
+ xbmc/application/Application.cpp              |   8 ++
+ .../VideoPlayer/VideoRenderers/BaseRenderer.h |   1 +
+ .../VideoRenderers/LinuxRendererGLES.cpp      |  52 ++++++-
+ .../VideoRenderers/LinuxRendererGLES.h        |   5 +
+ .../VideoRenderers/RenderManager.cpp          |  18 +--
+ .../VideoRenderers/RenderManager.h            |   2 +-
+ xbmc/rendering/gles/CMakeLists.txt            |   6 +-
+ .../rendering/gles/GuiCompositeShaderGLES.cpp |  39 ++++++
+ xbmc/rendering/gles/GuiCompositeShaderGLES.h  |  37 +++++
+ xbmc/windowing/WinSystem.h                    |   6 +
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 128 ++++++++++++++++++
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.h  |  17 +++
+ 14 files changed, 369 insertions(+), 23 deletions(-)
+ create mode 100644 system/shaders/GLES/2.0/gles_gui_composite.frag
+ create mode 100644 system/shaders/GLES/2.0/gles_gui_composite.vert
+ create mode 100644 xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+ create mode 100644 xbmc/rendering/gles/GuiCompositeShaderGLES.h
+
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.frag b/system/shaders/GLES/2.0/gles_gui_composite.frag
+new file mode 100644
+index 0000000000..ff9e41d2b8
+--- /dev/null
++++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
+@@ -0,0 +1,53 @@
++/*
++ *  Copyright (C) 2026 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#version 100
++
++precision mediump float;
++varying vec2 v_tex;
++uniform sampler2D u_samp;
++uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
++
++// ST2084 (PQ) constants
++const float ST2084_m1 = 0.1593017578125;   // 2610/16384
++const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
++const float ST2084_c1 = 0.8359375;          // 3424/4096
++const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
++const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
++
++// BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
++const mat3 bt709_to_bt2020 = mat3(
++  0.6274,  0.0691,  0.0164,
++  0.3293,  0.9195,  0.0880,
++  0.0433,  0.0114,  0.8956
++);
++
++vec3 forwardPQ(vec3 L)
++{
++  vec3 Lm1 = pow(L, vec3(ST2084_m1));
++  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
++}
++
++void main()
++{
++  vec4 gui = texture2D(u_samp, v_tex);
++
++  // sRGB -> linear (approximate)
++  vec3 linear = pow(gui.rgb, vec3(2.2));
++
++  // BT.709 -> BT.2020 gamut mapping
++  linear = bt709_to_bt2020 * linear;
++
++  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
++  linear *= u_sdrPeak;
++
++  // linear -> PQ
++  vec3 pq = forwardPQ(linear);
++
++  gl_FragColor = vec4(pq, gui.a);
++}
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.vert b/system/shaders/GLES/2.0/gles_gui_composite.vert
+new file mode 100644
+index 0000000000..00f9ea5404
+--- /dev/null
++++ b/system/shaders/GLES/2.0/gles_gui_composite.vert
+@@ -0,0 +1,20 @@
++/*
++ *  Copyright (C) 2026 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#version 100
++
++attribute vec2 a_pos;
++attribute vec2 a_tex;
++varying vec2 v_tex;
++uniform mat4 u_proj;
++
++void main()
++{
++  gl_Position = u_proj * vec4(a_pos, 0.0, 1.0);
++  v_tex = a_tex;
++}
+diff --git a/xbmc/application/Application.cpp b/xbmc/application/Application.cpp
+index 878e98d6bb..9bbe4f34fc 100644
+--- a/xbmc/application/Application.cpp
++++ b/xbmc/application/Application.cpp
+@@ -851,6 +851,8 @@ void CApplication::Render()
+     return;
+ 
+   // render gui layer
++  bool compositing = CServiceBroker::GetWinSystem()->BeginGuiComposite();
++
+   if (appPower->GetRenderGUI() && !m_skipGuiRender)
+   {
+     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::OFF)
+@@ -875,9 +877,15 @@ void CApplication::Render()
+     m_lastRenderTime = std::chrono::steady_clock::now();
+   }
+ 
++  if (compositing)
++    CServiceBroker::GetWinSystem()->EndGuiComposite();
++
+   // render video layer
+   CServiceBroker::GetGUI()->GetWindowManager().RenderEx();
+ 
++  if (compositing)
++    CServiceBroker::GetWinSystem()->CompositeGui();
++
+   CServiceBroker::GetRenderSystem()->EndRender();
+ 
+   // reset our info cache - we do this at the end of Render so that it is
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+index 26162aa7e0..17ba624ded 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+@@ -62,6 +62,7 @@ public:
+   virtual void ReleaseBuffer(int idx) { }
+   virtual bool NeedBuffer(int idx) { return false; }
+   virtual bool IsGuiLayer() { return true; }
++  virtual bool HasVideoPlane() { return !IsGuiLayer(); }
+   // Render info, can be called before configure
+   virtual CRenderInfo GetRenderInfo() { return CRenderInfo(); }
+   virtual void Update() = 0;
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index b9d1bd3216..c5bd0541bb 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -162,6 +162,12 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
+               m_passthroughHDR ? "on" : "off");
+   }
+ 
++  m_hdrFboActive =
++      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(m_passthroughHDR);
++  if (m_passthroughHDR && !m_hdrFboActive)
++    CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: HDR passthrough active but GUI "
++                          "compositing not supported by windowing system");
++
+   return true;
+ }
+ 
+@@ -580,14 +586,50 @@ void CLinuxRendererGLES::RenderUpdate(int index, int index2, bool clear, unsigne
+ void CLinuxRendererGLES::RenderUpdateVideo(bool clear, unsigned int flags, unsigned int alpha)
+ {
+   if (!m_bConfigured)
+-  {
+     return;
+-  }
+ 
+   if (IsGuiLayer())
+-  {
+     return;
++
++  int index = m_iYV12RenderBuffer;
++  CPictureBuffer& buf = m_buffers[index];
++
++  if (!buf.fields[FIELD_FULL][0].id)
++    return;
++
++  ManageRenderArea();
++
++  if (clear)
++  {
++    if (alpha == 255)
++      DrawBlackBars();
++    else
++      ClearBackBuffer();
+   }
++
++  if (alpha < 255)
++  {
++    glEnable(GL_BLEND);
++    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
++    if (m_pYUVProgShader)
++      m_pYUVProgShader->SetAlpha(alpha / 255.0f);
++    if (m_pYUVBobShader)
++      m_pYUVBobShader->SetAlpha(alpha / 255.0f);
++  }
++  else
++  {
++    glDisable(GL_BLEND);
++    if (m_pYUVProgShader)
++      m_pYUVProgShader->SetAlpha(1.0f);
++    if (m_pYUVBobShader)
++      m_pYUVBobShader->SetAlpha(1.0f);
++  }
++
++  if (!Render(flags, index) && clear)
++    ClearBackBuffer();
++
++  VerifyGLState();
++  glEnable(GL_BLEND);
+ }
+ 
+ void CLinuxRendererGLES::UpdateVideoFilter()
+@@ -898,6 +940,8 @@ void CLinuxRendererGLES::UnInit()
+ 
+   if (m_bConfigured)
+   {
++    m_hdrFboActive = false;
++    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+     m_passthroughHDR = false;
+     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+@@ -1922,7 +1966,7 @@ CRenderInfo CLinuxRendererGLES::GetRenderInfo()
+ 
+ bool CLinuxRendererGLES::IsGuiLayer()
+ {
+-  return true;
++  return !m_hdrFboActive;
+ }
+ 
+ CRenderCapture* CLinuxRendererGLES::GetRenderCapture()
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+index 727f2a7337..c4308e86de 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+@@ -73,6 +73,7 @@ public:
+   bool Flush(bool saveBuffers) override;
+   void SetBufferSize(int numBuffers) override { m_NumYV12Buffers = numBuffers; }
+   bool IsGuiLayer() override;
++  bool HasVideoPlane() override { return false; }
+   void ReleaseBuffer(int idx) override;
+   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
+   void Update() override;
+@@ -218,6 +219,10 @@ protected:
+   float m_clearColour{0.0f};
+   CRect m_lastViewRect;
+ 
++  // HDR FBO compositing: when active, IsGuiLayer() returns false so
++  // video renders separately from GUI via RenderUpdateVideo()
++  bool m_hdrFboActive{false};
++
+ private:
+   void ClearBackBuffer();
+   void ClearBackBufferQuad();
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+index 3a3d1132e9..f918f153a0 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+@@ -215,7 +215,7 @@ bool CRenderManager::Configure()
+ 
+     m_playerPort->UpdateRenderInfo(info);
+     m_playerPort->UpdateGuiRender(true);
+-    m_playerPort->UpdateVideoRender(!m_pRenderer->IsGuiLayer());
++    m_playerPort->UpdateVideoRender(m_pRenderer->HasVideoPlane());
+ 
+     m_queued.clear();
+     m_discard.clear();
+@@ -350,7 +350,7 @@ void CRenderManager::FrameMove()
+     m_bRenderGUI = true;
+   }
+ 
+-  m_playerPort->UpdateGuiRender(IsGuiLayer() || firstFrame);
++  m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->HasVideoPlane() || firstFrame);
+ 
+   ManageCaptures();
+ }
+@@ -821,20 +821,6 @@ bool CRenderManager::IsGuiLayer()
+   return false;
+ }
+ 
+-bool CRenderManager::IsVideoLayer()
+-{
+-  {
+-    std::unique_lock lock(m_statelock);
+-
+-    if (!m_pRenderer)
+-      return false;
+-
+-    if (!m_pRenderer->IsGuiLayer())
+-      return true;
+-  }
+-  return false;
+-}
+-
+ /* simple present method */
+ void CRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
+ {
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+index e3ea0298e6..2ba20a6b7c 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+@@ -65,7 +65,7 @@ public:
+   void FrameMove();
+   void FrameWait(std::chrono::milliseconds duration);
+   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
+-  bool IsVideoLayer();
++
+   RESOLUTION GetResolution();
+   void UpdateResolution();
+   void TriggerUpdateResolution(float fps, int width, int height, std::string &stereomode);
+diff --git a/xbmc/rendering/gles/CMakeLists.txt b/xbmc/rendering/gles/CMakeLists.txt
+index 94bef8e8ad..a6833cf32f 100644
+--- a/xbmc/rendering/gles/CMakeLists.txt
++++ b/xbmc/rendering/gles/CMakeLists.txt
+@@ -1,11 +1,13 @@
+ if(TARGET ${APP_NAME_LC}::OpenGLES)
+   set(SOURCES RenderSystemGLES.cpp
+               ScreenshotSurfaceGLES.cpp
+-              GLESShader.cpp)
++              GLESShader.cpp
++              GuiCompositeShaderGLES.cpp)
+ 
+   set(HEADERS RenderSystemGLES.h
+               ScreenshotSurfaceGLES.h
+-              GLESShader.h)
++              GLESShader.h
++              GuiCompositeShaderGLES.h)
+ 
+   core_add_library(rendering_gles)
+ endif()
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+new file mode 100644
+index 0000000000..36ba150996
+--- /dev/null
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+@@ -0,0 +1,39 @@
++/*
++ *  Copyright (C) 2026 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#include "GuiCompositeShaderGLES.h"
++
++#include "utils/log.h"
++
++CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
++{
++  VertexShader()->LoadSource("gles_gui_composite.vert");
++  PixelShader()->LoadSource("gles_gui_composite.frag");
++}
++
++void CGuiCompositeShaderGLES::OnCompiledAndLinked()
++{
++  m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
++  m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
++  m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
++  m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
++  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
++
++  glUseProgram(ProgramHandle());
++  glUniform1i(m_hSamp, 0);
++  glUseProgram(0);
++}
++
++bool CGuiCompositeShaderGLES::OnEnabled()
++{
++  if (m_proj)
++    glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
++
++  glUniform1f(m_hSdrPeak, m_sdrPeak);
++  return true;
++}
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.h b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+new file mode 100644
+index 0000000000..78a5430462
+--- /dev/null
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+@@ -0,0 +1,37 @@
++/*
++ *  Copyright (C) 2026 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#pragma once
++
++#include "guilib/Shader.h"
++
++class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
++{
++public:
++  CGuiCompositeShaderGLES();
++
++  void SetProjection(const GLfloat* proj) { m_proj = proj; }
++  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
++
++  GLint GetPosLoc() { return m_hPos; }
++  GLint GetTexLoc() { return m_hTex; }
++
++protected:
++  void OnCompiledAndLinked() override;
++  bool OnEnabled() override;
++
++private:
++  const GLfloat* m_proj{nullptr};
++  float m_sdrPeak{100.0f / 10000.0f};
++
++  GLint m_hPos{-1};
++  GLint m_hTex{-1};
++  GLint m_hSamp{-1};
++  GLint m_hProj{-1};
++  GLint m_hSdrPeak{-1};
++};
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+index e6a20b9ff3..a21844814b 100644
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -247,6 +247,12 @@ public:
+    */
+   virtual bool SupportsVideoSuperResolution() { return false; }
+ 
++  // GUI compositing for HDR: render GUI to FBO, composite with tone mapping
++  virtual bool SetGuiCompositing(bool active) { return false; }
++  virtual bool BeginGuiComposite() { return false; }
++  virtual void EndGuiComposite() {}
++  virtual void CompositeGui() {}
++
+   /*!
+    * \brief Gets debug info from video renderer for use in "Debug Info OSD" (Alt + O)
+    *
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index a0232ff595..ea9bea6818 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -19,6 +19,7 @@
+ #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h"
+ #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+ #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
++#include "rendering/gles/GuiCompositeShaderGLES.h"
+ #include "rendering/gles/ScreenshotSurfaceGLES.h"
+ #include "utils/BufferObjectFactory.h"
+ #include "utils/DMAHeapBufferObject.h"
+@@ -186,6 +187,133 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   }
+ }
+ 
++bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
++{
++  m_guiCompositing = active;
++
++  if (active)
++  {
++    if (!m_compositeShader)
++    {
++      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>();
++      if (!m_compositeShader->CompileAndLink())
++      {
++        CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");
++        m_compositeShader.reset();
++        m_guiCompositing = false;
++      }
++    }
++  }
++  else
++  {
++    m_guiFbo.Cleanup();
++    m_guiFboWidth = 0;
++    m_guiFboHeight = 0;
++    m_compositeShader.reset();
++  }
++
++  return m_guiCompositing;
++}
++
++bool CWinSystemGbmGLESContext::BeginGuiComposite()
++{
++  if (!m_guiCompositing)
++    return false;
++
++  int width = m_nWidth;
++  int height = m_nHeight;
++
++  // create or recreate FBO if size changed
++  if (!m_guiFbo.IsValid() || m_guiFboWidth != width || m_guiFboHeight != height)
++  {
++    m_guiFbo.Cleanup();
++
++    if (!m_guiFbo.Initialize())
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to initialize GUI FBO");
++      return false;
++    }
++
++    if (!m_guiFbo.CreateAndBindToTexture(GL_TEXTURE_2D, width, height, GL_RGBA))
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to create GUI FBO texture {}x{}", width,
++                height);
++      m_guiFbo.Cleanup();
++      return false;
++    }
++
++    m_guiFboWidth = width;
++    m_guiFboHeight = height;
++    CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
++  }
++
++  if (!m_guiFbo.BeginRender())
++    return false;
++
++  // clear FBO to transparent black
++  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++
++  return true;
++}
++
++void CWinSystemGbmGLESContext::EndGuiComposite()
++{
++  m_guiFbo.EndRender();
++
++  // Clear the backbuffer before video renders. In the FBO compositing path,
++  // video renders in the RenderEx pass with clear=false, so DrawBlackBars is
++  // never called. Without this clear, letterbox areas retain stale content
++  // from the swap chain when the display resolution doesn't change between
++  // GUI and video playback.
++  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++}
++
++// CompositeGui is the last GL operation in the frame (called just before EndRender).
++// GL state (blend mode, active texture, vertex arrays) is not restored afterward;
++// the next frame's rendering sets its own state.
++void CWinSystemGbmGLESContext::CompositeGui()
++{
++  if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
++    return;
++
++  glActiveTexture(GL_TEXTURE0);
++  glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
++
++  glEnable(GL_BLEND);
++  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
++
++  // set up orthographic projection (screen coords, Y-down)
++  float w = static_cast<float>(m_guiFboWidth);
++  float h = static_cast<float>(m_guiFboHeight);
++
++  GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
++
++  m_compositeShader->SetProjection(proj);
++  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
++  m_compositeShader->Enable();
++
++  GLint posLoc = m_compositeShader->GetPosLoc();
++  GLint texLoc = m_compositeShader->GetTexLoc();
++
++  GLfloat vert[4][2] = {{0, 0}, {w, 0}, {w, h}, {0, h}};
++  GLfloat tex[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
++  GLubyte idx[4] = {0, 1, 3, 2};
++
++  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, vert);
++  glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 0, tex);
++  glEnableVertexAttribArray(posLoc);
++  glEnableVertexAttribArray(texLoc);
++
++  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
++
++  glDisableVertexAttribArray(posLoc);
++  glDisableVertexAttribArray(texLoc);
++
++  m_compositeShader->Disable();
++}
++
+ bool CWinSystemGbmGLESContext::CreateContext()
+ {
+   const EGLint version = (m_renderableType == EGL_OPENGL_ES3_BIT) ? 3 : 2;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+index 4b8153ad92..cd7e12e0b8 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+@@ -9,11 +9,14 @@
+ #pragma once
+ 
+ #include "WinSystemGbmEGLContext.h"
++#include "cores/VideoPlayer/VideoRenderers/FrameBufferObject.h"
+ #include "rendering/gles/RenderSystemGLES.h"
+ #include "utils/EGLUtils.h"
+ 
+ #include <memory>
+ 
++class CGuiCompositeShaderGLES;
++
+ class CVaapiProxy;
+ 
+ namespace KODI
+@@ -39,10 +42,24 @@ public:
+   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+   void PresentRender(bool rendered, bool videoLayer) override;
+ 
++  // GUI compositing for HDR
++  bool SetGuiCompositing(bool active) override;
++  bool BeginGuiComposite() override;
++  void EndGuiComposite() override;
++  void CompositeGui() override;
++
+ protected:
+   void SetVSyncImpl(bool enable) override {}
+   void PresentRenderImpl(bool rendered) override {};
+   bool CreateContext() override;
++
++private:
++  bool m_guiCompositing{false};
++  CFrameBufferObject m_guiFbo;
++  int m_guiFboWidth{0};
++  int m_guiFboHeight{0};
++
++  std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
+ };
+ 
+ } // namespace GBM
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-GBM-GLES-LUT-textures-and-HLG-support-in-GUI-composi.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-GBM-GLES-LUT-textures-and-HLG-support-in-GUI-composi.patch
@@ -1,0 +1,445 @@
+From 07a6a769f043d8da388ea4284a841bf6c4359ff0 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 7 Apr 2026 11:48:26 -0400
+Subject: [PATCH 07/25] GBM/GLES: LUT textures and HLG support in GUI composite
+ shader
+
+Replace the expensive pow() calls in the GUI composite shader with
+1D LUT texture lookups for PQ, and add HLG support with direct
+shader computation following libplacebo's pl_color_delinearize.
+
+PQ path: degamma LUT (sRGB -> linear) + PQ LUT (linear -> PQ).
+On embedded GPUs, pow() with non-integer exponents decomposes to
+exp2(y * log2(x)) at 1/8 rate on Adreno and 1/2 rate on Mali/Intel.
+LUT texture fetches run on the texture pipe in parallel with ALU.
+
+HLG path: degamma LUT + direct OETF computation in shader. HLG's
+OETF is cheap (sqrt or log), and computing it directly avoids the
+LUT range problem from the inverse OOTF boosting saturated colors
+above 1.0. The shader normalizes by display peak (1000/203 nits),
+applies the inverse OOTF with 12x prescale, then the piecewise
+HLG OETF. GUI white (203 nits) maps to 75% HLG signal per BT.2408.
+
+SDR GUI peak luminance set to 203 nits, the BT.2408 reference white
+for HDR production (75% HLG signal level). This is also the value
+used by libplacebo (PL_COLOR_SDR_WHITE).
+
+SetGuiCompositing signature changed from bool to int (color transfer
+function ID, 0 to disable).
+
+Suggested by @jernejsk.
+---
+ .../shaders/GLES/2.0/gles_gui_composite.frag  |  67 ++++++---
+ .../VideoRenderers/LinuxRendererGLES.cpp      |   2 +-
+ .../rendering/gles/GuiCompositeShaderGLES.cpp | 131 +++++++++++++++++-
+ xbmc/rendering/gles/GuiCompositeShaderGLES.h  |  22 ++-
+ xbmc/windowing/WinSystem.h                    |   3 +-
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp |  21 ++-
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.h  |   2 +-
+ 7 files changed, 213 insertions(+), 35 deletions(-)
+
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.frag b/system/shaders/GLES/2.0/gles_gui_composite.frag
+index ff9e41d2b8..5811f99f9f 100644
+--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
++++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
+@@ -10,15 +10,11 @@
+ 
+ precision mediump float;
+ varying vec2 v_tex;
+-uniform sampler2D u_samp;
+-uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
+-
+-// ST2084 (PQ) constants
+-const float ST2084_m1 = 0.1593017578125;   // 2610/16384
+-const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
+-const float ST2084_c1 = 0.8359375;          // 3424/4096
+-const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
+-const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
++uniform sampler2D u_samp;       // GUI FBO texture (sRGB, rendered by GUI shaders)
++uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (1024 entries, pow 2.2)
++uniform sampler2D u_lutTF;      // linear -> PQ LUT (1024 entries, sdrPeak baked in)
++uniform float u_ootfGamma;      // HLG: OOTF gamma (1.2 for BT.2100 1000-nit ref)
++                                // PQ: 0.0 (use LUT path instead)
+ 
+ // BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
+ const mat3 bt709_to_bt2020 = mat3(
+@@ -27,27 +23,54 @@ const mat3 bt709_to_bt2020 = mat3(
+   0.0433,  0.0114,  0.8956
+ );
+ 
+-vec3 forwardPQ(vec3 L)
+-{
+-  vec3 Lm1 = pow(L, vec3(ST2084_m1));
+-  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
+-}
+-
+ void main()
+ {
+   vec4 gui = texture2D(u_samp, v_tex);
+ 
+-  // sRGB -> linear (approximate)
+-  vec3 linear = pow(gui.rgb, vec3(2.2));
++  // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
++  vec3 linear = vec3(
++    texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
++    texture2D(u_lutDegamma, vec2(gui.g, 0.5)).r,
++    texture2D(u_lutDegamma, vec2(gui.b, 0.5)).r
++  );
+ 
+   // BT.709 -> BT.2020 gamut mapping
+   linear = bt709_to_bt2020 * linear;
+ 
+-  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
+-  linear *= u_sdrPeak;
++  vec3 result;
++
++  if (u_ootfGamma > 0.0)
++  {
++    // HLG path: direct computation following libplacebo pl_color_delinearize.
++    // BT.2100 reference display: 1000 nits. GUI white (linear 1.0) = 203 nits
++    // (BT.2408 reference white) should map to 75% HLG signal.
++    //
++    // Step 1: normalize to display-peak-relative units
++    // Step 2: inverse OOTF with 12x prescale for OETF input domain
++    // Step 3: HLG OETF (ARIB STD-B67) piecewise: sqrt for <=1, log for >1
++    const float csp_max = 1000.0 / 203.0; // display peak in ref-white units
++    const float HLG_A = 0.17883277;
++    const float HLG_B = 0.28466892;
++    const float HLG_C = 0.55991073;
++
++    vec3 scene = linear / csp_max;
++    float Y = dot(scene, vec3(0.2627, 0.6780, 0.0593));
++    scene *= 12.0 * pow(max(1e-6, Y), (1.0 - u_ootfGamma) / u_ootfGamma);
+ 
+-  // linear -> PQ
+-  vec3 pq = forwardPQ(linear);
++    // HLG OETF piecewise (threshold at scene-light 1.0)
++    vec3 lo = vec3(0.5) * sqrt(max(scene, vec3(0.0)));
++    vec3 hi = vec3(HLG_A) * log(max(scene - vec3(HLG_B), vec3(1e-6))) + vec3(HLG_C);
++    result = mix(lo, hi, step(vec3(1.0), scene));
++  }
++  else
++  {
++    // PQ path: LUT lookup (sdrPeak baked into LUT range)
++    result = vec3(
++      texture2D(u_lutTF, vec2(linear.r, 0.5)).r,
++      texture2D(u_lutTF, vec2(linear.g, 0.5)).r,
++      texture2D(u_lutTF, vec2(linear.b, 0.5)).r
++    );
++  }
+ 
+-  gl_FragColor = vec4(pq, gui.a);
++  gl_FragColor = vec4(result, gui.a);
+ }
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index c5bd0541bb..aed09d2124 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -163,7 +163,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
+   }
+ 
+   m_hdrFboActive =
+-      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(m_passthroughHDR);
++      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
+   if (m_passthroughHDR && !m_hdrFboActive)
+     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: HDR passthrough active but GUI "
+                           "compositing not supported by windowing system");
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+index 36ba150996..a2bccb0f86 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+@@ -10,22 +10,57 @@
+ 
+ #include "utils/log.h"
+ 
++extern "C"
++{
++#include <libavutil/pixfmt.h>
++}
++
++#include <cmath>
++
++namespace
++{
++// ST2084 (PQ) constants
++constexpr float ST2084_m1 = 0.1593017578125f; // 2610/16384
++constexpr float ST2084_m2 = 78.84375f; // 2523/4096 * 128
++constexpr float ST2084_c1 = 0.8359375f; // 3424/4096
++constexpr float ST2084_c2 = 18.8515625f; // 2413/4096 * 32
++constexpr float ST2084_c3 = 18.6875f; // 2392/4096 * 32
++
++float ForwardPQ(float L)
++{
++  float Lm1 = std::pow(L, ST2084_m1);
++  return std::pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0f + ST2084_c3 * Lm1), ST2084_m2);
++}
++
++} // namespace
++
+ CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
+ {
+   VertexShader()->LoadSource("gles_gui_composite.vert");
+   PixelShader()->LoadSource("gles_gui_composite.frag");
+ }
+ 
++CGuiCompositeShaderGLES::~CGuiCompositeShaderGLES()
++{
++  if (m_lutDegammaTexId)
++    glDeleteTextures(1, &m_lutDegammaTexId);
++  if (m_lutTFTexId)
++    glDeleteTextures(1, &m_lutTFTexId);
++}
++
+ void CGuiCompositeShaderGLES::OnCompiledAndLinked()
+ {
+   m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
+   m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
+   m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
++  m_hLutDegamma = glGetUniformLocation(ProgramHandle(), "u_lutDegamma");
++  m_hLutTF = glGetUniformLocation(ProgramHandle(), "u_lutTF");
+   m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
+-  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
+-
++  m_hOotfGamma = glGetUniformLocation(ProgramHandle(), "u_ootfGamma");
+   glUseProgram(ProgramHandle());
+   glUniform1i(m_hSamp, 0);
++  glUniform1i(m_hLutDegamma, 1);
++  glUniform1i(m_hLutTF, 2);
+   glUseProgram(0);
+ }
+ 
+@@ -34,6 +69,96 @@ bool CGuiCompositeShaderGLES::OnEnabled()
+   if (m_proj)
+     glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
+ 
+-  glUniform1f(m_hSdrPeak, m_sdrPeak);
++  glUniform1f(m_hOotfGamma, m_ootfGamma);
++
++  glActiveTexture(GL_TEXTURE1);
++  glBindTexture(GL_TEXTURE_2D, m_lutDegammaTexId);
++  glActiveTexture(GL_TEXTURE2);
++  glBindTexture(GL_TEXTURE_2D, m_lutTFTexId);
++  glActiveTexture(GL_TEXTURE0);
++
++  return true;
++}
++
++GLuint CGuiCompositeShaderGLES::CreateLUTTexture(const std::vector<float>& data)
++{
++  GLuint texId;
++  glGenTextures(1, &texId);
++  glBindTexture(GL_TEXTURE_2D, texId);
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
++               data.data());
++  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
++  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
++  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
++  glBindTexture(GL_TEXTURE_2D, 0);
++  return texId;
++}
++
++std::vector<float> CGuiCompositeShaderGLES::GenerateDegammaLUT()
++{
++  std::vector<float> lut(LUT_SIZE);
++  for (int i = 0; i < LUT_SIZE; i++)
++  {
++    float x = static_cast<float>(i) / (LUT_SIZE - 1);
++    lut[i] = std::pow(x, 2.2f);
++  }
++  return lut;
++}
++
++std::vector<float> CGuiCompositeShaderGLES::GeneratePQLUT(float sdrPeak)
++{
++  // PQ is display-referred (absolute luminance). sdrPeak is in PQ-normalized
++  // units (nits / 10000), e.g. 203 nits = 0.0203. The LUT maps the full [0,1]
++  // texture coordinate range to ForwardPQ([0, sdrPeak]), giving full LUT
++  // resolution across the actual SDR luminance range.
++  std::vector<float> lut(LUT_SIZE);
++  for (int i = 0; i < LUT_SIZE; i++)
++  {
++    float L = static_cast<float>(i) / (LUT_SIZE - 1) * sdrPeak;
++    lut[i] = ForwardPQ(L);
++  }
++  return lut;
++}
++
++bool CGuiCompositeShaderGLES::CreateLUTs(int colorTransfer)
++{
++  if (m_lutDegammaTexId)
++    glDeleteTextures(1, &m_lutDegammaTexId);
++  if (m_lutTFTexId)
++    glDeleteTextures(1, &m_lutTFTexId);
++
++  m_lutDegammaTexId = CreateLUTTexture(GenerateDegammaLUT());
++  if (!m_lutDegammaTexId)
++  {
++    CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - failed to create degamma LUT");
++    return false;
++  }
++
++  if (colorTransfer == AVCOL_TRC_SMPTE2084)
++  {
++    m_lutTFTexId = CreateLUTTexture(GeneratePQLUT(m_sdrPeak));
++    if (!m_lutTFTexId)
++    {
++      CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - failed to create PQ LUT");
++      return false;
++    }
++    m_ootfGamma = 0.0f;
++    CLog::Log(LOGDEBUG, "CGuiCompositeShaderGLES::CreateLUTs - created PQ LUT ({} entries)",
++              LUT_SIZE);
++  }
++  else if (colorTransfer == AVCOL_TRC_ARIB_STD_B67)
++  {
++    // HLG: no TF LUT needed, shader computes OETF + inverse OOTF directly.
++    // BT.2100: gamma = 1.2 + 0.42 * log10(Lw/1000). For 1000-nit ref: 1.2.
++    m_ootfGamma = 1.2f;
++    CLog::Log(LOGDEBUG, "CGuiCompositeShaderGLES::CreateLUTs - HLG mode (gamma {})", m_ootfGamma);
++  }
++  else
++  {
++    CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - unsupported transfer function {}",
++              colorTransfer);
++    return false;
++  }
+   return true;
+ }
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.h b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+index 78a5430462..97d9083e41 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+@@ -10,13 +10,17 @@
+ 
+ #include "guilib/Shader.h"
+ 
++#include <vector>
++
+ class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
+ {
+ public:
+   CGuiCompositeShaderGLES();
++  ~CGuiCompositeShaderGLES() override;
+ 
+   void SetProjection(const GLfloat* proj) { m_proj = proj; }
+-  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
++
++  bool CreateLUTs(int colorTransfer);
+ 
+   GLint GetPosLoc() { return m_hPos; }
+   GLint GetTexLoc() { return m_hTex; }
+@@ -26,12 +30,24 @@ protected:
+   bool OnEnabled() override;
+ 
+ private:
++  static constexpr int LUT_SIZE = 1024;
++
++  GLuint CreateLUTTexture(const std::vector<float>& data);
++  static std::vector<float> GenerateDegammaLUT();
++  static std::vector<float> GeneratePQLUT(float sdrPeak);
++
+   const GLfloat* m_proj{nullptr};
+-  float m_sdrPeak{100.0f / 10000.0f};
++  float m_sdrPeak{203.0f / 10000.0f};
++
++  GLuint m_lutDegammaTexId{0};
++  GLuint m_lutTFTexId{0};
++  float m_ootfGamma{0.0f};
+ 
+   GLint m_hPos{-1};
+   GLint m_hTex{-1};
+   GLint m_hSamp{-1};
++  GLint m_hLutDegamma{-1};
++  GLint m_hLutTF{-1};
+   GLint m_hProj{-1};
+-  GLint m_hSdrPeak{-1};
++  GLint m_hOotfGamma{-1};
+ };
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+index a21844814b..954516b55d 100644
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -248,7 +248,8 @@ public:
+   virtual bool SupportsVideoSuperResolution() { return false; }
+ 
+   // GUI compositing for HDR: render GUI to FBO, composite with tone mapping
+-  virtual bool SetGuiCompositing(bool active) { return false; }
++  // colorTransfer: AVCOL_TRC_SMPTE2084 (PQ) or AVCOL_TRC_ARIB_STD_B67 (HLG), 0 to disable
++  virtual bool SetGuiCompositing(int colorTransfer) { return false; }
+   virtual bool BeginGuiComposite() { return false; }
+   virtual void EndGuiComposite() {}
+   virtual void CompositeGui() {}
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index ea9bea6818..c7c6db634e 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -21,6 +21,11 @@
+ #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+ #include "rendering/gles/GuiCompositeShaderGLES.h"
+ #include "rendering/gles/ScreenshotSurfaceGLES.h"
++
++extern "C"
++{
++#include <libavutil/pixfmt.h>
++}
+ #include "utils/BufferObjectFactory.h"
+ #include "utils/DMAHeapBufferObject.h"
+ #include "utils/DumbBufferObject.h"
+@@ -187,11 +192,11 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
+   }
+ }
+ 
+-bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
++bool CWinSystemGbmGLESContext::SetGuiCompositing(int colorTransfer)
+ {
+-  m_guiCompositing = active;
++  m_guiCompositing = (colorTransfer != 0);
+ 
+-  if (active)
++  if (m_guiCompositing)
+   {
+     if (!m_compositeShader)
+     {
+@@ -201,8 +206,17 @@ bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
+         CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");
+         m_compositeShader.reset();
+         m_guiCompositing = false;
++        return false;
+       }
+     }
++
++    if (!m_compositeShader->CreateLUTs(colorTransfer))
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to create LUTs");
++      m_compositeShader.reset();
++      m_guiCompositing = false;
++      return false;
++    }
+   }
+   else
+   {
+@@ -291,7 +305,6 @@ void CWinSystemGbmGLESContext::CompositeGui()
+   GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
+ 
+   m_compositeShader->SetProjection(proj);
+-  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
+   m_compositeShader->Enable();
+ 
+   GLint posLoc = m_compositeShader->GetPosLoc();
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+index cd7e12e0b8..92d0e744ed 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+@@ -43,7 +43,7 @@ public:
+   void PresentRender(bool rendered, bool videoLayer) override;
+ 
+   // GUI compositing for HDR
+-  bool SetGuiCompositing(bool active) override;
++  bool SetGuiCompositing(int colorTransfer) override;
+   bool BeginGuiComposite() override;
+   void EndGuiComposite() override;
+   void CompositeGui() override;
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0008-GBM-GLES-fix-LUT-texture-creation-for-GLES-3.x-drive.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0008-GBM-GLES-fix-LUT-texture-creation-for-GLES-3.x-drive.patch
@@ -1,0 +1,83 @@
+From 69ecdd44572a0b73a6a9d90da938d91ddbbfbfab Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Fri, 10 Apr 2026 12:48:47 -0400
+Subject: [PATCH 08/25] GBM/GLES: fix LUT texture creation for GLES 3.x drivers
+
+Prefer GL_R16F + GL_RED (GLES 3.0 sized format) over GL_LUMINANCE +
+GL_FLOAT (GLES 2.0 unsized format) for GUI composite shader LUT
+textures. The GLES 3.0 spec tightens format validation for unsized
+internal formats, and some drivers (e.g. Broadcom V3D on RPi5)
+silently reject GL_LUMINANCE + GL_FLOAT despite advertising
+OES_texture_float -- the texture is created but contains no data,
+causing the tone mapping shader to output black.
+
+Fall back to GL_LUMINANCE + GL_FLOAT for GLES 2.0-only devices
+(e.g. RPi3, some Rockchip SoCs). Check glGetError() after each
+attempt to detect silent upload failures.
+---
+ .../rendering/gles/GuiCompositeShaderGLES.cpp | 41 ++++++++++++++++++-
+ 1 file changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+index a2bccb0f86..aa5d69293e 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+@@ -82,16 +82,53 @@ bool CGuiCompositeShaderGLES::OnEnabled()
+ 
+ GLuint CGuiCompositeShaderGLES::CreateLUTTexture(const std::vector<float>& data)
+ {
++  while (glGetError() != GL_NO_ERROR)
++  {
++  }
++
+   GLuint texId;
+   glGenTextures(1, &texId);
+   glBindTexture(GL_TEXTURE_2D, texId);
+-  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
+-               data.data());
++
++  // Prefer GL_R16F (GLES 3.0 core) over GL_LUMINANCE + GL_FLOAT (GLES 2.0).
++  // The GLES 3.0 spec tightens format validation for unsized internal formats,
++  // and some drivers (e.g. V3D on RPi5) silently reject GL_LUMINANCE + GL_FLOAT
++  // despite advertising OES_texture_float. GL_R16F avoids this by using a sized
++  // format with well-defined behavior. Half-float precision is sufficient for
++  // a 1024-entry LUT.
++  bool uploaded = false;
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_R16F, data.size(), 1, 0, GL_RED, GL_FLOAT, data.data());
++  if (glGetError() == GL_NO_ERROR)
++  {
++    uploaded = true;
++  }
++  else
++  {
++    while (glGetError() != GL_NO_ERROR)
++    {
++    }
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
++                 data.data());
++    if (glGetError() == GL_NO_ERROR)
++      uploaded = true;
++    else
++      CLog::Log(LOGERROR,
++                "CGuiCompositeShaderGLES::CreateLUTTexture - failed to create {} entry "
++                "LUT texture (GL_R16F and GL_LUMINANCE+GL_FLOAT both failed)",
++                data.size());
++  }
++
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+   glBindTexture(GL_TEXTURE_2D, 0);
++
++  if (!uploaded)
++  {
++    glDeleteTextures(1, &texId);
++    return 0;
++  }
+   return texId;
+ }
+ 
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0009-FBO-add-depth-renderbuffer-for-front-to-back-renderi.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0009-FBO-add-depth-renderbuffer-for-front-to-back-renderi.patch
@@ -1,0 +1,115 @@
+From 66d623483cbce29a7c774973a9eac12a48b15ae5 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Wed, 15 Apr 2026 21:30:33 -0400
+Subject: [PATCH 09/25] FBO: add depth renderbuffer for front-to-back rendering
+ compatibility
+
+The GUI compositing FBO only had a color attachment. When the
+fronttobackrendering advanced setting is enabled, the opaque pass
+needs a depth buffer for occlusion testing. Without one, depth tests
+have nothing to reject against and Z ordering breaks.
+
+Attach a GL_DEPTH_COMPONENT16 renderbuffer to the compositing FBO,
+gated on GetEnabledFrontToBackRendering() so users without the setting
+pay no cost.
+---
+ .../VideoRenderers/FrameBufferObject.cpp      | 31 +++++++++++++++++++
+ .../VideoRenderers/FrameBufferObject.h        |  5 +++
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp |  9 ++++++
+ 3 files changed, 45 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
+index f2ce89a73b..f04132f9bd 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
+@@ -62,6 +62,10 @@ void CFrameBufferObject::Cleanup()
+   if (m_texid)
+     glDeleteTextures(1, &m_texid);
+ 
++  if (m_depthBuffer)
++    glDeleteRenderbuffers(1, &m_depthBuffer);
++
++  m_depthBuffer = 0;
+   m_texid = 0;
+   m_fbo = 0;
+   m_valid = false;
+@@ -102,6 +106,33 @@ bool CFrameBufferObject::CreateAndBindToTexture(GLenum target, int width, int he
+   return true;
+ }
+ 
++bool CFrameBufferObject::AttachDepthBuffer(int width, int height)
++{
++  if (!IsValid() || !IsBound())
++    return false;
++
++  if (m_depthBuffer)
++    glDeleteRenderbuffers(1, &m_depthBuffer);
++
++  glGenRenderbuffers(1, &m_depthBuffer);
++  glBindRenderbuffer(GL_RENDERBUFFER, m_depthBuffer);
++  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, width, height);
++  glBindRenderbuffer(GL_RENDERBUFFER, 0);
++
++  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
++  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthBuffer);
++  const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
++  glBindFramebuffer(GL_FRAMEBUFFER, 0);
++
++  if (status != GL_FRAMEBUFFER_COMPLETE)
++  {
++    glDeleteRenderbuffers(1, &m_depthBuffer);
++    m_depthBuffer = 0;
++    return false;
++  }
++  return true;
++}
++
+ void CFrameBufferObject::SetFiltering(GLenum target, GLenum mode)
+ {
+   glBindTexture(target, m_texid);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h
+index a284c829dc..1a50c8c429 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h
+@@ -57,6 +57,10 @@ public:
+   bool CreateAndBindToTexture(GLenum target, int width, int height, GLenum format, GLenum type=GL_UNSIGNED_BYTE,
+                               GLenum filter=GL_LINEAR, GLenum clampmode=GL_CLAMP_TO_EDGE);
+ 
++  // Attach a depth renderbuffer. Required when rendering into the FBO with
++  // front-to-back (depth-tested) opaque passes enabled.
++  bool AttachDepthBuffer(int width, int height);
++
+   // Return the internally created texture ID
+   GLuint Texture() const { return m_texid; }
+ 
+@@ -71,6 +75,7 @@ private:
+   bool   m_bound;
+   bool   m_supported;
+   GLuint m_texid = 0;
++  GLuint m_depthBuffer = 0;
+ };
+ 
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index c7c6db634e..16831bd13c 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -256,6 +256,15 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
+       return false;
+     }
+ 
++    if (GetEnabledFrontToBackRendering() && !m_guiFbo.AttachDepthBuffer(width, height))
++    {
++      CLog::Log(LOGERROR,
++                "CWinSystemGbmGLESContext: failed to attach depth buffer to GUI FBO {}x{}", width,
++                height);
++      m_guiFbo.Cleanup();
++      return false;
++    }
++
+     m_guiFboWidth = width;
+     m_guiFboHeight = height;
+     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0010-GBM-GLES-compensate-GUI-alpha-blend-for-non-linear-H.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0010-GBM-GLES-compensate-GUI-alpha-blend-for-non-linear-H.patch
@@ -1,0 +1,108 @@
+From e0597d67ce16db8124cd5911a530dc95f39005f3 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 21 Apr 2026 15:48:05 -0400
+Subject: [PATCH 10/25] GBM/GLES: compensate GUI alpha blend for non-linear HDR
+ composite
+
+Alpha blending assumes linear light. In SDR the skin is drawn directly
+against the backbuffer in sRGB -- "wrong but consistent", and the default
+accumulator alpha (GL_ONE_MINUS_DST_ALPHA / GL_ONE) is correct for dual-
+plane GUI coverage. When HDR FBO compositing is active, GUI is rendered
+into an sRGB FBO that is later color-transformed to PQ/HLG and composited
+against HDR video in that non-linear space. Applying linear-blend math
+to non-linear values yields incorrect transparency.
+
+Add CWinSystemBase::IsHdrComposite() (overridden in CWinSystemGbmGLESContext)
+and branch on it in CGUIFontTTFGLES::FirstBegin and CGUITextureGLES::Begin
+to select a compensated squared-alpha blend for the HDR FBO path. This is
+a visual compromise, not a mathematically correct fix -- linear-light
+compositing would be prohibitively expensive on ARM GPUs. Empirically
+matches SDR closely on the default Estuary skin.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ xbmc/guilib/GUIFontTTFGLES.cpp               | 15 +++++++++++++--
+ xbmc/guilib/GUITextureGLES.cpp               |  9 ++++++++-
+ xbmc/windowing/WinSystem.h                   |  7 +++++++
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.h |  1 +
+ 4 files changed, 29 insertions(+), 3 deletions(-)
+
+diff --git a/xbmc/guilib/GUIFontTTFGLES.cpp b/xbmc/guilib/GUIFontTTFGLES.cpp
+index 307f72bb5e..ea57d0dc8f 100644
+--- a/xbmc/guilib/GUIFontTTFGLES.cpp
++++ b/xbmc/guilib/GUIFontTTFGLES.cpp
+@@ -126,8 +126,19 @@ bool CGUIFontTTFGLES::FirstBegin()
+     m_textureStatus = TEXTURE_READY;
+   }
+ 
+-  // Turn Blending On
+-  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
++  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
++  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
++  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
++  // FBO that is color-transformed to PQ/HLG before compositing with video
++  // in that non-linear space -- two stages of non-linear blending. The
++  // compensated factors below trade accumulator coverage for a squared-
++  // alpha blend that approximately matches SDR perceived translucency. It
++  // is a "close enough" compromise; a mathematically correct fix would
++  // require linear-light compositing (too expensive on typical ARM GPUs).
++  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
++    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
++  else
++    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+   glEnable(GL_BLEND);
+   glActiveTexture(GL_TEXTURE0);
+   glBindTexture(GL_TEXTURE_2D, m_nTexture);
+diff --git a/xbmc/guilib/GUITextureGLES.cpp b/xbmc/guilib/GUITextureGLES.cpp
+index a0c7d10514..f98d4d485d 100644
+--- a/xbmc/guilib/GUITextureGLES.cpp
++++ b/xbmc/guilib/GUITextureGLES.cpp
+@@ -121,7 +121,14 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
+ 
+   if (hasAlpha)
+   {
+-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
++    // See CGUIFontTTFGLES::FirstBegin for rationale. SDR uses accumulator
++    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
++    // blend because the FBO is color-transformed to PQ/HLG before composite,
++    // and alpha blending in non-linear space is mathematically wrong.
++    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
++      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
++    else
++      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+     glEnable( GL_BLEND );
+   }
+   else
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+index 954516b55d..d3b7c33a80 100644
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -254,6 +254,13 @@ public:
+   virtual void EndGuiComposite() {}
+   virtual void CompositeGui() {}
+ 
++  // True when GUI is rendered to an FBO that is then color-transformed
++  // (sRGB -> PQ/HLG) and composited against HDR video in that non-linear
++  // space. Alpha blending assumes linear light; blending non-linear values
++  // yields wrong transparency. When true, GUI draws select a compensated
++  // alpha blend (see CGUIFontTTFGLES::FirstBegin).
++  virtual bool IsHdrComposite() const { return false; }
++
+   /*!
+    * \brief Gets debug info from video renderer for use in "Debug Info OSD" (Alt + O)
+    *
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+index 92d0e744ed..706eca0d87 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+@@ -47,6 +47,7 @@ public:
+   bool BeginGuiComposite() override;
+   void EndGuiComposite() override;
+   void CompositeGui() override;
++  bool IsHdrComposite() const override { return m_guiCompositing; }
+ 
+ protected:
+   void SetVSyncImpl(bool enable) override {}
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0011-GBM-GLES-discard-composite-fragments-with-alpha-0.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0011-GBM-GLES-discard-composite-fragments-with-alpha-0.patch
@@ -1,0 +1,43 @@
+From d88413ee2f41c7424c3be50168e21a30d939401a Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Thu, 23 Apr 2026 19:51:09 -0400
+Subject: [PATCH 11/25] GBM/GLES: discard composite fragments with alpha=0
+
+The HDR composite pass is run as a full-screen quad, so the shader
+executes for every pixel including the large majority that the GUI
+never wrote to (e.g. during video playback with only a subtitle line
+visible). Discarding early on alpha=0 lets the GPU skip the tone-map
+math, the backbuffer read and the backbuffer write for those pixels.
+
+Blend identity (DST*(1-0) + garbage*0 = DST) already preserves video
+bit-exactly on alpha=0 pixels today. Discard makes that guarantee
+structural: the GPU never visits those pixels, so no arithmetic, no
+blend unit involvement, no quantization path.
+
+Only the texture sample of the GUI FBO happens before the discard
+decision; that is unavoidable without out-of-shader culling (scissor,
+stencil) which is a separate optimization.
+---
+ system/shaders/GLES/2.0/gles_gui_composite.frag | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.frag b/system/shaders/GLES/2.0/gles_gui_composite.frag
+index 5811f99f9f..5e80cedde8 100644
+--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
++++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
+@@ -27,6 +27,12 @@ void main()
+ {
+   vec4 gui = texture2D(u_samp, v_tex);
+ 
++  // Skip pixels the GUI never wrote to. Blend unit would still preserve video
++  // bit-exactly via DST*(1-0)+garbage*0=DST, but discard makes it structural
++  // and avoids the tone-map math, BO read and BO write for those pixels.
++  if (gui.a == 0.0)
++    discard;
++
+   // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
+   vec3 linear = vec3(
+     texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0012-GBM-GLES-use-proper-sRGB-EOTF-and-right-size-GUI-com.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0012-GBM-GLES-use-proper-sRGB-EOTF-and-right-size-GUI-com.patch
@@ -1,0 +1,106 @@
+From 5fec3d16d6780a0e5b458e0559877e94a85ec11e Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Sun, 26 Apr 2026 12:22:09 -0400
+Subject: [PATCH 12/25] GBM/GLES: use proper sRGB EOTF and right-size GUI
+ composite degamma LUT
+
+The degamma LUT was using pow(x, 2.2) as a simplified approximation
+of the sRGB encoding curve. The actual sRGB EOTF defined in IEC
+61966-2-1 (and the W3C document by Stokes et al. 1996 that the
+standard was based on) is piecewise: a linear segment near zero and
+a power form above the breakpoint at sRGB-encoded V = 0.04045.
+
+The two curves agree to ~1-2% in the mid-tones but diverge by up to
+3x in the dark region. Below the breakpoint, the standard's linear
+segment lifts values that pow(2.2) crushes toward zero. On HDR
+displays this is visible as too-dark GUI in subtitle outlines,
+panel shadows, and similar low-luminance regions.
+
+Bring this LUT up to the same precision bar as the PQ and HLG paths
+in the same shader, both of which use full SMPTE / BT.2100 math.
+
+Also right-size LUT_SIZE from 1024 to 256. The GUI FBO is RGBA8, so
+256 entries precisely represent every distinct input value (k/255
+for k in 0..255). 1024 was 4x oversampled, with GL_LINEAR filtering
+interpolating between near-identical neighbors. A comment documents
+that the size should grow to match if the FBO ever moves to >8-bit
+storage.
+
+Verified against:
+- Mesa src/util/format_srgb.py (used by every Linux GLES driver)
+- W3C Stokes et al. 1996 "A Standard Default Color Space for the
+  Internet" (the document IEC 61966-2-1 was based on)
+
+No code-flow change: same texture format, same upload path, same
+sampling code. Only the LUT data values and entry count change.
+---
+ system/shaders/GLES/2.0/gles_gui_composite.frag | 4 ++--
+ xbmc/rendering/gles/GuiCompositeShaderGLES.cpp  | 8 +++++++-
+ xbmc/rendering/gles/GuiCompositeShaderGLES.h    | 3 ++-
+ 3 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.frag b/system/shaders/GLES/2.0/gles_gui_composite.frag
+index 5e80cedde8..308622d580 100644
+--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
++++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
+@@ -11,7 +11,7 @@
+ precision mediump float;
+ varying vec2 v_tex;
+ uniform sampler2D u_samp;       // GUI FBO texture (sRGB, rendered by GUI shaders)
+-uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (1024 entries, pow 2.2)
++uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (IEC 61966-2-1)
+ uniform sampler2D u_lutTF;      // linear -> PQ LUT (1024 entries, sdrPeak baked in)
+ uniform float u_ootfGamma;      // HLG: OOTF gamma (1.2 for BT.2100 1000-nit ref)
+                                 // PQ: 0.0 (use LUT path instead)
+@@ -33,7 +33,7 @@ void main()
+   if (gui.a == 0.0)
+     discard;
+ 
+-  // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
++  // sRGB -> linear via LUT (IEC 61966-2-1 EOTF, replaces inline pow)
+   vec3 linear = vec3(
+     texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
+     texture2D(u_lutDegamma, vec2(gui.g, 0.5)).r,
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+index aa5d69293e..b5c0406604 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+@@ -32,6 +32,12 @@ float ForwardPQ(float L)
+   return std::pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0f + ST2084_c3 * Lm1), ST2084_m2);
+ }
+ 
++// IEC 61966-2-1 sRGB EOTF.
++float SRGBToLinear(float v)
++{
++  return v <= 0.04045f ? v / 12.92f : std::pow((v + 0.055f) / 1.055f, 2.4f);
++}
++
+ } // namespace
+ 
+ CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
+@@ -138,7 +144,7 @@ std::vector<float> CGuiCompositeShaderGLES::GenerateDegammaLUT()
+   for (int i = 0; i < LUT_SIZE; i++)
+   {
+     float x = static_cast<float>(i) / (LUT_SIZE - 1);
+-    lut[i] = std::pow(x, 2.2f);
++    lut[i] = SRGBToLinear(x);
+   }
+   return lut;
+ }
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.h b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+index 97d9083e41..3bdfd49203 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+@@ -30,7 +30,8 @@ protected:
+   bool OnEnabled() override;
+ 
+ private:
+-  static constexpr int LUT_SIZE = 1024;
++  // One entry per RGBA8 input value; increase to match GUI bit depth.
++  static constexpr int LUT_SIZE = 256;
+ 
+   GLuint CreateLUTTexture(const std::vector<float>& data);
+   static std::vector<float> GenerateDegammaLUT();
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0013-GBM-GLES-encode-limited-range-PQ-at-composite-shader.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0013-GBM-GLES-encode-limited-range-PQ-at-composite-shader.patch
@@ -1,0 +1,141 @@
+From 868c521e0a3f445e8bb944d67c0c271f07c1be34 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Wed, 29 Apr 2026 22:55:12 -0400
+Subject: [PATCH 13/25] GBM/GLES: encode limited-range PQ at composite shader
+ output
+
+When HDR FBO compositing is active and limitedrange=true, GUI shaders
+were applying KODI_LIMITED_RANGE before writing to the FBO. The composite
+shader then ran sRGB EOTF on the already-squashed values, decoding peak
+white (squashed to 0.922) as 0.832 linear instead of 1.0. Mid-tones and
+textured GUI elements rendered ~17% dim relative to fonts at peak.
+
+Move the limited-range encoding from the GUI shader to the BO-write
+boundary in the composite shader:
+
+- RenderSystemGLES: gate m_limitedColorRange on !IsHdrComposite() so GUI
+  shaders write un-squashed sRGB into the FBO. The composite shader's
+  sRGB EOTF now operates on its actual inverse domain.
+
+- gles_gui_composite.frag: add KODI_LIMITED_RANGE block at the end of
+  main() (after the PQ encode, before gl_FragColor). Uses canonical
+  16-235 / 219 ratios consistent with KODI_LIMITED_RANGE elsewhere in
+  the GUI shader chain.
+
+- GuiCompositeShaderGLES: constructor takes a const std::string& prefix
+  argument and passes it to both VertexShader and PixelShader LoadSource,
+  matching CGLESShader's existing pattern.
+
+- WinSystemGbmGLESContext::SetGuiCompositing: build the defines string
+  with #define KODI_LIMITED_RANGE 1 when UseLimitedColor() is true and
+  pass to the composite shader constructor.
+
+Verified on Intel N250 4K AR30 PQ via DialogPlayerProcessInfo
+diagnostic stripes: all three GUI render paths (SM_TEXTURE_NOBLEND,
+SM_TEXTURE, SM_FONTS) land at 574 at peak white, the SMPTE limited-range
+PQ encoding of sdrPeak (203 nits).
+---
+ system/shaders/GLES/2.0/gles_gui_composite.frag | 7 +++++++
+ xbmc/rendering/gles/GuiCompositeShaderGLES.cpp  | 6 +++---
+ xbmc/rendering/gles/GuiCompositeShaderGLES.h    | 3 ++-
+ xbmc/rendering/gles/RenderSystemGLES.cpp        | 6 ++++--
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp  | 5 ++++-
+ 5 files changed, 20 insertions(+), 7 deletions(-)
+
+diff --git a/system/shaders/GLES/2.0/gles_gui_composite.frag b/system/shaders/GLES/2.0/gles_gui_composite.frag
+index 308622d580..4cfd4fdd07 100644
+--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
++++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
+@@ -78,5 +78,12 @@ void main()
+     );
+   }
+ 
++  // Limited-range encoding at the BO write boundary. Canonical normalized
++  // ratios (bit-depth-agnostic in float space; BO write quantizes to the
++  // active surface bit depth).
++#ifdef KODI_LIMITED_RANGE
++  result = result * ((235.0 - 16.0) / 255.0) + (16.0 / 255.0);
++#endif
++
+   gl_FragColor = vec4(result, gui.a);
+ }
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+index b5c0406604..77dc71381a 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+@@ -40,10 +40,10 @@ float SRGBToLinear(float v)
+ 
+ } // namespace
+ 
+-CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
++CGuiCompositeShaderGLES::CGuiCompositeShaderGLES(const std::string& prefix)
+ {
+-  VertexShader()->LoadSource("gles_gui_composite.vert");
+-  PixelShader()->LoadSource("gles_gui_composite.frag");
++  VertexShader()->LoadSource("gles_gui_composite.vert", prefix);
++  PixelShader()->LoadSource("gles_gui_composite.frag", prefix);
+ }
+ 
+ CGuiCompositeShaderGLES::~CGuiCompositeShaderGLES()
+diff --git a/xbmc/rendering/gles/GuiCompositeShaderGLES.h b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+index 3bdfd49203..9a1f83f745 100644
+--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
++++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+@@ -10,12 +10,13 @@
+ 
+ #include "guilib/Shader.h"
+ 
++#include <string>
+ #include <vector>
+ 
+ class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
+ {
+ public:
+-  CGuiCompositeShaderGLES();
++  explicit CGuiCompositeShaderGLES(const std::string& prefix);
+   ~CGuiCompositeShaderGLES() override;
+ 
+   void SetProjection(const GLfloat* proj) { m_proj = proj; }
+diff --git a/xbmc/rendering/gles/RenderSystemGLES.cpp b/xbmc/rendering/gles/RenderSystemGLES.cpp
+index 38105c0a64..480d5d76ac 100644
+--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
++++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
+@@ -176,7 +176,8 @@ bool CRenderSystemGLES::BeginRender()
+   if (!m_bRenderCreated)
+     return false;
+ 
+-  const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
++  const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
++                          !CServiceBroker::GetWinSystem()->IsHdrComposite();
+   const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();
+ 
+   if (m_limitedColorRange != useLimited || m_transferPQ != usePQ)
+@@ -445,7 +446,8 @@ void CRenderSystemGLES::SetDepthCulling(DepthCulling culling)
+ void CRenderSystemGLES::InitialiseShaders()
+ {
+   std::string defines;
+-  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor();
++  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
++                        !CServiceBroker::GetWinSystem()->IsHdrComposite();
+   if (m_limitedColorRange)
+   {
+     defines += "#define KODI_LIMITED_RANGE 1\n";
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index 16831bd13c..6ad94cf060 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -200,7 +200,10 @@ bool CWinSystemGbmGLESContext::SetGuiCompositing(int colorTransfer)
+   {
+     if (!m_compositeShader)
+     {
+-      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>();
++      std::string defines;
++      if (UseLimitedColor())
++        defines += "#define KODI_LIMITED_RANGE 1\n";
++      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>(defines);
+       if (!m_compositeShader->CompileAndLink())
+       {
+         CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0014-RendererDRMPRIMEGLES-add-HDR-passthrough-and-GUI-com.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0014-RendererDRMPRIMEGLES-add-HDR-passthrough-and-GUI-com.patch
@@ -1,0 +1,149 @@
+From a2e9a4ee361fd323f0f8a3eccf6eea0f7870fe69 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 16 Mar 2026 21:05:56 -0400
+Subject: [PATCH 14/25] RendererDRMPRIMEGLES: add HDR passthrough and GUI
+ compositing
+
+Enable HDR support for RendererDRMPRIMEGLES (single-plane EGL
+rendering of DRMPRIME buffers):
+
+- SetVideoOutput() in Configure() and reverse-paired in UnInit() so
+  the windowing system can switch the GUI plane format when video
+  starts/stops.
+- SetHDR() in Configure() to signal HDR metadata to the display,
+  fixing "no HDR in EGL mode" on ARM platforms.
+- FBO GUI compositing via SetGuiCompositing() when HDR is active,
+  using the sRGB-to-PQ tone mapping shader from #28012.
+- IsGuiLayer()/HasVideoPlane() overrides for the render split that
+  FBO compositing needs.
+
+UnInit() and the destructor follow the CLinuxRendererGLES model:
+
+- m_configured is set early in Configure (after the winSystem
+  null-check, before any WinSystem state changes), so a later
+  early-return still triggers proper cleanup of state already set.
+- Dtor delegates to UnInit(); single source of truth.
+- UnInit() reverses Configure's call order: SetGuiCompositing,
+  SetHDR, SetVideoOutput.
+- Flush(false) at the top of UnInit() so buffer release and
+  WinSystem teardown are colocated.
+
+Depends on #28012.
+---
+ .../HwDecRender/RendererDRMPRIMEGLES.cpp      | 57 ++++++++++++++++---
+ .../HwDecRender/RendererDRMPRIMEGLES.h        |  6 +-
+ 2 files changed, 54 insertions(+), 9 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+index e1be23d886..f30fef57b5 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+@@ -30,13 +30,7 @@ using namespace KODI::UTILS::EGL;
+ 
+ CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
+ {
+-  Flush(false);
+-
+-  if (m_configured)
+-  {
+-    if (auto winSystem = CServiceBroker::GetWinSystem())
+-      winSystem->SetVideoOutput(nullptr);
+-  }
++  UnInit();
+ }
+ 
+ CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
+@@ -115,6 +109,8 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
+   if (!winSystem)
+     return false;
+ 
++  m_configured = true;
++
+   if (!winSystem->SetVideoOutput(&picture))
+     CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: SetVideoOutput failed");
+ 
+@@ -136,10 +132,55 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
+ 
+   m_clearColour = winSystem->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
+-  m_configured = true;
++  //! @todo limited-range color management is broken on the DRMPRIMEGLES path.
++  //! The OES_EGL_image_external sampler (samplerExternalOES) does YUV->RGB
++  //! conversion in mesa with hardcoded matrices that always output full-range
++  //! RGB regardless of source range. So `videoscreen.limitedrange=true` is
++  //! silently ignored for video pixels here, while GUI pixels go through the
++  //! GLES shader chain that does honor the setting -- producing a range
++  //! mismatch in the BO when both are composited. The clean fix is to migrate
++  //! from OES_EGL_image_external to EXT_YUV_target's __samplerExternal2DY2YEXT
++  //! (sampler returns raw YUV) and apply the conversion matrix in our own
++  //! shader, the way RendererVAAPIGLES does. Tracked in
++  //! project_limited_range_hdr.md.
++
++  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
++      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
++  {
++    m_passthroughHDR = winSystem->SetHDR(&picture);
++    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
++              m_passthroughHDR ? "on" : "off");
++  }
++
++  m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
++  if (m_passthroughHDR && !m_hdrFboActive)
++    CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: HDR passthrough active but GUI "
++                          "compositing not supported by windowing system");
++
+   return true;
+ }
+ 
++bool CRendererDRMPRIMEGLES::IsGuiLayer()
++{
++  return !m_hdrFboActive;
++}
++
++void CRendererDRMPRIMEGLES::UnInit()
++{
++  Flush(false);
++
++  if (m_configured)
++  {
++    m_hdrFboActive = false;
++    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
++    CServiceBroker::GetWinSystem()->SetHDR(nullptr);
++    m_passthroughHDR = false;
++    CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
++  }
++
++  m_configured = false;
++}
++
+ void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int index)
+ {
+   BUFFER& buf = m_buffers[index];
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+index 20be4e3f75..38ec39a325 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+@@ -37,8 +37,10 @@ public:
+   // Player functions
+   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
+   bool IsConfigured() override { return m_configured; }
++  bool IsGuiLayer() override;
++  bool HasVideoPlane() override { return false; }
+   void AddVideoPicture(const VideoPicture& picture, int index) override;
+-  void UnInit() override {}
++  void UnInit() override;
+   bool Flush(bool saveBuffers) override;
+   void ReleaseBuffer(int idx) override;
+   bool NeedBuffer(int idx) override;
+@@ -59,6 +61,8 @@ private:
+   void Render(unsigned int flags, int index);
+ 
+   bool m_configured = false;
++  bool m_passthroughHDR{false};
++  bool m_hdrFboActive{false};
+   float m_clearColour{0.0f};
+ 
+   struct BUFFER
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0015-RendererDRMPRIME-add-GUI-compositing-for-Direct-to-P.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0015-RendererDRMPRIME-add-GUI-compositing-for-Direct-to-P.patch
@@ -1,0 +1,55 @@
+From b3777e96241ce640489501a616df393e854bd01a Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Sat, 21 Mar 2026 00:46:13 -0400
+Subject: [PATCH 15/25] RendererDRMPRIME: add GUI compositing for
+ Direct-to-Plane HDR
+
+Enable FBO-based GUI tone mapping for Direct-to-Plane rendering.
+The GUI plane is still rendered via GLES, so the existing FBO
+compositing infrastructure works -- GUI renders to FBO with
+sRGB-to-PQ conversion, then composites onto the GUI plane's
+framebuffer. The DRM display controller alpha-composites the
+tone-mapped GUI plane over the HDR video plane.
+
+Gate SetHDR/SetGuiCompositing on color_transfer check, matching
+the pattern in LinuxRendererGLES and RendererDRMPRIMEGLES.
+
+Depends on #28012.
+---
+ .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp         | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+index 3627ff7f7e..22da4923c5 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+@@ -44,8 +44,9 @@ void CVideoLayerBridgeDRMPRIME::Disable()
+   if (!winSystem)
+     return;
+ 
+-  // disable HDR metadata
++  // disable HDR metadata and GUI compositing
+   winSystem->SetHDR(nullptr);
++  winSystem->SetGuiCompositing(false);
+ }
+ 
+ void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
+@@ -169,7 +170,14 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+ 
+   const VideoPicture& picture = buffer->GetPicture();
+ 
+-  winSystem->SetHDR(&picture);
++  // Gate HDR passthrough on transfer function, matching the pattern in
++  // LinuxRendererGLES and RendererDRMPRIMEGLES (see smp79's 850dfb04d4).
++  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
++      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
++  {
++    if (winSystem->SetHDR(&picture))
++      winSystem->SetGuiCompositing(picture.color_transfer);
++  }
+ 
+   std::optional<uint64_t> colorEncoding =
+       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0016-LinuxRendererGL-FBO-based-GUI-compositing-for-HDR-pa.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0016-LinuxRendererGL-FBO-based-GUI-compositing-for-HDR-pa.patch
@@ -1,0 +1,489 @@
+From 5ffbca72e1150c4f265f4ade0db3ce8ec26d29f1 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Fri, 20 Mar 2026 13:01:27 -0400
+Subject: [PATCH 16/25] LinuxRendererGL: FBO-based GUI compositing for HDR
+ passthrough
+
+Port the GLES FBO GUI compositing (PR #28012) to the GL path.
+
+When LinuxRendererGL enables HDR passthrough, the GUI is rendered
+into an off-screen FBO, then composited onto the final frame using
+a custom sRGB->PQ tone-mapping shader with BT.709->BT.2020 gamut
+conversion. This keeps the SDR GUI legible on a PQ HDR surface.
+
+SDR GUI peak is hardcoded to 100 nits (100/10000 in PQ normalized
+units), which is the sRGB reference white. This should be made
+configurable in a future change (applies to both this and #28012).
+
+GL differences from the GLES implementation:
+- VBOs required for vertex data (GL 3.2 core profile does not
+  support client-side vertex arrays)
+- GLSL #version 150 syntax (in/out, texture(), out vec4 fragColor)
+- Custom shader with own projection uniform (bypasses Kodi's
+  global matrix stack which is in arbitrary state after video render)
+---
+ system/shaders/GL/1.5/gl_gui_composite.frag   |  53 +++++++
+ system/shaders/GL/1.5/gl_gui_composite.vert   |  20 +++
+ .../VideoRenderers/LinuxRendererGL.cpp        |  13 ++
+ .../VideoRenderers/LinuxRendererGL.h          |   3 +
+ xbmc/rendering/gl/CMakeLists.txt              |   6 +-
+ xbmc/rendering/gl/GuiCompositeShaderGL.cpp    |  39 +++++
+ xbmc/rendering/gl/GuiCompositeShaderGL.h      |  37 +++++
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 138 ++++++++++++++++++
+ xbmc/windowing/gbm/WinSystemGbmGLContext.h    |  15 ++
+ 9 files changed, 322 insertions(+), 2 deletions(-)
+ create mode 100644 system/shaders/GL/1.5/gl_gui_composite.frag
+ create mode 100644 system/shaders/GL/1.5/gl_gui_composite.vert
+ create mode 100644 xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+ create mode 100644 xbmc/rendering/gl/GuiCompositeShaderGL.h
+
+diff --git a/system/shaders/GL/1.5/gl_gui_composite.frag b/system/shaders/GL/1.5/gl_gui_composite.frag
+new file mode 100644
+index 0000000000..b1c0fea88c
+--- /dev/null
++++ b/system/shaders/GL/1.5/gl_gui_composite.frag
+@@ -0,0 +1,53 @@
++/*
++ *  Copyright (C) 2024 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#version 150
++
++in vec2 v_tex;
++out vec4 fragColor;
++uniform sampler2D u_samp;
++uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
++
++// ST2084 (PQ) constants
++const float ST2084_m1 = 0.1593017578125;   // 2610/16384
++const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
++const float ST2084_c1 = 0.8359375;          // 3424/4096
++const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
++const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
++
++// BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
++const mat3 bt709_to_bt2020 = mat3(
++  0.6274,  0.0691,  0.0164,
++  0.3293,  0.9195,  0.0880,
++  0.0433,  0.0114,  0.8956
++);
++
++vec3 forwardPQ(vec3 L)
++{
++  vec3 Lm1 = pow(L, vec3(ST2084_m1));
++  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
++}
++
++void main()
++{
++  vec4 gui = texture(u_samp, v_tex);
++
++  // sRGB -> linear (approximate)
++  vec3 linear = pow(gui.rgb, vec3(2.2));
++
++  // BT.709 -> BT.2020 gamut mapping
++  linear = bt709_to_bt2020 * linear;
++
++  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
++  linear *= u_sdrPeak;
++
++  // linear -> PQ
++  vec3 pq = forwardPQ(linear);
++
++  fragColor = vec4(pq, gui.a);
++}
+diff --git a/system/shaders/GL/1.5/gl_gui_composite.vert b/system/shaders/GL/1.5/gl_gui_composite.vert
+new file mode 100644
+index 0000000000..277ce7d677
+--- /dev/null
++++ b/system/shaders/GL/1.5/gl_gui_composite.vert
+@@ -0,0 +1,20 @@
++/*
++ *  Copyright (C) 2024 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#version 150
++
++in vec2 a_pos;
++in vec2 a_tex;
++out vec2 v_tex;
++uniform mat4 u_proj;
++
++void main()
++{
++  gl_Position = u_proj * vec4(a_pos, 0.0, 1.0);
++  v_tex = a_tex;
++}
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+index 08051af878..28b5004602 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+@@ -268,6 +268,12 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
+               m_passthroughHDR ? "on" : "off");
+   }
+ 
++  m_hdrFboActive = m_passthroughHDR &&
++                   CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
++  if (m_passthroughHDR && !m_hdrFboActive)
++    CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: HDR passthrough active but GUI "
++                          "compositing not supported by windowing system");
++
+   // load 3DLUT
+   if (m_ColorManager->IsEnabled())
+   {
+@@ -1075,6 +1081,8 @@ void CLinuxRendererGL::UnInit()
+ 
+   if (m_bConfigured)
+   {
++    m_hdrFboActive = false;
++    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+     m_passthroughHDR = false;
+     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+@@ -1086,6 +1094,11 @@ void CLinuxRendererGL::UnInit()
+   m_bConfigured = false;
+ }
+ 
++bool CLinuxRendererGL::IsGuiLayer()
++{
++  return !m_hdrFboActive;
++}
++
+ bool CLinuxRendererGL::Render(unsigned int flags, int renderBuffer)
+ {
+   // obtain current field, if interlaced
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+index 2a5c786b4b..59d7c2a2e2 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+@@ -82,6 +82,8 @@ public:
+   bool Supports(ESCALINGMETHOD method) const override;
+ 
+   CRenderCapture* GetRenderCapture() override;
++  bool IsGuiLayer() override;
++  bool HasVideoPlane() override { return false; }
+ 
+ protected:
+ 
+@@ -220,6 +222,7 @@ protected:
+   bool m_toneMap = false;
+   ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
+   bool m_passthroughHDR = false;
++  bool m_hdrFboActive{false};
+   float m_clearColour = 0.0f;
+   bool m_pboSupported = true;
+   bool m_pboUsed = false;
+diff --git a/xbmc/rendering/gl/CMakeLists.txt b/xbmc/rendering/gl/CMakeLists.txt
+index a6a5b90575..2b64864b61 100644
+--- a/xbmc/rendering/gl/CMakeLists.txt
++++ b/xbmc/rendering/gl/CMakeLists.txt
+@@ -1,11 +1,13 @@
+ if(TARGET ${APP_NAME_LC}::OpenGl)
+   set(SOURCES RenderSystemGL.cpp
+               ScreenshotSurfaceGL.cpp
+-              GLShader.cpp)
++              GLShader.cpp
++              GuiCompositeShaderGL.cpp)
+ 
+   set(HEADERS RenderSystemGL.h
+               ScreenshotSurfaceGL.h
+-              GLShader.h)
++              GLShader.h
++              GuiCompositeShaderGL.h)
+ 
+   core_add_library(rendering_gl)
+ endif()
+diff --git a/xbmc/rendering/gl/GuiCompositeShaderGL.cpp b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+new file mode 100644
+index 0000000000..08709f90e2
+--- /dev/null
++++ b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+@@ -0,0 +1,39 @@
++/*
++ *  Copyright (C) 2024 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#include "GuiCompositeShaderGL.h"
++
++#include "utils/log.h"
++
++CGuiCompositeShaderGL::CGuiCompositeShaderGL()
++{
++  VertexShader()->LoadSource("gl_gui_composite.vert");
++  PixelShader()->LoadSource("gl_gui_composite.frag");
++}
++
++void CGuiCompositeShaderGL::OnCompiledAndLinked()
++{
++  m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
++  m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
++  m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
++  m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
++  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
++
++  glUseProgram(ProgramHandle());
++  glUniform1i(m_hSamp, 0);
++  glUseProgram(0);
++}
++
++bool CGuiCompositeShaderGL::OnEnabled()
++{
++  if (m_proj)
++    glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
++
++  glUniform1f(m_hSdrPeak, m_sdrPeak);
++  return true;
++}
+diff --git a/xbmc/rendering/gl/GuiCompositeShaderGL.h b/xbmc/rendering/gl/GuiCompositeShaderGL.h
+new file mode 100644
+index 0000000000..4d7e3f80b0
+--- /dev/null
++++ b/xbmc/rendering/gl/GuiCompositeShaderGL.h
+@@ -0,0 +1,37 @@
++/*
++ *  Copyright (C) 2024 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#pragma once
++
++#include "guilib/Shader.h"
++
++class CGuiCompositeShaderGL : public Shaders::CGLSLShaderProgram
++{
++public:
++  CGuiCompositeShaderGL();
++
++  void SetProjection(const GLfloat* proj) { m_proj = proj; }
++  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
++
++  GLint GetPosLoc() { return m_hPos; }
++  GLint GetTexLoc() { return m_hTex; }
++
++protected:
++  void OnCompiledAndLinked() override;
++  bool OnEnabled() override;
++
++private:
++  const GLfloat* m_proj{nullptr};
++  float m_sdrPeak{100.0f / 10000.0f};
++
++  GLint m_hPos{-1};
++  GLint m_hTex{-1};
++  GLint m_hSamp{-1};
++  GLint m_hProj{-1};
++  GLint m_hSdrPeak{-1};
++};
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index f469655d44..eb6f6b8161 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -15,6 +15,7 @@
+ #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+ #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
+ #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
++#include "rendering/gl/GuiCompositeShaderGL.h"
+ #include "rendering/gl/ScreenshotSurfaceGL.h"
+ #include "utils/BufferObjectFactory.h"
+ #include "utils/DMAHeapBufferObject.h"
+@@ -204,3 +205,140 @@ bool CWinSystemGbmGLContext::CreateContext()
+ 
+   return true;
+ }
++
++bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
++{
++  // TODO: add CreateLUTs(colorTransfer) support to GL composite shader to match
++  // GLES (WinSystemGbmGLESContext). Currently GL only handles PQ via pow shader;
++  // HLG and LUT-based PQ are not yet implemented.
++  m_guiCompositing = (colorTransfer != 0);
++
++  if (m_guiCompositing)
++  {
++    if (!m_compositeShader)
++    {
++      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>();
++      if (!m_compositeShader->CompileAndLink())
++      {
++        CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to compile GUI composite shader");
++        m_compositeShader.reset();
++        m_guiCompositing = false;
++      }
++    }
++  }
++  else
++  {
++    m_guiFbo.Cleanup();
++    m_guiFboWidth = 0;
++    m_guiFboHeight = 0;
++    m_compositeShader.reset();
++  }
++
++  return m_guiCompositing;
++}
++
++bool CWinSystemGbmGLContext::BeginGuiComposite()
++{
++  if (!m_guiCompositing)
++    return false;
++
++  int width = m_nWidth;
++  int height = m_nHeight;
++
++  if (!m_guiFbo.IsValid() || m_guiFboWidth != width || m_guiFboHeight != height)
++  {
++    m_guiFbo.Cleanup();
++
++    if (!m_guiFbo.Initialize())
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to initialize GUI FBO");
++      return false;
++    }
++
++    if (!m_guiFbo.CreateAndBindToTexture(GL_TEXTURE_2D, width, height, GL_RGBA))
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to create GUI FBO texture {}x{}", width,
++                height);
++      m_guiFbo.Cleanup();
++      return false;
++    }
++
++    m_guiFboWidth = width;
++    m_guiFboHeight = height;
++    CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
++  }
++
++  if (!m_guiFbo.BeginRender())
++    return false;
++
++  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++
++  return true;
++}
++
++void CWinSystemGbmGLContext::EndGuiComposite()
++{
++  m_guiFbo.EndRender();
++
++  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++}
++
++// CompositeGui is the last GL operation in the frame (called just before EndRender).
++// GL state (blend mode, active texture, vertex arrays) is not restored afterward;
++// the next frame's rendering sets its own state.
++void CWinSystemGbmGLContext::CompositeGui()
++{
++  if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
++    return;
++
++  glActiveTexture(GL_TEXTURE0);
++  glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
++
++  glEnable(GL_BLEND);
++  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
++
++  // set up orthographic projection (screen coords, Y-down)
++  float w = static_cast<float>(m_guiFboWidth);
++  float h = static_cast<float>(m_guiFboHeight);
++
++  GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
++
++  m_compositeShader->SetProjection(proj);
++  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
++  m_compositeShader->Enable();
++
++  GLint posLoc = m_compositeShader->GetPosLoc();
++  GLint texLoc = m_compositeShader->GetTexLoc();
++
++  GLfloat vert[4][2] = {{0, 0}, {w, 0}, {w, h}, {0, h}};
++  GLfloat tex[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
++  GLubyte idx[4] = {0, 1, 3, 2};
++
++  GLuint vbo[3];
++  glGenBuffers(3, vbo);
++
++  glBindBuffer(GL_ARRAY_BUFFER, vbo[0]);
++  glBufferData(GL_ARRAY_BUFFER, sizeof(vert), vert, GL_STREAM_DRAW);
++  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
++  glEnableVertexAttribArray(posLoc);
++
++  glBindBuffer(GL_ARRAY_BUFFER, vbo[1]);
++  glBufferData(GL_ARRAY_BUFFER, sizeof(tex), tex, GL_STREAM_DRAW);
++  glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
++  glEnableVertexAttribArray(texLoc);
++
++  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo[2]);
++  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(idx), idx, GL_STREAM_DRAW);
++
++  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
++
++  glDisableVertexAttribArray(posLoc);
++  glDisableVertexAttribArray(texLoc);
++  glBindBuffer(GL_ARRAY_BUFFER, 0);
++  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
++  glDeleteBuffers(3, vbo);
++
++  m_compositeShader->Disable();
++}
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.h b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+index 25cc5daef8..58ee38388b 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+@@ -9,11 +9,13 @@
+ #pragma once
+ 
+ #include "WinSystemGbmEGLContext.h"
++#include "cores/VideoPlayer/VideoRenderers/FrameBufferObject.h"
+ #include "rendering/gl/RenderSystemGL.h"
+ #include "utils/EGLUtils.h"
+ 
+ #include <memory>
+ 
++class CGuiCompositeShaderGL;
+ class CVaapiProxy;
+ 
+ namespace KODI
+@@ -39,10 +41,23 @@ public:
+   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+   void PresentRender(bool rendered, bool videoLayer) override;
+ 
++  // GUI compositing for HDR (FBO + sRGB->PQ shader)
++  bool SetGuiCompositing(int colorTransfer) override;
++  bool BeginGuiComposite() override;
++  void EndGuiComposite() override;
++  void CompositeGui() override;
++
+ protected:
+   void SetVSyncImpl(bool enable) override {}
+   void PresentRenderImpl(bool rendered) override {};
+   bool CreateContext() override;
++
++private:
++  bool m_guiCompositing{false};
++  CFrameBufferObject m_guiFbo;
++  int m_guiFboWidth{0};
++  int m_guiFboHeight{0};
++  std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
+ };
+ 
+ } // namespace GBM
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0017-GL-discard-alpha-zero-and-encode-limited-range-PQ-in.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0017-GL-discard-alpha-zero-and-encode-limited-range-PQ-in.patch
@@ -1,0 +1,148 @@
+From a0072a6b476affb90431bd00de5f2aa1a994303a Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Wed, 29 Apr 2026 23:22:45 -0400
+Subject: [PATCH 17/25] GL: discard alpha-zero and encode limited-range PQ in
+ composite shader
+
+Bring the GL FBO compositing path closer to feature parity with GLES,
+covering two improvements:
+
+1. discard for alpha=0 -- skips the tone-mapping math, BO read and BO
+   write for fully-transparent pixels. Mirrors the GLES side's discard
+   block.
+
+2. KODI_LIMITED_RANGE encoding at the BO write boundary -- same fix as
+   on the GLES side. When HDR FBO compositing is active and
+   limitedrange=true, GUI shaders skip the limited-range compression
+   (gated via RenderSystemGL's !IsHdrComposite() check) so they write
+   un-squashed sRGB into the FBO. The composite shader then applies the
+   limited-range encoding at the end (after the PQ encode) using the
+   canonical 16-235 / 219 ratios. Without the gate on the GUI shader
+   side, this would be double-compression.
+
+CGuiCompositeShaderGL constructor now takes a const std::string& prefix
+argument, matching CGLESShader's pattern, so KODI_LIMITED_RANGE can be
+defined per build. The GL caller (CWinSystemGbmGLContext) builds the
+defines string and passes it.
+
+Not yet at parity (deliberate, follow-ups):
+- Proper sRGB EOTF (still uses pow(2.2) approximation)
+- HLG support
+- LUT-based degamma/PQ optimization
+---
+ system/shaders/GL/1.5/gl_gui_composite.frag  | 13 +++++++++++++
+ xbmc/rendering/gl/GuiCompositeShaderGL.cpp   |  6 +++---
+ xbmc/rendering/gl/GuiCompositeShaderGL.h     |  4 +++-
+ xbmc/rendering/gl/RenderSystemGL.cpp         |  6 ++++--
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp |  5 ++++-
+ 5 files changed, 27 insertions(+), 7 deletions(-)
+
+diff --git a/system/shaders/GL/1.5/gl_gui_composite.frag b/system/shaders/GL/1.5/gl_gui_composite.frag
+index b1c0fea88c..8379d7dfee 100644
+--- a/system/shaders/GL/1.5/gl_gui_composite.frag
++++ b/system/shaders/GL/1.5/gl_gui_composite.frag
+@@ -37,6 +37,12 @@ void main()
+ {
+   vec4 gui = texture(u_samp, v_tex);
+ 
++  // Skip pixels the GUI never wrote to. Blend unit would still preserve video
++  // bit-exactly via DST*(1-0)+garbage*0=DST, but discard makes it structural
++  // and avoids the tone-map math, BO read and BO write for those pixels.
++  if (gui.a == 0.0)
++    discard;
++
+   // sRGB -> linear (approximate)
+   vec3 linear = pow(gui.rgb, vec3(2.2));
+ 
+@@ -49,5 +55,12 @@ void main()
+   // linear -> PQ
+   vec3 pq = forwardPQ(linear);
+ 
++  // Limited-range encoding at the BO write boundary. Canonical normalized
++  // ratios (bit-depth-agnostic in float space; BO write quantizes to the
++  // active surface bit depth).
++#ifdef KODI_LIMITED_RANGE
++  pq = pq * ((235.0 - 16.0) / 255.0) + (16.0 / 255.0);
++#endif
++
+   fragColor = vec4(pq, gui.a);
+ }
+diff --git a/xbmc/rendering/gl/GuiCompositeShaderGL.cpp b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+index 08709f90e2..f4641d1f9d 100644
+--- a/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
++++ b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+@@ -10,10 +10,10 @@
+ 
+ #include "utils/log.h"
+ 
+-CGuiCompositeShaderGL::CGuiCompositeShaderGL()
++CGuiCompositeShaderGL::CGuiCompositeShaderGL(const std::string& prefix)
+ {
+-  VertexShader()->LoadSource("gl_gui_composite.vert");
+-  PixelShader()->LoadSource("gl_gui_composite.frag");
++  VertexShader()->LoadSource("gl_gui_composite.vert", prefix);
++  PixelShader()->LoadSource("gl_gui_composite.frag", prefix);
+ }
+ 
+ void CGuiCompositeShaderGL::OnCompiledAndLinked()
+diff --git a/xbmc/rendering/gl/GuiCompositeShaderGL.h b/xbmc/rendering/gl/GuiCompositeShaderGL.h
+index 4d7e3f80b0..d19515468b 100644
+--- a/xbmc/rendering/gl/GuiCompositeShaderGL.h
++++ b/xbmc/rendering/gl/GuiCompositeShaderGL.h
+@@ -10,10 +10,12 @@
+ 
+ #include "guilib/Shader.h"
+ 
++#include <string>
++
+ class CGuiCompositeShaderGL : public Shaders::CGLSLShaderProgram
+ {
+ public:
+-  CGuiCompositeShaderGL();
++  explicit CGuiCompositeShaderGL(const std::string& prefix);
+ 
+   void SetProjection(const GLfloat* proj) { m_proj = proj; }
+   void SetSdrPeak(float peak) { m_sdrPeak = peak; }
+diff --git a/xbmc/rendering/gl/RenderSystemGL.cpp b/xbmc/rendering/gl/RenderSystemGL.cpp
+index 161e52d889..b2a138c096 100644
+--- a/xbmc/rendering/gl/RenderSystemGL.cpp
++++ b/xbmc/rendering/gl/RenderSystemGL.cpp
+@@ -262,7 +262,8 @@ bool CRenderSystemGL::BeginRender()
+   if (!m_bRenderCreated)
+     return false;
+ 
+-  bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
++  bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
++                    !CServiceBroker::GetWinSystem()->IsHdrComposite();
+ 
+   if (m_limitedColorRange != useLimited)
+   {
+@@ -710,7 +711,8 @@ bool CRenderSystemGL::SupportsStereo(RenderStereoMode mode) const
+ void CRenderSystemGL::InitialiseShaders()
+ {
+   std::string defines;
+-  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor();
++  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
++                        !CServiceBroker::GetWinSystem()->IsHdrComposite();
+   if (m_limitedColorRange)
+   {
+     defines += "#define KODI_LIMITED_RANGE 1\n";
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index eb6f6b8161..df740d1597 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -217,7 +217,10 @@ bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
+   {
+     if (!m_compositeShader)
+     {
+-      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>();
++      std::string defines;
++      if (UseLimitedColor())
++        defines += "#define KODI_LIMITED_RANGE 1\n";
++      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>(defines);
+       if (!m_compositeShader->CompileAndLink())
+       {
+         CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to compile GUI composite shader");
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0018-WinSystemGbm-move-HDR-transfer-function-check-into-S.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0018-WinSystemGbm-move-HDR-transfer-function-check-into-S.patch
@@ -1,0 +1,125 @@
+From de471f457835cade91ce01abdd49f5ea9b290d82 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 7 Apr 2026 11:23:14 -0400
+Subject: [PATCH 18/25] WinSystemGbm: move HDR transfer function check into
+ SetHDR
+
+Move the color_transfer check (PQ/HLG) from individual renderer
+callers into SetHDR itself. Previously, some renderers checked
+color_transfer before calling SetHDR while others (VideoLayerBridge
+DRMPRIME) called it unconditionally. This was inconsistent and
+required every new renderer to duplicate the check.
+
+Now SetHDR returns false early for non-HDR content, so all callers
+can simply use the return value directly.
+---
+ .../HwDecRender/RendererDRMPRIMEGLES.cpp               | 10 +++-------
+ .../HwDecRender/VideoLayerBridgeDRMPRIME.cpp           | 10 ++--------
+ .../VideoPlayer/VideoRenderers/LinuxRendererGL.cpp     | 10 +++-------
+ .../VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp   | 10 +++-------
+ xbmc/windowing/gbm/WinSystemGbm.cpp                    |  5 +++++
+ 5 files changed, 16 insertions(+), 29 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+index f30fef57b5..67d9fbce8d 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+@@ -144,13 +144,9 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
+   //! shader, the way RendererVAAPIGLES does. Tracked in
+   //! project_limited_range_hdr.md.
+ 
+-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+-  {
+-    m_passthroughHDR = winSystem->SetHDR(&picture);
+-    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+-              m_passthroughHDR ? "on" : "off");
+-  }
++  m_passthroughHDR = winSystem->SetHDR(&picture);
++  CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
++            m_passthroughHDR ? "on" : "off");
+ 
+   m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
+   if (m_passthroughHDR && !m_hdrFboActive)
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+index 22da4923c5..cf90e9e999 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+@@ -170,14 +170,8 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
+ 
+   const VideoPicture& picture = buffer->GetPicture();
+ 
+-  // Gate HDR passthrough on transfer function, matching the pattern in
+-  // LinuxRendererGLES and RendererDRMPRIMEGLES (see smp79's 850dfb04d4).
+-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+-  {
+-    if (winSystem->SetHDR(&picture))
+-      winSystem->SetGuiCompositing(picture.color_transfer);
+-  }
++  if (winSystem->SetHDR(&picture))
++    winSystem->SetGuiCompositing(picture.color_transfer);
+ 
+   std::optional<uint64_t> colorEncoding =
+       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+index 28b5004602..1f5d0e73de 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+@@ -260,13 +260,9 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
+   // setup the background colour
+   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
+-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+-  {
+-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+-    CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
+-              m_passthroughHDR ? "on" : "off");
+-  }
++  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
++  CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
++            m_passthroughHDR ? "on" : "off");
+ 
+   m_hdrFboActive = m_passthroughHDR &&
+                    CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index aed09d2124..c102c0072d 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -154,13 +154,9 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
+   // setup the background colour
+   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
+-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+-  {
+-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+-    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
+-              m_passthroughHDR ? "on" : "off");
+-  }
++  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
++  CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
++            m_passthroughHDR ? "on" : "off");
+ 
+   m_hdrFboActive =
+       m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 2325d3d224..8fce84eb05 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -421,6 +421,11 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+     return false;
+   }
+ 
++  // Only enable HDR for PQ (HDR10/HDR10+/DV) or HLG transfer functions
++  if (videoPicture->color_transfer != AVCOL_TRC_SMPTE2084 &&
++      videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
++    return false;
++
+   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
+ 
+   if (connector->SupportsProperty("Colorspace") && m_info &&
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0019-WinSystemGbm-cache-EOTF-and-colorimetry-in-SetHDR.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0019-WinSystemGbm-cache-EOTF-and-colorimetry-in-SetHDR.patch
@@ -1,0 +1,78 @@
+From ae2d5bc52e4abcf7366180761c54170f463509e9 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 30 Mar 2026 19:52:52 -0400
+Subject: [PATCH 19/25] WinSystemGbm: cache EOTF and colorimetry in SetHDR
+
+Store the current EOTF and colorimetry when SetHDR is called so other
+components (e.g. screenshot capture) can query the active HDR state
+without reading back DRM connector properties.
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp | 7 +++++--
+ xbmc/windowing/gbm/WinSystemGbm.h   | 5 +++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 8fce84eb05..99ca3ca33e 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -418,6 +418,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+       m_hdr_blob_id = 0;
+     }
+ 
++    m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
++    m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+     return false;
+   }
+ 
+@@ -427,6 +429,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+     return false;
+ 
+   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
++  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
++  m_colorimetry = colorimetry;
++  m_eotf = eotf;
+ 
+   if (connector->SupportsProperty("Colorspace") && m_info &&
+       m_info->SupportsColorimetry(colorimetry))
+@@ -441,8 +446,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+     }
+   }
+ 
+-  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
+-
+   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
+       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))
+   {
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 6d4ca18422..9e568e21ca 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -10,6 +10,7 @@
+ 
+ #include "VideoLayerBridge.h"
+ #include "drm/DRMUtils.h"
++#include "utils/DisplayInfo.h"
+ #include "threads/CriticalSection.h"
+ #include "threads/SystemClock.h"
+ #include "windowing/WinSystem.h"
+@@ -61,6 +62,8 @@ public:
+ 
+   bool SetVideoOutput(const VideoPicture* videoPicture) override;
+ 
++  KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
++  KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
+   bool SetHDR(const VideoPicture* videoPicture) override;
+   bool IsHDRDisplay() override;
+   CHDRCapabilities GetDisplayHDRCapabilities() const override;
+@@ -94,6 +97,8 @@ protected:
+ 
+ private:
+   uint32_t m_hdr_blob_id = 0;
++  KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
++  KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+ 
+   std::unique_ptr<UTILS::CDisplayInfo> m_info;
+ };
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0020-GBM-use-CDRMPropertyBlob-for-HDR_OUTPUT_METADATA.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0020-GBM-use-CDRMPropertyBlob-for-HDR_OUTPUT_METADATA.patch
@@ -1,0 +1,100 @@
+From dcbdd6a0b32cb4e01ee990b304ba77d3e6e34ec4 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 20 Apr 2026 11:30:59 -0400
+Subject: [PATCH 20/25] GBM: use CDRMPropertyBlob for HDR_OUTPUT_METADATA
+
+CDRMPropertyBlob (introduced in the previous commit) is now used for
+the HDR_OUTPUT_METADATA blob member in CWinSystemGbm. Replaces the
+hand-rolled drmModeCreate/DestroyPropertyBlob dance around
+m_hdr_blob_id.
+
+The member becomes CDRMPropertyBlob m_hdrBlob, which:
+
+ - Collapses the "destroy old, create new" pattern into a single
+   move-assignment in SetHDR.
+ - Automatically destroys the blob on winsystem shutdown, fixing a
+   previously-existing blob leak (the hand-rolled member was never
+   destroyed in CWinSystemGbm's destructor).
+ - Removes two copies of the error-check / conditional-destroy
+   boilerplate.
+
+No behavioral change beyond the leak fix on shutdown. Same lifetime
+semantics as before: the blob lives from SetHDR call to SetHDR call
+(or to winsystem destruction), and any atomic commit that references
+it completes synchronously while the blob is still alive.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ xbmc/windowing/gbm/WinSystemGbm.cpp | 15 +++++----------
+ xbmc/windowing/gbm/WinSystemGbm.h   |  3 ++-
+ 2 files changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index 99ca3ca33e..f337094a9f 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -413,9 +413,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
+       drm->SetActive(true);
+ 
+-      if (m_hdr_blob_id)
+-        drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
+-      m_hdr_blob_id = 0;
++      m_hdrBlob.Reset();
+     }
+ 
+     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+@@ -455,9 +453,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+     hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
+     hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
+ 
+-    if (m_hdr_blob_id)
+-      drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
+-    m_hdr_blob_id = 0;
++    m_hdrBlob.Reset();
+ 
+     if (hdr_metadata.hdmi_metadata_type1.eotf)
+     {
+@@ -518,15 +514,14 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+                   hdr_metadata.hdmi_metadata_type1.max_fall);
+       }
+ 
+-      drmModeCreatePropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata),
+-                                &m_hdr_blob_id);
++      m_hdrBlob = CDRMPropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata));
+     }
+ 
+-    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
++    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdrBlob.Get());
+     drm->SetActive(true);
+   }
+ 
+-  return m_hdr_blob_id != 0;
++  return m_hdrBlob.IsValid();
+ }
+ 
+ bool CWinSystemGbm::IsHDRDisplay()
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 9e568e21ca..2a35680817 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -9,6 +9,7 @@
+ #pragma once
+ 
+ #include "VideoLayerBridge.h"
++#include "drm/DRMObject.h"
+ #include "drm/DRMUtils.h"
+ #include "utils/DisplayInfo.h"
+ #include "threads/CriticalSection.h"
+@@ -96,7 +97,7 @@ protected:
+   std::unique_ptr<CLibInputHandler> m_libinput;
+ 
+ private:
+-  uint32_t m_hdr_blob_id = 0;
++  CDRMPropertyBlob m_hdrBlob;
+   KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+   KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+ 
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0021-HDRUtils-factor-video-metadata-helpers-out-of-DRMPRI.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0021-HDRUtils-factor-video-metadata-helpers-out-of-DRMPRI.patch
@@ -1,0 +1,312 @@
+From 8679229cb117cbb950c935db1d7f1f3615a2f003 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 10 Mar 2026 11:44:30 -0400
+Subject: [PATCH 21/25] HDRUtils: factor video metadata helpers out of DRMPRIME
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Move GetColorimetry, GetEOTF, GetMasteringDisplayMetadata, and
+GetContentLightMetadata from the DRMPRIME namespace into
+KODI::UTILS::HDRUtils so they can be used by the single-plane
+EGL rendering pipeline without depending on VideoBufferDRMPRIME.
+
+Pure refactor — no behavior change.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../Buffers/VideoBufferDRMPRIME.cpp           | 37 -----------
+ .../VideoPlayer/Buffers/VideoBufferDRMPRIME.h | 19 ------
+ xbmc/utils/CMakeLists.txt                     |  2 +
+ xbmc/utils/HDRUtils.cpp                       | 64 +++++++++++++++++++
+ xbmc/utils/HDRUtils.h                         | 37 +++++++++++
+ xbmc/windowing/gbm/WinSystemGbm.cpp           | 14 ++--
+ 6 files changed, 110 insertions(+), 63 deletions(-)
+ create mode 100644 xbmc/utils/HDRUtils.cpp
+ create mode 100644 xbmc/utils/HDRUtils.h
+
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+index 9737f1969d..f47801cd22 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+@@ -20,19 +20,6 @@ extern "C"
+ namespace DRMPRIME
+ {
+ 
+-KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture)
+-{
+-  switch (picture.color_space)
+-  {
+-    case AVCOL_SPC_BT2020_CL:
+-      return KODI::UTILS::Colorimetry::BT2020_CYCC;
+-    case AVCOL_SPC_BT2020_NCL:
+-      return KODI::UTILS::Colorimetry::BT2020_YCC;
+-    default:
+-      return KODI::UTILS::Colorimetry::DEFAULT;
+-  }
+-}
+-
+ std::string GetColorEncoding(const VideoPicture& picture)
+ {
+   switch (picture.color_space)
+@@ -63,30 +50,6 @@ std::string GetColorRange(const VideoPicture& picture)
+   return "YCbCr limited range";
+ }
+ 
+-KODI::UTILS::Eotf GetEOTF(const VideoPicture& picture)
+-{
+-  switch (picture.color_transfer)
+-  {
+-    case AVCOL_TRC_SMPTE2084:
+-      return KODI::UTILS::Eotf::PQ;
+-    case AVCOL_TRC_ARIB_STD_B67:
+-    case AVCOL_TRC_BT2020_10:
+-      return KODI::UTILS::Eotf::HLG;
+-    default:
+-      return KODI::UTILS::Eotf::TRADITIONAL_SDR;
+-  }
+-}
+-
+-const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture)
+-{
+-  return picture.hasDisplayMetadata ? &picture.displayMetadata : nullptr;
+-}
+-
+-const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture)
+-{
+-  return picture.hasLightMetadata ? &picture.lightMetadata : nullptr;
+-}
+-
+ } // namespace DRMPRIME
+ 
+ CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
+diff --git a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+index b83ee8ca68..dc7c0e6984 100644
+--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
++++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+@@ -10,37 +10,18 @@
+ 
+ #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+ #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+-#include "utils/DisplayInfo.h"
+ 
+ extern "C"
+ {
+ #include <libavutil/frame.h>
+ #include <libavutil/hwcontext_drm.h>
+-#include <libavutil/mastering_display_metadata.h>
+ }
+ 
+ namespace DRMPRIME
+ {
+ 
+-// HDR enums is copied from linux include/linux/hdmi.h (strangely not part of uapi)
+-enum hdmi_metadata_type
+-{
+-  HDMI_STATIC_METADATA_TYPE1 = 0,
+-};
+-enum hdmi_eotf
+-{
+-  HDMI_EOTF_TRADITIONAL_GAMMA_SDR,
+-  HDMI_EOTF_TRADITIONAL_GAMMA_HDR,
+-  HDMI_EOTF_SMPTE_ST2084,
+-  HDMI_EOTF_BT_2100_HLG,
+-};
+-
+-KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture);
+ std::string GetColorEncoding(const VideoPicture& picture);
+ std::string GetColorRange(const VideoPicture& picture);
+-KODI::UTILS::Eotf GetEOTF(const VideoPicture& picture);
+-const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
+-const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
+ 
+ } // namespace DRMPRIME
+ 
+diff --git a/xbmc/utils/CMakeLists.txt b/xbmc/utils/CMakeLists.txt
+index 6b6bfee4e4..dcdd23b5d8 100644
+--- a/xbmc/utils/CMakeLists.txt
++++ b/xbmc/utils/CMakeLists.txt
+@@ -30,6 +30,7 @@ set(SOURCES ActorProtocol.cpp
+             FontUtils.cpp
+             GpuInfo.cpp
+             GroupUtils.cpp
++            HDRUtils.cpp
+             HevcSei.cpp
+             HTMLUtil.cpp
+             HttpHeader.cpp
+@@ -118,6 +119,7 @@ set(HEADERS ActorProtocol.h
+             GpuInfo.h
+             GroupUtils.h
+             HDRCapabilities.h
++            HDRUtils.h
+             HevcSei.h
+             HTMLUtil.h
+             HttpHeader.h
+diff --git a/xbmc/utils/HDRUtils.cpp b/xbmc/utils/HDRUtils.cpp
+new file mode 100644
+index 0000000000..b8ad1167eb
+--- /dev/null
++++ b/xbmc/utils/HDRUtils.cpp
+@@ -0,0 +1,64 @@
++/*
++ *  Copyright (C) 2017-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#include "HDRUtils.h"
++
++extern "C"
++{
++#include <libavcodec/avcodec.h>
++}
++
++namespace KODI
++{
++namespace UTILS
++{
++
++Colorimetry GetColorimetry(const VideoPicture& picture)
++{
++  switch (picture.color_space)
++  {
++    case AVCOL_SPC_BT2020_CL:
++      return Colorimetry::BT2020_CYCC;
++    case AVCOL_SPC_BT2020_NCL:
++      return Colorimetry::BT2020_YCC;
++    case AVCOL_SPC_BT709:
++      return Colorimetry::BT709_YCC;
++    case AVCOL_SPC_SMPTE170M:
++    case AVCOL_SPC_BT470BG:
++      return Colorimetry::SMPTE_170M_YCC;
++    default:
++      return Colorimetry::DEFAULT;
++  }
++}
++
++Eotf GetEOTF(const VideoPicture& picture)
++{
++  switch (picture.color_transfer)
++  {
++    case AVCOL_TRC_SMPTE2084:
++      return Eotf::PQ;
++    case AVCOL_TRC_ARIB_STD_B67:
++    case AVCOL_TRC_BT2020_10:
++      return Eotf::HLG;
++    default:
++      return Eotf::TRADITIONAL_SDR;
++  }
++}
++
++const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture)
++{
++  return picture.hasDisplayMetadata ? &picture.displayMetadata : nullptr;
++}
++
++const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture)
++{
++  return picture.hasLightMetadata ? &picture.lightMetadata : nullptr;
++}
++
++} // namespace UTILS
++} // namespace KODI
+diff --git a/xbmc/utils/HDRUtils.h b/xbmc/utils/HDRUtils.h
+new file mode 100644
+index 0000000000..2a72d0596c
+--- /dev/null
++++ b/xbmc/utils/HDRUtils.h
+@@ -0,0 +1,37 @@
++/*
++ *  Copyright (C) 2017-2018 Team Kodi
++ *  This file is part of Kodi - https://kodi.tv
++ *
++ *  SPDX-License-Identifier: GPL-2.0-or-later
++ *  See LICENSES/README.md for more information.
++ */
++
++#pragma once
++
++#include "utils/DisplayInfo.h"
++
++#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
++
++extern "C"
++{
++#include <libavutil/mastering_display_metadata.h>
++}
++
++namespace KODI
++{
++namespace UTILS
++{
++
++// HDR enums copied from linux include/linux/hdmi.h (not part of uapi)
++enum hdmi_metadata_type
++{
++  HDMI_STATIC_METADATA_TYPE1 = 0,
++};
++
++Colorimetry GetColorimetry(const VideoPicture& picture);
++Eotf GetEOTF(const VideoPicture& picture);
++const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
++const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
++
++} // namespace UTILS
++} // namespace KODI
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index f337094a9f..d2943f4851 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -12,7 +12,7 @@
+ #include "OptionalsReg.h"
+ #include "ServiceBroker.h"
+ #include "VideoSyncGbm.h"
+-#include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
++#include "utils/HDRUtils.h"
+ #include "cores/VideoPlayer/VideoReferenceClock.h"
+ #include "drm/DRMAtomic.h"
+ #include "drm/DRMLegacy.h"
+@@ -426,8 +426,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+       videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
+     return false;
+ 
+-  KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
+-  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
++  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
++  KODI::UTILS::Eotf eotf = KODI::UTILS::GetEOTF(*videoPicture);
+   m_colorimetry = colorimetry;
+   m_eotf = eotf;
+ 
+@@ -449,15 +449,15 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+   {
+     hdr_output_metadata hdr_metadata = {};
+ 
+-    hdr_metadata.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
++    hdr_metadata.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
+     hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
+-    hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
++    hdr_metadata.hdmi_metadata_type1.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
+ 
+     m_hdrBlob.Reset();
+ 
+     if (hdr_metadata.hdmi_metadata_type1.eotf)
+     {
+-      const AVMasteringDisplayMetadata* mdmd = DRMPRIME::GetMasteringDisplayMetadata(*videoPicture);
++      const AVMasteringDisplayMetadata* mdmd = KODI::UTILS::GetMasteringDisplayMetadata(*videoPicture);
+       if (mdmd && mdmd->has_primaries)
+       {
+         // Convert to unsigned 16-bit values in units of 0.00002,
+@@ -502,7 +502,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+                   __FUNCTION__, hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance);
+       }
+ 
+-      const AVContentLightMetadata* clmd = DRMPRIME::GetContentLightMetadata(*videoPicture);
++      const AVContentLightMetadata* clmd = KODI::UTILS::GetContentLightMetadata(*videoPicture);
+       if (clmd)
+       {
+         hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0022-GBM-add-SetColorimetry-with-BT709-SMPTE170M-BT2020-s.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0022-GBM-add-SetColorimetry-with-BT709-SMPTE170M-BT2020-s.patch
@@ -1,0 +1,296 @@
+From 2f7e65a5d37764ca6b42a6d586dbecb583e7cf70 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Tue, 10 Mar 2026 11:44:49 -0400
+Subject: [PATCH 22/25] GBM: add SetColorimetry with BT709/SMPTE170M/BT2020
+ signaling
+
+Add SetColorimetry() virtual to CWinSystemBase with GBM implementation
+that sends explicit colorimetry (BT709_YCC, SMPTE_170M_YCC, BT2020_YCC,
+etc.) via the DRM connector Colorspace property for all content.
+
+- Add all DRM_MODE_COLORIMETRY_* enum values to DisplayInfo.h
+- Infer colorimetry from resolution when color_space is unspecified
+- Remove colorimetry handling from SetHDR() (now in SetColorimetry)
+- Call SetColorimetry() from LinuxRendererGLES on configure/uninit
+- Reset both Colorspace and HDR_OUTPUT_METADATA on init
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../VideoRenderers/LinuxRendererGLES.cpp      |   3 +
+ xbmc/utils/DisplayInfo.cpp                    |   3 +
+ xbmc/utils/DisplayInfo.h                      |  11 +-
+ xbmc/windowing/WinSystem.h                    |   7 ++
+ xbmc/windowing/gbm/WinSystemGbm.cpp           | 104 ++++++++++++------
+ xbmc/windowing/gbm/WinSystemGbm.h             |   1 +
+ 6 files changed, 93 insertions(+), 36 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index c102c0072d..d0268af112 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -154,6 +154,8 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
+   // setup the background colour
+   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
++  CServiceBroker::GetWinSystem()->SetColorimetry(&picture);
++
+   m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+   CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
+             m_passthroughHDR ? "on" : "off");
+@@ -940,6 +942,7 @@ void CLinuxRendererGLES::UnInit()
+     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+     m_passthroughHDR = false;
++    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
+     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+   }
+ 
+diff --git a/xbmc/utils/DisplayInfo.cpp b/xbmc/utils/DisplayInfo.cpp
+index 8641984d65..2627a4921b 100644
+--- a/xbmc/utils/DisplayInfo.cpp
++++ b/xbmc/utils/DisplayInfo.cpp
+@@ -202,6 +202,9 @@ bool CDisplayInfo::SupportsColorimetry(Colorimetry colorimetry) const
+ 
+   switch (colorimetry)
+   {
++    case Colorimetry::SMPTE_170M_YCC:
++    case Colorimetry::BT709_YCC:
++      return true; // baseline HDMI, all sinks support these
+     case Colorimetry::XVYCC_601:
+       return m_colorimetry->xvycc_601;
+     case Colorimetry::XVYCC_709:
+diff --git a/xbmc/utils/DisplayInfo.h b/xbmc/utils/DisplayInfo.h
+index 333c313460..5cf7ef51e9 100644
+--- a/xbmc/utils/DisplayInfo.h
++++ b/xbmc/utils/DisplayInfo.h
+@@ -32,15 +32,24 @@ enum class Eotf
+ 
+ enum class Colorimetry
+ {
++  // DRM order (DRM_MODE_COLORIMETRY_*)
+   DEFAULT,
++  SMPTE_170M_YCC,
++  BT709_YCC,
+   XVYCC_601,
+   XVYCC_709,
+   SYCC_601,
+   OPYCC_601,
+   OPRGB,
+   BT2020_CYCC,
+-  BT2020_YCC,
+   BT2020_RGB,
++  BT2020_YCC,
++  DCI_P3_RGB_D65,
++  DCI_P3_RGB_THEATER,
++  RGB_WIDE_FIXED,
++  RGB_WIDE_FLOAT,
++  BT601_YCC,
++  // CTA-861 only (not in DRM)
+   ST2113_RGB,
+   ICTCP,
+ };
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+index d3b7c33a80..3abc92a7e5 100644
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -226,6 +226,13 @@ public:
+    */
+   virtual bool SetVideoOutput(const VideoPicture* videoPicture) { return false; }
+ 
++  /*!
++   * \brief Set colorimetry (BT.709, BT.2020, etc). Passing nullptr as the
++   * parameter resets to "Default" (display then decides based on rez)
++   *
++   */
++  virtual void SetColorimetry(const VideoPicture* videoPicture) {}
++
+   /*!
+    * \brief Set the HDR metadata. Passing nullptr as the parameter should
+    * disable HDR.
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.cpp b/xbmc/windowing/gbm/WinSystemGbm.cpp
+index d2943f4851..0b68573707 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
+@@ -73,14 +73,21 @@ namespace
+ 
+ constexpr auto ColorimetryMap = make_map<KODI::UTILS::Colorimetry, std::string_view>({
+     {KODI::UTILS::Colorimetry::DEFAULT, "Default"},
++    {KODI::UTILS::Colorimetry::SMPTE_170M_YCC, "SMPTE_170M_YCC"},
++    {KODI::UTILS::Colorimetry::BT709_YCC, "BT709_YCC"},
+     {KODI::UTILS::Colorimetry::XVYCC_601, "XVYCC_601"},
+     {KODI::UTILS::Colorimetry::XVYCC_709, "XVYCC_709"},
+     {KODI::UTILS::Colorimetry::SYCC_601, "SYCC_601"},
+     {KODI::UTILS::Colorimetry::OPYCC_601, "opYCC_601"},
+     {KODI::UTILS::Colorimetry::OPRGB, "opRGB"},
+     {KODI::UTILS::Colorimetry::BT2020_CYCC, "BT2020_CYCC"},
+-    {KODI::UTILS::Colorimetry::BT2020_YCC, "BT2020_YCC"},
+     {KODI::UTILS::Colorimetry::BT2020_RGB, "BT2020_RGB"},
++    {KODI::UTILS::Colorimetry::BT2020_YCC, "BT2020_YCC"},
++    {KODI::UTILS::Colorimetry::DCI_P3_RGB_D65, "DCI-P3_RGB_D65"},
++    {KODI::UTILS::Colorimetry::DCI_P3_RGB_THEATER, "DCI-P3_RGB_Theater"},
++    {KODI::UTILS::Colorimetry::RGB_WIDE_FIXED, "RGB_WIDE_FIXED"},
++    {KODI::UTILS::Colorimetry::RGB_WIDE_FLOAT, "RGB_WIDE_FLOAT"},
++    {KODI::UTILS::Colorimetry::BT601_YCC, "BT601_YCC"},
+     {KODI::UTILS::Colorimetry::ST2113_RGB, "Default"},
+     {KODI::UTILS::Colorimetry::ICTCP, "Default"},
+ });
+@@ -158,6 +165,9 @@ bool CWinSystemGbm::InitWindowSystem()
+     return false;
+   }
+ 
++  SetColorimetry(nullptr);
++  SetHDR(nullptr);
++
+   auto settingsComponent = CServiceBroker::GetSettingsComponent();
+   if (!settingsComponent)
+     return false;
+@@ -166,16 +176,10 @@ bool CWinSystemGbm::InitWindowSystem()
+   if (!settings)
+     return false;
+ 
+-  auto setting = settings->GetSetting(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+-  if (setting)
+-    setting->SetVisible(true);
+-
+-  setting = settings->GetSetting("videoscreen.limitguisize");
++  auto setting = settings->GetSetting("videoscreen.limitguisize");
+   if (setting)
+     setting->SetVisible(true);
+ 
+-  SetHDR(nullptr);
+-
+   CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - initialized DRM", __FUNCTION__);
+   return CWinSystemBase::InitWindowSystem();
+ }
+@@ -374,6 +378,62 @@ bool CWinSystemGbm::SetVideoOutput(const VideoPicture* videoPicture)
+                       : m_DRM->FindGuiPlane(current->GetFormat(), current->GetModifier());
+ }
+ 
++void CWinSystemGbm::SetColorimetry(const VideoPicture* videoPicture)
++{
++  auto drm = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
++  if (!drm)
++    return;
++
++  auto connector = drm->GetConnector();
++  if (!connector || !connector->SupportsProperty("Colorspace"))
++    return;
++
++  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
++
++  if (videoPicture)
++    colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
++
++  m_colorimetry = colorimetry;
++
++  // The DRM Colorspace connector property controls what colorimetry tag the
++  // driver transmits in the HDMI AVI InfoFrame (or DisplayPort VSC SDP). The
++  // transmitted tag must match the pixel encoding actually on the wire.
++  // Kodi scans out to an RGB primary plane (XR24/XR30/AB4H), so we must pick
++  // an RGB-variant Colorspace. Signaling YCC while sending RGB causes most
++  // DP-to-HDMI bridges (incl. LSPCON) to misinterpret the signal.
++  //
++  // The CTA-861 standard (used by both HDMI and DisplayPort for colorimetry
++  // signaling) defines explicit RGB variants only for wide-gamut spaces
++  // (BT.2020_RGB, DCI-P3_RGB). BT.709 RGB and BT.601 RGB are signaled via
++  // "Default", with the sink inferring primaries from the transmitted mode
++  // (HD resolution -> BT.709, SD resolution -> BT.601).
++  KODI::UTILS::Colorimetry scanoutColorimetry;
++  switch (colorimetry)
++  {
++    case KODI::UTILS::Colorimetry::BT2020_YCC:
++    case KODI::UTILS::Colorimetry::BT2020_CYCC:
++      scanoutColorimetry = KODI::UTILS::Colorimetry::BT2020_RGB;
++      break;
++    default:
++      // BT709_YCC, SMPTE_170M_YCC, and all other YCC variants map to Default,
++      // which signals sRGB/BT.709 RGB (HD) or BT.601 RGB (SD) based on the
++      // transmitted resolution.
++      scanoutColorimetry = KODI::UTILS::Colorimetry::DEFAULT;
++      break;
++  }
++
++  std::optional<uint64_t> colorspace =
++      connector->GetPropertyEnumValue("Colorspace", ColorimetryMap.at(scanoutColorimetry));
++  if (colorspace)
++  {
++    CLog::LogF(LOGDEBUG, "setting connector colorspace to {} (source {})",
++               KODI::UTILS::ColorimetryToString(scanoutColorimetry),
++               KODI::UTILS::ColorimetryToString(colorimetry));
++    drm->AddProperty(connector, "Colorspace", colorspace.value());
++    drm->SetActive(true);
++  }
++}
++
+ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+ {
+   auto settingsComponent = CServiceBroker::GetSettingsComponent();
+@@ -397,19 +457,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+ 
+   if (!videoPicture)
+   {
+-    if (connector->SupportsProperty("Colorspace"))
+-    {
+-      std::optional<uint64_t> colorspace = connector->GetPropertyEnumValue("Colorspace", "Default");
+-      if (colorspace)
+-      {
+-        CLog::LogF(LOGDEBUG, "setting connector colorspace to Default");
+-        drm->AddProperty(connector, "Colorspace", colorspace.value());
+-        drm->SetActive(true);
+-      }
+-    }
+-
+     if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+     {
++      CLog::LogF(LOGDEBUG, "clearing HDR_OUTPUT_METADATA");
+       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
+       drm->SetActive(true);
+ 
+@@ -417,7 +467,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+     }
+ 
+     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+-    m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+     return false;
+   }
+ 
+@@ -426,24 +475,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
+       videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
+     return false;
+ 
+-  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
+   KODI::UTILS::Eotf eotf = KODI::UTILS::GetEOTF(*videoPicture);
+-  m_colorimetry = colorimetry;
+   m_eotf = eotf;
+ 
+-  if (connector->SupportsProperty("Colorspace") && m_info &&
+-      m_info->SupportsColorimetry(colorimetry))
+-  {
+-    std::optional<uint64_t> colorspace =
+-        connector->GetPropertyEnumValue("Colorspace", ColorimetryMap.at(colorimetry));
+-    if (colorspace)
+-    {
+-      CLog::LogF(LOGDEBUG, "setting connector colorspace to {}", ColorimetryMap.at(colorimetry));
+-      drm->AddProperty(connector, "Colorspace", colorspace.value());
+-      drm->SetActive(true);
+-    }
+-  }
+-
+   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
+       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))
+   {
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 2a35680817..5cdfcf2543 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -63,6 +63,7 @@ public:
+ 
+   bool SetVideoOutput(const VideoPicture* videoPicture) override;
+ 
++  void SetColorimetry(const VideoPicture* videoPicture) override;
+   KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
+   KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
+   bool SetHDR(const VideoPicture* videoPicture) override;
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0023-Colorimetry-add-ColorimetryToString-consolidate-infe.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0023-Colorimetry-add-ColorimetryToString-consolidate-infe.patch
@@ -1,0 +1,106 @@
+From 1c83f0bbbf2f83c5cdab0e455f386d135d74a329 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Sun, 8 Mar 2026 23:00:24 -0400
+Subject: [PATCH 23/25] Colorimetry: add ColorimetryToString, consolidate
+ inference logic
+
+- Add ColorimetryToString() to HDRUtils as single source for DRM
+  colorspace property string names
+- Move resolution-based colorimetry inference into GetColorimetry()
+  matching the YUV2RGB shader's SetColParams() thresholds (>1024/>=600)
+- Remove duplicate inference from WinSystemGbm::SetColorimetry()
+- Add one-shot colorimetry log in LinuxRendererGLES::Configure()
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../VideoRenderers/LinuxRendererGLES.cpp      | 10 +++++-
+ xbmc/utils/HDRUtils.cpp                       | 32 ++++++++++++++++++-
+ xbmc/utils/HDRUtils.h                         |  1 +
+ 3 files changed, 41 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+index d0268af112..daa45c5b0a 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+@@ -26,6 +26,7 @@
+ #include "settings/Settings.h"
+ #include "settings/SettingsComponent.h"
+ #include "utils/GLUtils.h"
++#include "utils/HDRUtils.h"
+ #include "utils/MathUtils.h"
+ #include "utils/log.h"
+ #include "windowing/WinSystem.h"
+@@ -126,7 +127,14 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
+ 
+ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsigned int orientation)
+ {
+-  CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: fps: {:0.3f}", fps);
++  auto colorimetry = KODI::UTILS::GetColorimetry(picture);
++  bool inferred = (picture.color_space == AVCOL_SPC_UNSPECIFIED);
++  CLog::Log(LOGDEBUG,
++            "LinuxRendererGLES::Configure: fps: {:0.3f}, {}x{}, colorimetry: {}{}, {}bit, {} range",
++            fps, picture.iWidth, picture.iHeight,
++            KODI::UTILS::ColorimetryToString(colorimetry),
++            inferred ? " (inferred)" : "", picture.colorBits,
++            picture.color_range == 1 ? "full" : "limited");
+   m_format = picture.videoBuffer->GetFormat();
+   m_sourceWidth = picture.iWidth;
+   m_sourceHeight = picture.iHeight;
+diff --git a/xbmc/utils/HDRUtils.cpp b/xbmc/utils/HDRUtils.cpp
+index b8ad1167eb..19e31f96e6 100644
+--- a/xbmc/utils/HDRUtils.cpp
++++ b/xbmc/utils/HDRUtils.cpp
+@@ -32,7 +32,37 @@ Colorimetry GetColorimetry(const VideoPicture& picture)
+     case AVCOL_SPC_BT470BG:
+       return Colorimetry::SMPTE_170M_YCC;
+     default:
+-      return Colorimetry::DEFAULT;
++      if (picture.iWidth > 1024 || picture.iHeight >= 600)
++        return Colorimetry::BT709_YCC;
++      else
++        return Colorimetry::SMPTE_170M_YCC;
++  }
++}
++
++const char* ColorimetryToString(Colorimetry colorimetry)
++{
++  // DRM connector "Colorspace" property strings from drm_connector.c
++  switch (colorimetry)
++  {
++    case Colorimetry::DEFAULT: return "Default";
++    case Colorimetry::SMPTE_170M_YCC: return "SMPTE_170M_YCC";
++    case Colorimetry::BT709_YCC: return "BT709_YCC";
++    case Colorimetry::XVYCC_601: return "XVYCC_601";
++    case Colorimetry::XVYCC_709: return "XVYCC_709";
++    case Colorimetry::SYCC_601: return "SYCC_601";
++    case Colorimetry::OPYCC_601: return "opYCC_601";
++    case Colorimetry::OPRGB: return "opRGB";
++    case Colorimetry::BT2020_CYCC: return "BT2020_CYCC";
++    case Colorimetry::BT2020_RGB: return "BT2020_RGB";
++    case Colorimetry::BT2020_YCC: return "BT2020_YCC";
++    case Colorimetry::DCI_P3_RGB_D65: return "DCI-P3_RGB_D65";
++    case Colorimetry::DCI_P3_RGB_THEATER: return "DCI-P3_RGB_Theater";
++    case Colorimetry::RGB_WIDE_FIXED: return "RGB_WIDE_FIXED";
++    case Colorimetry::RGB_WIDE_FLOAT: return "RGB_WIDE_FLOAT";
++    case Colorimetry::BT601_YCC: return "BT601_YCC";
++    case Colorimetry::ST2113_RGB: return "ST2113_RGB";
++    case Colorimetry::ICTCP: return "ICtCp";
++    default: return "Default";
+   }
+ }
+ 
+diff --git a/xbmc/utils/HDRUtils.h b/xbmc/utils/HDRUtils.h
+index 2a72d0596c..85c4bb3104 100644
+--- a/xbmc/utils/HDRUtils.h
++++ b/xbmc/utils/HDRUtils.h
+@@ -29,6 +29,7 @@ enum hdmi_metadata_type
+ };
+ 
+ Colorimetry GetColorimetry(const VideoPicture& picture);
++const char* ColorimetryToString(Colorimetry colorimetry);
+ Eotf GetEOTF(const VideoPicture& picture);
+ const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
+ const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0024-Renderers-pair-SetColorimetry-with-SetHDR-in-all-Lin.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0024-Renderers-pair-SetColorimetry-with-SetHDR-in-all-Lin.patch
@@ -1,0 +1,102 @@
+From 6879cb4587104f93bcecdbe5f4d23055934a46e5 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 20 Apr 2026 10:36:54 -0400
+Subject: [PATCH 24/25] Renderers: pair SetColorimetry with SetHDR in all Linux
+ renderers
+
+LinuxRendererGLES already called SetColorimetry, but LinuxRendererGL,
+RendererDRMPRIME, and RendererDRMPRIMEGLES did not, leaving the DRM
+Colorspace connector property unset for those video rendering paths.
+This caused DP-to-HDMI bridges to signal the wrong colorimetry tag
+in the HDMI AVI InfoFrame, with visible color shifts on wide-gamut
+content.
+
+Pair SetColorimetry(picture) with the existing SetHDR(picture) call in
+Configure, and clear both at UnInit / destructor in reverse order. Also
+flip LinuxRendererGLES's existing cleanup so SetHDR(nullptr) precedes
+SetColorimetry(nullptr), matching reverse-init order.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ .../HwDecRender/RendererDRMPRIME.cpp             | 16 ++++++++++++++++
+ .../HwDecRender/RendererDRMPRIMEGLES.cpp         |  2 ++
+ .../VideoRenderers/LinuxRendererGL.cpp           |  2 ++
+ 3 files changed, 20 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+index 30cf945cdb..05b1f084be 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+@@ -29,6 +29,13 @@ using namespace KODI::WINDOWING::GBM;
+ CRendererDRMPRIME::~CRendererDRMPRIME()
+ {
+   Flush(false);
++  // Clear the scanout colorspace and HDR metadata set during Configure so
++  // the GUI after playback falls back to Default / SDR.
++  if (auto* winSystem = CServiceBroker::GetWinSystem())
++  {
++    winSystem->SetHDR(nullptr);
++    winSystem->SetColorimetry(nullptr);
++  }
+ }
+ 
+ CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
+@@ -108,6 +115,15 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
+              GetFlagsColorPrimaries(picture.color_primaries) |
+              GetFlagsStereoMode(picture.stereoMode);
+ 
++  // Signal source colorimetry and HDR metadata on the scanout via the DRM
++  // Colorspace and HDR_OUTPUT_METADATA connector properties. The direct-to-
++  // plane scanout path bypasses GL video rendering entirely.
++  if (auto* winSystem = CServiceBroker::GetWinSystem())
++  {
++    winSystem->SetColorimetry(&picture);
++    winSystem->SetHDR(&picture);
++  }
++
+   // Calculate the input frame aspect ratio.
+   CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
+   SetViewMode(m_videoSettings.m_ViewMode);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+index 67d9fbce8d..404c84cad4 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+@@ -144,6 +144,7 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
+   //! shader, the way RendererVAAPIGLES does. Tracked in
+   //! project_limited_range_hdr.md.
+ 
++  winSystem->SetColorimetry(&picture);
+   m_passthroughHDR = winSystem->SetHDR(&picture);
+   CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+             m_passthroughHDR ? "on" : "off");
+@@ -171,6 +172,7 @@ void CRendererDRMPRIMEGLES::UnInit()
+     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+     m_passthroughHDR = false;
++    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
+     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+   }
+ 
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+index 1f5d0e73de..6088ef420c 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+@@ -260,6 +260,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
+   // setup the background colour
+   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+ 
++  CServiceBroker::GetWinSystem()->SetColorimetry(&picture);
+   m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+   CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
+             m_passthroughHDR ? "on" : "off");
+@@ -1081,6 +1082,7 @@ void CLinuxRendererGL::UnInit()
+     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+     m_passthroughHDR = false;
++    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
+     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+   }
+ 
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0025-Screenshot-10-12-bit-framebuffer-readback-with-HDR-f.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0025-Screenshot-10-12-bit-framebuffer-readback-with-HDR-f.patch
@@ -1,0 +1,522 @@
+From 78baf776c5e4ddaf83f2a1b43d63ba65c226a923 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Fri, 1 May 2026 02:09:00 -0400
+Subject: [PATCH 25/25] Screenshot: 10/12-bit framebuffer readback with HDR
+ filename tagging
+
+Extend the screenshot path to capture high-bit-depth framebuffers
+(10-bit AR30, 12/16-bit RGBA16) and tag output filenames with the
+active scanout color state.
+
+ScreenshotSurfaceGLES: add glReadPixels paths via
+GL_UNSIGNED_INT_2_10_10_10_REV (10-bit surfaces) and GL_UNSIGNED_SHORT
+(12/16-bit surfaces), selecting based on the framebuffer's red-bits.
+Falls back to GL_UNSIGNED_BYTE on driver failure.
+
+IScreenshotSurface, Screenshot, Picture: thread bit depth through
+the screenshot interface and image-save dispatch so the high-bit-depth
+buffer survives to the PNG encoder.
+
+TextureFormats: add XB_FMT_RGBA16 for 16-bit-per-channel storage.
+
+FFmpegImage: add 16-bit PNG output path for RGBA16 sources.
+
+Screenshot filename tagging: BT.709 + SDR is the default assumption
+and produces the original screenshot00000.png pattern. When the
+active scanout deviates, the colorspace and/or transfer tag is
+inserted BEFORE the index:
+  _bt2020  if colorimetry is BT.2020 (any variant)
+  _pq      if EOTF is PQ
+  _hlg     if EOTF is HLG
+
+Examples:
+  BT.709 + SDR : screenshot00000.png
+  BT.2020 + PQ : screenshot_bt2020_pq_00000.png
+  BT.709 + HLG : screenshot_hlg_00000.png
+
+Each tag combination has its own sequence counter via per-pattern
+exact-match in CUtil::GetNextFilename. Tags are computed up front in
+the no-arg TakeScreenshot() and baked into the GetNextFilename
+template, so the post-capture re-tagging path (the old tagFilename
+parameter) is no longer needed and has been removed. The bit-depth
+tag from the WIP version (_10bit / _16bit) is also dropped: bit
+depth is an output-format property, not a metadata characteristic
+of the captured content.
+
+WinSystem: add GetEotf() and GetColorimetry() virtuals with SDR
+defaults so the platform-independent Screenshot code can query the
+current scanout color state without dynamic_casting to a specific
+winsystem implementation. WinSystemGbm overrides to return its
+cached state from the last SetHDR/SetColorimetry call.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+---
+ xbmc/guilib/FFmpegImage.cpp                   |  23 +++-
+ xbmc/guilib/TextureFormats.h                  |   1 +
+ xbmc/pictures/Picture.cpp                     |   9 +-
+ xbmc/pictures/Picture.h                       |   6 +-
+ xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp | 119 ++++++++++++++++--
+ xbmc/utils/IScreenshotSurface.h               |   2 +
+ xbmc/utils/Screenshot.cpp                     |  53 ++++++--
+ xbmc/windowing/WinSystem.h                    |   3 +
+ xbmc/windowing/gbm/WinSystemGbm.h             |   4 +-
+ 9 files changed, 187 insertions(+), 33 deletions(-)
+
+diff --git a/xbmc/guilib/FFmpegImage.cpp b/xbmc/guilib/FFmpegImage.cpp
+index e997c4ba2d..d1cde3f6b8 100644
+--- a/xbmc/guilib/FFmpegImage.cpp
++++ b/xbmc/guilib/FFmpegImage.cpp
+@@ -569,12 +569,14 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned
+                                              unsigned int &bufferoutSize)
+ {
+   // It seems XB_FMT_A8R8G8B8 mean RGBA and not ARGB
+-  if (format != XB_FMT_A8R8G8B8)
++  if (format != XB_FMT_A8R8G8B8 && format != XB_FMT_RGBA16)
+   {
+     CLog::Log(LOGERROR, "Supplied format: {} is not supported.", format);
+     return false;
+   }
+ 
++  bool is16bit = (format == XB_FMT_RGBA16);
++
+   bool jpg_output = false;
+   if (m_strMimeType == "image/jpeg" || m_strMimeType == "image/jpg")
+     jpg_output = true;
+@@ -607,7 +609,9 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned
+   tdm.avOutctx->width = width;
+   tdm.avOutctx->time_base.num = 1;
+   tdm.avOutctx->time_base.den = 1;
+-  tdm.avOutctx->pix_fmt = jpg_output ? AV_PIX_FMT_YUVJ420P : AV_PIX_FMT_RGBA;
++  tdm.avOutctx->pix_fmt = jpg_output ? AV_PIX_FMT_YUVJ420P
++                        : is16bit   ? AV_PIX_FMT_RGBA64BE
++                                    : AV_PIX_FMT_RGBA;
+   tdm.avOutctx->flags = AV_CODEC_FLAG_QSCALE;
+   tdm.avOutctx->mb_lmin = tdm.avOutctx->qmin * FF_QP2LAMBDA;
+   tdm.avOutctx->mb_lmax = tdm.avOutctx->qmax * FF_QP2LAMBDA;
+@@ -659,7 +663,10 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned
+     return false;
+   }
+ 
+-  if (av_image_fill_arrays(tdm.frame_temporary->data, tdm.frame_temporary->linesize, tdm.intermediateBuffer, jpg_output ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_RGBA, width, height, 16) < 0)
++  AVPixelFormat intermediateFmt = jpg_output ? AV_PIX_FMT_YUV420P
++                               : is16bit   ? AV_PIX_FMT_RGBA64BE
++                                           : AV_PIX_FMT_RGBA;
++  if (av_image_fill_arrays(tdm.frame_temporary->data, tdm.frame_temporary->linesize, tdm.intermediateBuffer, intermediateFmt, width, height, 16) < 0)
+   {
+     CLog::Log(LOGERROR, "Could not fill picture for thumbnail: {}", destFile);
+     CleanupLocalOutputBuffer();
+@@ -670,7 +677,11 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned
+   int srcStride[] = { (int) pitch, 0, 0, 0};
+ 
+   //input size == output size which means only pix_fmt conversion
+-  tdm.sws = sws_getContext(width, height, AV_PIX_FMT_RGB32, width, height, jpg_output ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_RGBA, 0, 0, 0, 0);
++  AVPixelFormat srcFmt = is16bit ? AV_PIX_FMT_RGBA64LE : AV_PIX_FMT_RGB32;
++  AVPixelFormat dstFmt = jpg_output ? AV_PIX_FMT_YUV420P
++                       : is16bit   ? AV_PIX_FMT_RGBA64BE
++                                   : AV_PIX_FMT_RGBA;
++  tdm.sws = sws_getContext(width, height, srcFmt, width, height, dstFmt, 0, 0, 0, 0);
+   if (!tdm.sws)
+   {
+     CLog::Log(LOGERROR, "Could not setup scaling context for thumbnail: {}", destFile);
+@@ -718,7 +729,9 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned
+   tdm.frame_input->linesize[1] = tdm.frame_temporary->linesize[1];
+   tdm.frame_input->linesize[2] = tdm.frame_temporary->linesize[2];
+   // this is deprecated but mjpeg is not yet transitioned
+-  tdm.frame_input->format = jpg_output ? AV_PIX_FMT_YUVJ420P : AV_PIX_FMT_RGBA;
++  tdm.frame_input->format = jpg_output ? AV_PIX_FMT_YUVJ420P
++                          : is16bit   ? AV_PIX_FMT_RGBA64BE
++                                      : AV_PIX_FMT_RGBA;
+ 
+   int got_package = 0;
+   AVPacket* avpkt;
+diff --git a/xbmc/guilib/TextureFormats.h b/xbmc/guilib/TextureFormats.h
+index 5b7d87c5fb..93e8982138 100644
+--- a/xbmc/guilib/TextureFormats.h
++++ b/xbmc/guilib/TextureFormats.h
+@@ -22,6 +22,7 @@ enum XB_FMT
+   XB_FMT_A8          = 0x20,
+   XB_FMT_RGBA8       = 0x40,
+   XB_FMT_RGB8        = 0x80,
++  XB_FMT_RGBA16      = 0x100, // 16-bit per channel RGBA (for 10-bit+ screenshot capture)
+   XB_FMT_MASK        = 0xFFFF,
+   XB_FMT_OPAQUE      = 0x10000,
+ };
+diff --git a/xbmc/pictures/Picture.cpp b/xbmc/pictures/Picture.cpp
+index cdababf823..7812cdaef7 100644
+--- a/xbmc/pictures/Picture.cpp
++++ b/xbmc/pictures/Picture.cpp
+@@ -56,14 +56,14 @@ bool CPicture::GetThumbnailFromSurface(const unsigned char* buffer, int width, i
+   return true;
+ }
+ 
+-bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width, int height, int stride, const std::string &thumbFile)
++bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width, int height, int stride, const std::string &thumbFile, unsigned int format)
+ {
+   CLog::Log(LOGDEBUG, "cached image '{}' size {}x{}", CURL::GetRedacted(thumbFile), width, height);
+ 
+   unsigned char *thumb = NULL;
+   unsigned int thumbsize=0;
+   IImage* pImage = ImageFactory::CreateLoader(thumbFile);
+-  if(pImage == NULL || !pImage->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height, XB_FMT_A8R8G8B8, stride, thumbFile.c_str(), thumb, thumbsize))
++  if(pImage == NULL || !pImage->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height, format, stride, thumbFile.c_str(), thumb, thumbsize))
+   {
+     CLog::Log(LOGERROR, "Failed to CreateThumbnailFromSurface for {}",
+               CURL::GetRedacted(thumbFile));
+@@ -81,13 +81,14 @@ bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width
+   return ret;
+ }
+ 
+-CThumbnailWriter::CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile):
++CThumbnailWriter::CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile, unsigned int format):
+   m_thumbFile(thumbFile)
+ {
+   m_buffer    = buffer;
+   m_width     = width;
+   m_height    = height;
+   m_stride    = stride;
++  m_format    = format;
+ }
+ 
+ CThumbnailWriter::~CThumbnailWriter()
+@@ -99,7 +100,7 @@ bool CThumbnailWriter::DoWork()
+ {
+   bool success = true;
+ 
+-  if (!CPicture::CreateThumbnailFromSurface(m_buffer, m_width, m_height, m_stride, m_thumbFile))
++  if (!CPicture::CreateThumbnailFromSurface(m_buffer, m_width, m_height, m_stride, m_thumbFile, m_format))
+   {
+     CLog::Log(LOGERROR, "CThumbnailWriter::DoWork unable to write {}",
+               CURL::GetRedacted(m_thumbFile));
+diff --git a/xbmc/pictures/Picture.h b/xbmc/pictures/Picture.h
+index 6ba061a2b7..bc44e395e8 100644
+--- a/xbmc/pictures/Picture.h
++++ b/xbmc/pictures/Picture.h
+@@ -8,6 +8,7 @@
+ 
+ #pragma once
+ 
++#include "guilib/TextureFormats.h"
+ #include "jobs/Job.h"
+ #include "pictures/PictureScalingAlgorithm.h"
+ 
+@@ -28,7 +29,7 @@ class CPicture
+ {
+ public:
+   static bool GetThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile, uint8_t* &result, size_t& result_size);
+-  static bool CreateThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile);
++  static bool CreateThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile, unsigned int format = XB_FMT_A8R8G8B8);
+ 
+   static std::unique_ptr<CTexture> CreateTiledThumb(const std::vector<std::string>& files);
+ 
+@@ -117,7 +118,7 @@ class CThumbnailWriter : public CJob
+ {
+   public:
+     //WARNING: buffer is deleted from DoWork()
+-    CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile);
++    CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile, unsigned int format = XB_FMT_A8R8G8B8);
+     ~CThumbnailWriter() override;
+     bool DoWork() override;
+ 
+@@ -126,6 +127,7 @@ class CThumbnailWriter : public CJob
+     int            m_width;
+     int            m_height;
+     int            m_stride;
++    unsigned int   m_format;
+     std::string    m_thumbFile;
+ };
+ 
+diff --git a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+index d49bf0e494..e7536cd187 100644
+--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
++++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+@@ -12,6 +12,7 @@
+ #include "guilib/GUIComponent.h"
+ #include "guilib/GUIWindowManager.h"
+ #include "utils/Screenshot.h"
++#include "utils/log.h"
+ #include "windowing/GraphicContext.h"
+ #include "windowing/WinSystem.h"
+ 
+@@ -50,24 +51,118 @@ bool CScreenshotSurfaceGLES::Capture()
+ 
+   m_width = viewport[2] - viewport[0];
+   m_height = viewport[3] - viewport[1];
+-  m_stride = m_width * 4;
+-  std::vector<uint8_t> surface(m_stride * m_height);
+ 
+-  //read pixels from the backbuffer
+-  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
++  GLint redBits = 8;
++  glGetIntegerv(GL_RED_BITS, &redBits);
+ 
+-  //make a new buffer and copy the read image to it with the Y axis inverted
+-  m_buffer = new unsigned char[m_stride * m_height];
+-  for (int y = 0; y < m_height; y++)
++  // GLES only guarantees GL_RGBA/GL_UNSIGNED_BYTE for glReadPixels.
++  // Any other format must be queried via GL_IMPLEMENTATION_COLOR_READ_TYPE.
++  // For >8-bit surfaces, the driver may support:
++  //   GL_UNSIGNED_INT_2_10_10_10_REV -- packed 10:10:10:2 (10-bit surfaces)
++  //   GL_UNSIGNED_SHORT -- 16-bit per channel (12-bit or 16-bit surfaces)
++  enum class ReadbackMode { Uint8, Packed1010102, Uint16 };
++  ReadbackMode readbackMode = ReadbackMode::Uint8;
++
++#if HAS_GLES == 3
++  if (redBits > 8)
++  {
++    GLint readFormat = GL_RGBA;
++    GLint readType = GL_UNSIGNED_BYTE;
++    glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &readFormat);
++    glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &readType);
++    if (readFormat == GL_RGBA)
++    {
++      if (readType == GL_UNSIGNED_INT_2_10_10_10_REV)
++        readbackMode = ReadbackMode::Packed1010102;
++      else if (readType == GL_UNSIGNED_SHORT)
++        readbackMode = ReadbackMode::Uint16;
++    }
++  }
++#endif
++
++  m_bitDepth = (readbackMode != ReadbackMode::Uint8) ? redBits : 8;
++
++  if (readbackMode == ReadbackMode::Packed1010102)
++  {
++    // 10-bit surface: read packed 10:10:10:2 RGBA and unpack to 16-bit per channel
++    std::vector<uint32_t> packed(m_width * m_height);
++    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3],
++                 GL_RGBA, GL_UNSIGNED_INT_2_10_10_10_REV,
++                 static_cast<GLvoid*>(packed.data()));
++
++    if (glGetError() != GL_NO_ERROR)
++    {
++      CLog::Log(LOGERROR, "CScreenshotSurfaceGLES: glReadPixels 10-bit failed, falling back to 8-bit");
++      readbackMode = ReadbackMode::Uint8;
++      m_bitDepth = 8;
++    }
++    else
++    {
++      m_stride = m_width * 8; // 4 channels x 2 bytes
++      m_buffer = new unsigned char[m_stride * m_height];
++      for (int y = 0; y < m_height; y++)
++      {
++        uint16_t* dst = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
++        uint32_t* src = packed.data() + (m_height - 1 - y) * m_width;
++        for (int x = 0; x < m_width; x++)
++        {
++          uint32_t p = src[x];
++          dst[x * 4 + 0] = static_cast<uint16_t>(((p >> 0) & 0x3FF) << 6);  // R
++          dst[x * 4 + 1] = static_cast<uint16_t>(((p >> 10) & 0x3FF) << 6); // G
++          dst[x * 4 + 2] = static_cast<uint16_t>(((p >> 20) & 0x3FF) << 6); // B
++          dst[x * 4 + 3] = 0xFFFF;                                           // A
++        }
++      }
++    }
++  }
++  else if (readbackMode == ReadbackMode::Uint16)
+   {
+-    // we need to save in BGRA order so XOR Swap RGBA -> BGRA
+-    unsigned char* swap_pixels = surface.data() + (m_height - y - 1) * m_stride;
+-    for (int x = 0; x < m_width; x++, swap_pixels += 4)
++    // 12-bit or 16-bit surface: read 16-bit per channel directly
++    m_stride = m_width * 8; // 4 channels x 2 bytes
++    std::vector<uint16_t> raw(m_width * m_height * 4);
++    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3],
++                 GL_RGBA, GL_UNSIGNED_SHORT,
++                 static_cast<GLvoid*>(raw.data()));
++
++    if (glGetError() != GL_NO_ERROR)
+     {
+-      std::swap(swap_pixels[0], swap_pixels[2]);
++      CLog::Log(LOGERROR, "CScreenshotSurfaceGLES: glReadPixels 16-bit failed, falling back to 8-bit");
++      readbackMode = ReadbackMode::Uint8;
++      m_bitDepth = 8;
+     }
++    else
++    {
++      m_buffer = new unsigned char[m_stride * m_height];
++      for (int y = 0; y < m_height; y++)
++      {
++        uint16_t* dst = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
++        uint16_t* src = raw.data() + (m_height - 1 - y) * m_width * 4;
++        memcpy(dst, src, m_stride); // already RGBA16, just Y-flip
++      }
++    }
++  }
+ 
+-    memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride, m_stride);
++  if (readbackMode == ReadbackMode::Uint8)
++  {
++    // 8-bit readback (default, or fallback from failed high-bit readback)
++    m_stride = m_width * 4;
++    std::vector<uint8_t> surface(m_stride * m_height);
++
++    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3],
++                 GL_RGBA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
++
++    m_buffer = new unsigned char[m_stride * m_height];
++    for (int y = 0; y < m_height; y++)
++    {
++      // we need to save in BGRA order so XOR Swap RGBA -> BGRA
++      unsigned char* swap_pixels = surface.data() + (m_height - y - 1) * m_stride;
++      for (int x = 0; x < m_width; x++, swap_pixels += 4)
++      {
++        std::swap(swap_pixels[0], swap_pixels[2]);
++      }
++
++      memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride, m_stride);
++    }
+   }
+ 
+   return m_buffer != nullptr;
+diff --git a/xbmc/utils/IScreenshotSurface.h b/xbmc/utils/IScreenshotSurface.h
+index ba3fa6a690..9e446c36fa 100644
+--- a/xbmc/utils/IScreenshotSurface.h
++++ b/xbmc/utils/IScreenshotSurface.h
+@@ -18,6 +18,7 @@ public:
+   int GetWidth() const { return m_width; }
+   int GetHeight() const { return m_height; }
+   int GetStride() const { return m_stride; }
++  int GetBitDepth() const { return m_bitDepth; }
+   unsigned char* GetBuffer() const { return m_buffer; }
+   void ReleaseBuffer()
+   {
+@@ -32,5 +33,6 @@ protected:
+   int m_width{0};
+   int m_height{0};
+   int m_stride{0};
++  int m_bitDepth{8};
+   unsigned char* m_buffer{nullptr};
+ };
+diff --git a/xbmc/utils/Screenshot.cpp b/xbmc/utils/Screenshot.cpp
+index dc3aea8103..a2f394cd3d 100644
+--- a/xbmc/utils/Screenshot.cpp
++++ b/xbmc/utils/Screenshot.cpp
+@@ -20,8 +20,10 @@
+ #include "settings/Settings.h"
+ #include "settings/SettingsComponent.h"
+ #include "settings/windows/GUIControlSettings.h"
++#include "utils/StringUtils.h"
+ #include "utils/URIUtils.h"
+ #include "utils/log.h"
++#include "windowing/WinSystem.h"
+ 
+ using namespace XFILE;
+ 
+@@ -52,18 +54,27 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+ 
+   CLog::Log(LOGDEBUG, "Saving screenshot {}", CURL::GetRedacted(filename));
+ 
+-  //set alpha byte to 0xFF
+-  for (int y = 0; y < surface->GetHeight(); y++)
++  unsigned int format = XB_FMT_A8R8G8B8;
++  if (surface->GetBitDepth() > 8)
+   {
+-    unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
+-    for (int x = 0; x < surface->GetWidth(); x++)
+-      *(alphaptr += 4) = 0xFF;
++    // 10-bit capture: buffer is already RGBA16 with correct alpha, no swap needed
++    format = XB_FMT_RGBA16;
++  }
++  else
++  {
++    //set alpha byte to 0xFF
++    for (int y = 0; y < surface->GetHeight(); y++)
++    {
++      unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
++      for (int x = 0; x < surface->GetWidth(); x++)
++        *(alphaptr += 4) = 0xFF;
++    }
+   }
+ 
+   //if sync is true, the png file needs to be completely written when this function returns
+   if (sync)
+   {
+-    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename))
++    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename, format))
+       CLog::Log(LOGERROR, "Unable to write screenshot {}", CURL::GetRedacted(filename));
+ 
+     surface->ReleaseBuffer();
+@@ -79,7 +90,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+ 
+     //write .png file asynchronous with CThumbnailWriter, prevents stalling of the render thread
+     //buffer is deleted from CThumbnailWriter
+-    CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename);
++    CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename, format);
+     CServiceBroker::GetJobManager()->AddJob(thumbnailwriter, nullptr);
+   }
+ }
+@@ -104,8 +115,34 @@ void CScreenShot::TakeScreenshot()
+ 
+   if (!strDir.empty())
+   {
++    // Compute colorspace+EOTF tag from current scanout state.
++    // BT.709 + SDR is the default assumption; only deviations are tagged.
++    // Tag goes BEFORE the index, e.g. screenshot_bt2020_pq_00000.png.
++    std::string tag;
++    using KODI::UTILS::Eotf;
++    using KODI::UTILS::Colorimetry;
++    if (auto* winSystem = CServiceBroker::GetWinSystem())
++    {
++      Colorimetry colorimetry = winSystem->GetColorimetry();
++      Eotf eotf = winSystem->GetEotf();
++
++      if (colorimetry == Colorimetry::BT2020_YCC ||
++          colorimetry == Colorimetry::BT2020_RGB ||
++          colorimetry == Colorimetry::BT2020_CYCC)
++        tag += "_bt2020";
++
++      if (eotf == Eotf::PQ)
++        tag += "_pq";
++      else if (eotf == Eotf::HLG)
++        tag += "_hlg";
++    }
++
++    const std::string templateFile = tag.empty()
++        ? "screenshot{:05}.png"
++        : "screenshot" + tag + "_{:05}.png";
++
+     std::string file =
+-        CUtil::GetNextFilename(URIUtils::AddFileToFolder(strDir, "screenshot{:05}.png"), 65535);
++        CUtil::GetNextFilename(URIUtils::AddFileToFolder(strDir, templateFile), 65535);
+ 
+     if (!file.empty())
+     {
+diff --git a/xbmc/windowing/WinSystem.h b/xbmc/windowing/WinSystem.h
+index 3abc92a7e5..cb36602ac4 100644
+--- a/xbmc/windowing/WinSystem.h
++++ b/xbmc/windowing/WinSystem.h
+@@ -16,6 +16,7 @@
+ #include "cores/VideoPlayer/VideoRenderers/DebugInfo.h"
+ #include "guilib/DirtyRegion.h"
+ #include "guilib/DispResource.h"
++#include "utils/DisplayInfo.h"
+ #include "utils/HDRCapabilities.h"
+ 
+ #include <memory>
+@@ -243,6 +244,8 @@ public:
+   virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }
+   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }
+   virtual CHDRCapabilities GetDisplayHDRCapabilities() const { return {}; }
++  virtual KODI::UTILS::Eotf GetEotf() const { return KODI::UTILS::Eotf::TRADITIONAL_SDR; }
++  virtual KODI::UTILS::Colorimetry GetColorimetry() const { return KODI::UTILS::Colorimetry::DEFAULT; }
+   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
+   virtual float GetGuiSdrPeakLuminance() const { return .0f; }
+   virtual bool HasSystemSdrPeakLuminance() { return false; }
+diff --git a/xbmc/windowing/gbm/WinSystemGbm.h b/xbmc/windowing/gbm/WinSystemGbm.h
+index 5cdfcf2543..79de3d69af 100644
+--- a/xbmc/windowing/gbm/WinSystemGbm.h
++++ b/xbmc/windowing/gbm/WinSystemGbm.h
+@@ -64,8 +64,8 @@ public:
+   bool SetVideoOutput(const VideoPicture* videoPicture) override;
+ 
+   void SetColorimetry(const VideoPicture* videoPicture) override;
+-  KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
+-  KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
++  KODI::UTILS::Colorimetry GetColorimetry() const override { return m_colorimetry; }
++  KODI::UTILS::Eotf GetEotf() const override { return m_eotf; }
+   bool SetHDR(const VideoPicture* videoPicture) override;
+   bool IsHDRDisplay() override;
+   CHDRCapabilities GetDisplayHDRCapabilities() const override;
+-- 
+2.43.0
+

--- a/projects/Generic/devices/Generic/options
+++ b/projects/Generic/devices/Generic/options
@@ -1,1 +1,1 @@
-../gbm/options
+../OpenGLES/options

--- a/projects/Generic/devices/OpenGL/options
+++ b/projects/Generic/devices/OpenGL/options
@@ -1,0 +1,23 @@
+# OpenGL(X) implementation to use (mesa / no)
+  OPENGL="mesa"
+
+# OpenGLES implementation to use (mesa / no)
+  OPENGLES="no"
+
+# Vulkan implementation to use (vulkan-loader / no)
+  VULKAN="no"
+
+# Displayserver to use (weston / x11 / no)
+  DISPLAYSERVER="no"
+
+# Windowmanager to use (fluxbox / weston / no)
+  WINDOWMANAGER="no"
+
+# KODI Player implementation to use (mesa / default)
+  KODIPLAYER_DRIVER="mesa"
+
+# Set the addon project
+  ADDON_PROJECT="Generic"
+
+# Mesa 3D Graphic drivers to use
+  GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"

--- a/projects/Generic/devices/OpenGLES/options
+++ b/projects/Generic/devices/OpenGLES/options
@@ -1,7 +1,7 @@
 # OpenGL(X) implementation to use (mesa / no)
   OPENGL="no"
 
-# OpenGL-ES implementation to use (mesa / no)
+# OpenGLES implementation to use (mesa / no)
   OPENGLES="mesa"
 
 # Vulkan implementation to use (vulkan-loader / no)
@@ -16,10 +16,8 @@
 # KODI Player implementation to use (mesa / default)
   KODIPLAYER_DRIVER="mesa"
 
-# set the addon project
+# Set the addon project
   ADDON_PROJECT="Generic"
 
-# Mesa 3D Graphic drivers to use (all / crocus,i915,iris,r300,r600,radeonsi,vmware,virtio)
-# Space separated list is supported,
-# e.g. GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"
+# Mesa 3D Graphic drivers to use
   GRAPHIC_DRIVERS="crocus i915 iris r300 r600 radeonsi vmware virtio"


### PR DESCRIPTION
The reardonia Kodi patches are sourced from https://github.com/reardonia/xbmc/tree/integration-test and cover changes to 10-bit/HDR and colourspace management for GLES/GL/VAAPI code-paths. The majority of the changes are architectural to facilitate a common set of features over Linux code-paths. From an end-user perspective the main changes are support for dithering on GLES3.1+ capable hardware and GUI/OSD tonemapping on GLES2.0+ hardware during HDR playback. Some of the colour changes are complex and you'll need to read the individual patch descriptions. The goal of adding the patches for all buildsystem projects/devices is to achieve broad-scale testing and confidence to drive upstream merge, and of course to generate feedback and shake out issues. I've run Generic, Amlogic, Rockchip (newer) and RPi5 images with these included so I'm reasonably confident things work well enough to inflict them on an unsuspecting public :)

The Intel GPU kernel patch addresses long-running audio dropouts with 4K@23.976 playback on a wide range of newer Intel hardware. Preventing 12-bit depth is a hack/workaround but the upstream investigation from Intel developers continues to move at a glacial pace so it's better to have something in-place for LE13. This supersedes the userspace script workaround proposed in #8588.

The Generic device rename/add follows-on from the switch back to OpenGLES; several devs have requested a GBM device to faciliate easier image build/test with OpenGL (and this should also support downstream use). As part of the changes I've lightly cleaned up the options files.

Lastly we bump the default kernel to Linux 7.0.5.