### PR TITLE
 packages: add git format-patch headers to plain-diff patches

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/gtk3/patches/0001-disable-to-pixdata-build.patch
+++ b/packages/addons/addon-depends/chrome-depends/gtk3/patches/0001-disable-to-pixdata-build.patch
@@ -1,5 +1,11 @@
---- a/gtk/gen-gtk-gresources-xml.py	2021-02-24 19:13:19.000000000 +0000
-+++ b/gtk/gen-gtk-gresources-xml.py	2021-04-03 23:52:35.000000000 +0000
+From 86f4306ef84355d9d2a53bddc52c1119be28f042 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 04 Apr 2021 00:00:26 +0000
+Subject: [PATCH] disable to pixdata build
+
+diff --git a/gtk/gen-gtk-gresources-xml.py b/gtk/gen-gtk-gresources-xml.py
+--- a/gtk/gen-gtk-gresources-xml.py
++++ b/gtk/gen-gtk-gresources-xml.py
 @@ -23,11 +23,6 @@
      <file>theme/Adwaita/gtk-contained-dark.css</file>
  '''

--- a/packages/addons/addon-depends/chrome-depends/unclutter/patches/0001-fix-gcc-14-1-build.patch
+++ b/packages/addons/addon-depends/chrome-depends/unclutter/patches/0001-fix-gcc-14-1-build.patch
@@ -1,5 +1,11 @@
---- a/unclutter.c	2007-02-05 23:13:12.000000000 +0000
-+++ b/unclutter.c	2024-05-23 07:41:37.115416042 +0000
+From efc9c7e4d18e3a4a569b88feb90800c876666643 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 23 May 2024 08:01:53 +0000
+Subject: [PATCH] fix gcc 14 1 build
+
+diff --git a/unclutter.c b/unclutter.c
+--- a/unclutter.c
++++ b/unclutter.c
 @@ -37,14 +37,15 @@
  #include <X11/Xutil.h>
  #include <X11/Xproto.h>
@@ -62,8 +68,9 @@
      Display *display;
      int screen,oldx = -99,oldy = -99,numscreens;
      int doroot = 0, jitter = 0, idletime = 5, usegrabmethod = 0, waitagain = 0,
---- a/vroot.h	2007-02-05 22:52:40.000000000 +0000
-+++ b/vroot.h	2024-05-23 07:59:50.811488716 +0000
+diff --git a/vroot.h b/vroot.h
+--- a/vroot.h
++++ b/vroot.h
 @@ -40,6 +40,7 @@
  static Window
  VirtualRootWindow(dpy, screen)

--- a/packages/addons/addon-depends/chrome-depends/unclutter/patches/0002-fix-gcc-15-1-build.patch
+++ b/packages/addons/addon-depends/chrome-depends/unclutter/patches/0002-fix-gcc-15-1-build.patch
@@ -1,5 +1,11 @@
---- a/unclutter.c	2025-05-17 23:11:53.709868560 +0000
-+++ b/unclutter.c	2025-05-17 23:11:12.811903184 +0000
+From cbec1b03df4851e970666bdbfb2c399d3dbaa45c Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 17 May 2025 23:14:16 +0000
+Subject: [PATCH] fix gcc 15 1 build
+
+diff --git a/unclutter.c b/unclutter.c
+--- a/unclutter.c
++++ b/unclutter.c
 @@ -73,7 +73,7 @@
   * window can disappear while we are trying to create the child. Trap and
   * ignore these errors.

--- a/packages/addons/addon-depends/comskip/patches/0002-gcc15.patch
+++ b/packages/addons/addon-depends/comskip/patches/0002-gcc15.patch
@@ -1,5 +1,11 @@
---- a/comskip.c	2024-12-09 13:06:15.051318034 +0000
-+++ b/comskip.c	2024-12-09 13:07:54.348640394 +0000
+From 8227a01fc92d0f1d78731c8da377f43f117fa863 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 09 Dec 2024 13:09:43 +0000
+Subject: [PATCH] gcc15
+
+diff --git a/comskip.c b/comskip.c
+--- a/comskip.c
++++ b/comskip.c
 @@ -976,7 +976,7 @@
  int					FindUniformThreshold(double percentile);
  void				OutputFrameArray(bool screenOnly);

--- a/packages/addons/addon-depends/cxxtools/patches/0001-2.2-Char-operator-eq-unsigned-int.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0001-2.2-Char-operator-eq-unsigned-int.patch
@@ -1,7 +1,13 @@
+From 4779a5086456daadf9678f8d39466760672df0a4 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sun, 06 Oct 2013 14:40:02 +0300
+Subject: [PATCH] 2.2 Char operator eq unsigned int
+
 Index: cxxtools-2.2/include/cxxtools/char.h
 ===================================================================
---- cxxtools-2.2.orig/include/cxxtools/char.h	2013-05-05 14:18:00.180572107 +0300
-+++ cxxtools-2.2/include/cxxtools/char.h	2013-05-05 14:18:00.176571966 +0300
+diff --git a/include/cxxtools/char.h b/include/cxxtools/char.h
+--- a/include/cxxtools/char.h
++++ b/include/cxxtools/char.h
 @@ -148,6 +148,12 @@
              friend bool operator==(char a, const Char& b)
              { return a == b.value(); }

--- a/packages/addons/addon-depends/cxxtools/patches/0002-2.2-hdstream-stdio.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0002-2.2-hdstream-stdio.patch
@@ -1,7 +1,13 @@
+From 4779a5086456daadf9678f8d39466760672df0a4 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sun, 06 Oct 2013 14:40:02 +0300
+Subject: [PATCH] 2.2 hdstream stdio
+
 Index: cxxtools-2.0/src/hdstream.cpp
 ===================================================================
---- cxxtools-2.0.orig/src/hdstream.cpp	2011-08-08 13:07:59.567275994 +0300
-+++ cxxtools-2.0/src/hdstream.cpp	2011-08-08 13:08:11.447275959 +0300
+diff --git a/src/hdstream.cpp b/src/hdstream.cpp
+--- a/src/hdstream.cpp
++++ b/src/hdstream.cpp
 @@ -30,6 +30,7 @@
  #include <ios>
  #include <iomanip>

--- a/packages/addons/addon-depends/cxxtools/patches/0004-3.0-gcc12-time.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0004-3.0-gcc12-time.patch
@@ -1,4 +1,12 @@
+From ee19e2675554c02733fd9af20617724a2cf038dc Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 12 Jul 2022 13:56:23 +0000
+Subject: [PATCH] 3.0 gcc12 time
+
 https://bugs.gentoo.org/851837
+
+---
+diff --git a/src/timer.cpp b/src/timer.cpp
 --- a/src/timer.cpp
 +++ b/src/timer.cpp
 @@ -27,6 +27,7 @@

--- a/packages/addons/addon-depends/cxxtools/patches/0005-3.0-lld-linking-openssl.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0005-3.0-lld-linking-openssl.patch
@@ -1,3 +1,9 @@
+From ee19e2675554c02733fd9af20617724a2cf038dc Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 12 Jul 2022 13:56:23 +0000
+Subject: [PATCH] 3.0 lld linking openssl
+
+diff --git a/src/Makefile.am b/src/Makefile.am
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -173,7 +173,7 @@ libcxxtools_la_LIBADD = $(LIBICONV)

--- a/packages/addons/addon-depends/cxxtools/patches/0006-crosscompile.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0006-crosscompile.patch
@@ -1,6 +1,11 @@
-diff -Naur a/configure.ac b/configure.ac
---- a/configure.ac	2013-04-20 23:31:50.000000000 +0200
-+++ b/configure.ac	2014-01-03 20:26:32.064005192 +0100
+From 0ef33bc05599d324689a7c0d664e24e1cfdc40b2 Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Fri, 03 Jan 2014 20:40:03 +0100
+Subject: [PATCH] crosscompile
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -106,8 +106,8 @@
  
  AC_PROG_LIBTOOL
@@ -12,9 +17,9 @@ diff -Naur a/configure.ac b/configure.ac
  
  AC_SUBST(CXXTOOLS_CXXFLAGS)
  AC_SUBST(CXXTOOLS_LDFLAGS)
-diff -Naur a/configure b/configure
---- a/configure	2013-04-21 21:13:11.000000000 +0200
-+++ b/configure	2014-01-03 20:34:53.404660480 +0100
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
 @@ -3119,7 +3119,7 @@
  ac_compiler_gnu=$ac_cv_c_compiler_gnu
  

--- a/packages/addons/addon-depends/docker/cli/patches/0001-path-for-cli-plugins.patch
+++ b/packages/addons/addon-depends/docker/cli/patches/0001-path-for-cli-plugins.patch
@@ -1,5 +1,11 @@
---- a/cli-plugins/manager/manager_unix.go	2023-02-03 11:54:16.746399916 +0000
-+++ b/cli-plugins/manager/manager_unix.go	2023-02-03 11:59:04.528175595 +0000
+From 6b6852f88b86b57e42ca1e9814f0f333350a608f Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 03 Feb 2023 12:22:05 +0000
+Subject: [PATCH] path for cli plugins
+
+diff --git a/cli-plugins/manager/manager_unix.go b/cli-plugins/manager/manager_unix.go
+--- a/cli-plugins/manager/manager_unix.go
++++ b/cli-plugins/manager/manager_unix.go
 @@ -13,8 +13,6 @@
  //
  // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs

--- a/packages/addons/addon-depends/docker/moby/patches/0002-use-unconfined-seccomp-profile-as-default.patch
+++ b/packages/addons/addon-depends/docker/moby/patches/0002-use-unconfined-seccomp-profile-as-default.patch
@@ -1,5 +1,11 @@
---- a/daemon/config/config.go	2022-06-03 10:30:24.000000000 -0700
-+++ b/daemon/config/config.go	2022-06-07 14:29:36.755713207 -0700
+From 2216bd1642da39e1d5cf82c67ccebfa674698731 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Tue, 07 Jun 2022 15:08:52 -0700
+Subject: [PATCH] use unconfined seccomp profile as default
+
+diff --git a/daemon/config/config.go b/daemon/config/config.go
+--- a/daemon/config/config.go
++++ b/daemon/config/config.go
 @@ -67,7 +67,7 @@
  	// MinAPIVersion is the minimum API version supported by the daemon.
  	MinAPIVersion = "1.24"
@@ -9,8 +15,9 @@
  	// SeccompProfileUnconfined is a special profile name for seccomp to use an
  	// "unconfined" seccomp profile.
  	SeccompProfileUnconfined = "unconfined"
---- a/daemon/daemon_unix.go	2022-06-03 10:30:24.000000000 -0700
-+++ b/daemon/daemon_unix.go	2022-06-07 14:34:55.315558083 -0700
+diff --git a/daemon/daemon_unix.go b/daemon/daemon_unix.go
+--- a/daemon/daemon_unix.go
++++ b/daemon/daemon_unix.go
 @@ -1598,8 +1598,6 @@
  
  func (daemon *Daemon) setupSeccompProfile(cfg *config.Config) error {

--- a/packages/addons/addon-depends/ffmpegx/patches/0001-fix-NULL-dereference-if-no-frames-before-end-of-strea.patch
+++ b/packages/addons/addon-depends/ffmpegx/patches/0001-fix-NULL-dereference-if-no-frames-before-end-of-strea.patch
@@ -1,79 +1,8 @@
-From patchwork Sat Jul 19 07:08:36 2025
-Content-Type: text/plain; charset="utf-8"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-X-Patchwork-Submitter: James Hutchinson <jahutchinson99@googlemail.com>
-X-Patchwork-Id: 56391
-Return-Path: <ffmpeg-devel-bounces@ffmpeg.org>
-X-Original-To: ffmpeg-patchwork@ffmpeg.org
-Delivered-To: ffmpeg-patchwork@ffmpeg.org
-Received: from [127.0.1.1] (localhost [127.0.0.1])
-	by ffbox0-bg.ffmpeg.org (Postfix) with ESMTP id DE79168C231;
-	Sat, 19 Jul 2025 10:09:04 +0300 (EEST)
-X-Original-To: ffmpeg-devel@ffmpeg.org
-Delivered-To: ffmpeg-devel@ffmpeg.org
-Received: from mail-ej1-f52.google.com (mail-ej1-f52.google.com
- [209.85.218.52])
- by ffbox0-bg.ffmpeg.org (Postfix) with ESMTPS id 9A95468BDD6
- for <ffmpeg-devel@ffmpeg.org>; Sat, 19 Jul 2025 10:08:58 +0300 (EEST)
-Received: by mail-ej1-f52.google.com with SMTP id
- a640c23a62f3a-ae0b2ead33cso479703566b.0
- for <ffmpeg-devel@ffmpeg.org>; Sat, 19 Jul 2025 00:08:58 -0700 (PDT)
-X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
- d=1e100.net; s=20230601; t=1752908937; x=1753513737;
- h=content-transfer-encoding:mime-version:message-id:date:subject:cc
- :to:from:x-gm-message-state:from:to:cc:subject:date:message-id
- :reply-to;
- bh=2dgePZ7nkFD/l9ba1w+iqvJ6bPcp8CnRMMdiL89sQjs=;
- b=fxolVU0f6lC0bG62RAIWwzdNb0Ppc0I5FcIyXCD5S/BUbkyRidOe9gUQMdM6tyeQke
- EYPR6GppfEhkNYOrO09L7D8eFUpmaVPXsDt24HP3SAl1bDoEZNzV6N+emcefHoAtedUR
- 59bMG7xU/DrhH1zVncryNMzReTZMTzkkFg1rK3jpcSpXRjsUHd3Eeyp5a05TMZDQhjYk
- Gs1Qp3ceFgKX7Awinhu7EtqpCSmjwsJkkqPKberRQO5UWXdBTU9n4lwKKbq8pE3tDRk9
- 4jOwcrm1q4MGkB651KZO9uqJ4d926eUoyNgg1+5dMVI6WM0NXDWTd/SGUzNev1XHi95e
- EG8w==
-X-Gm-Message-State: AOJu0YwfLUWzpx354L+DikUVlulayk7JaPxt4+5IcAk7h+4Tw0vmjQJj
- pR04G7AQ7uHdjZfFDelg2ysc2vqWfZGi7nquGv95cEtNvVSmgvUloWiGZms7lQ==
-X-Gm-Gg: ASbGncveUGNDyMLnqtJmHj5HXzox/EZLHd4frYqSlTnViB3dlI326N2JlbHOMaJSntE
- wBoDnCvmXESMt/FG7vsvHl6qfLXdF80ZJUbMrVDMtvz2iSMl5vpXCM7EQFNEgreGEUclG11RZ4B
- nHBYO+swzV/yx293i5VqeEfmQGq4XChY8OjQZG8hwtowYnsvgqut0/G7kLtnaty2BEWklG/s5iW
- Q4GZyJ7cfmiqfWGejZsD24Q1sFGQFd9iWef3tW0XNeotu3G2pWFP/BiGr07HgR2Motb5c+HnVFw
- 1xgoKFUUa30G1lRjBTQqhIudGa2UWAhiaPFhHjvkbxG9TKV+cCblsVuq1hZKEXeYN9hahIw0jRp
- qWIXTuzp8PjqqIKiscruZb7CIC6eTzEoO4EYPCk/hNqA=
-X-Google-Smtp-Source: 
- AGHT+IFBbNh6HR778NSqbSozK3zA6zgI09LiaJY3EpoIFGzahtWIAa16h5k79lnzQGZqPjn8qMYedg==
-X-Received: by 2002:a17:906:d7c7:b0:ae0:7e95:fb with SMTP id
- a640c23a62f3a-aec65abd4a4mr609160766b.5.1752908937148;
- Sat, 19 Jul 2025 00:08:57 -0700 (PDT)
-Received: from mediapc.localdomain ([193.28.38.52])
- by smtp.gmail.com with ESMTPSA id
- a640c23a62f3a-aec6c79cd11sm252704466b.16.2025.07.19.00.08.56
- (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
- Sat, 19 Jul 2025 00:08:56 -0700 (PDT)
-To: ffmpeg-devel@ffmpeg.org
-Date: Sat, 19 Jul 2025 08:08:36 +0100
-Message-ID: <20250719070836.283597-1-jahutchinson99@googlemail.com>
-X-Mailer: git-send-email 2.50.1
-MIME-Version: 1.0
-Subject: [FFmpeg-devel] [PATCH] avcodec/hw_base_encode: fix NULL dereference
- if no frames before end-of-stream
-X-BeenThere: ffmpeg-devel@ffmpeg.org
-X-Mailman-Version: 2.1.29
-Precedence: list
-List-Id: FFmpeg development discussions and patches <ffmpeg-devel.ffmpeg.org>
-List-Unsubscribe: <https://ffmpeg.org/mailman/options/ffmpeg-devel>,
- <mailto:ffmpeg-devel-request@ffmpeg.org?subject=unsubscribe>
-List-Archive: <https://ffmpeg.org/pipermail/ffmpeg-devel>
-List-Post: <mailto:ffmpeg-devel@ffmpeg.org>
-List-Help: <mailto:ffmpeg-devel-request@ffmpeg.org?subject=help>
-List-Subscribe: <https://ffmpeg.org/mailman/listinfo/ffmpeg-devel>,
- <mailto:ffmpeg-devel-request@ffmpeg.org?subject=subscribe>
-X-Patchwork-Original-From: James Hutchinson via ffmpeg-devel
- <ffmpeg-devel@ffmpeg.org>
+From b0b0e0fe07905ec2f819f0823a0d967bf2bc7fc3 Mon Sep 17 00:00:00 2001
 From: James Hutchinson <jahutchinson99@googlemail.com>
-Reply-To: FFmpeg development discussions and patches <ffmpeg-devel@ffmpeg.org>
-Cc: James Hutchinson <jahutchinson99@googlemail.com>
-Errors-To: ffmpeg-devel-bounces@ffmpeg.org
-Sender: "ffmpeg-devel" <ffmpeg-devel-bounces@ffmpeg.org>
+Date: Sat, 19 Jul 2025 08:08:36 +0100
+Subject: [PATCH] avcodec/hw_base_encode: fix NULL dereference if no frames
+ before end-of-stream
 
 If hw_base_encode_send_frame() is called with frame == NULL before any
 input frames are submitted, ctx->pic_end is NULL and dereferencing it
@@ -93,11 +22,11 @@ index 33a30c8d10..7aa8aeedb1 100644
 --- a/libavcodec/hw_base_encode.c
 +++ b/libavcodec/hw_base_encode.c
 @@ -504,7 +504,7 @@ static int hw_base_encode_send_frame(AVCodecContext *avctx, FFHWBaseEncodeContex
- 
+
          // Fix timestamps if we hit end-of-stream before the initial decode
          // delay has elapsed.
 -        if (ctx->input_order <= ctx->decode_delay)
 +        if (ctx->input_order <= ctx->decode_delay && ctx->pic_end)
              ctx->dts_pts_diff = ctx->pic_end->pts - ctx->first_pts;
      }
- 
+

--- a/packages/addons/addon-depends/flatpak-depends/appstream/patches/0001-local-disable-tests.patch
+++ b/packages/addons/addon-depends/flatpak-depends/appstream/patches/0001-local-disable-tests.patch
@@ -1,3 +1,8 @@
+From bc22f89fc0daa2744dd06f9119ea0abae96042fe Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 13 Apr 2026 18:51:12 +0200
+Subject: [PATCH] local disable tests
+
 diff --git a/meson.build b/meson.build
 index e3e71168c85f..9b030a10ea67 100644
 --- a/meson.build

--- a/packages/addons/addon-depends/game-tools/linuxconsoletools/patches/0001-disable-building-ffmvforce.patch
+++ b/packages/addons/addon-depends/game-tools/linuxconsoletools/patches/0001-disable-building-ffmvforce.patch
@@ -1,6 +1,11 @@
-diff -Naur a/utils/Makefile b/utils/Makefile
---- a/utils/Makefile	2022-05-21 09:44:47.000000000 +0000
-+++ b/utils/Makefile	2022-05-21 18:58:51.363206817 +0000
+From 8b36cc8aba405a06f6741622e65ac4e87fe6ea99 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Wed, 01 Feb 2017 13:39:10 -0800
+Subject: [PATCH] disable building ffmvforce
+
+diff --git a/utils/Makefile b/utils/Makefile
+--- a/utils/Makefile
++++ b/utils/Makefile
 @@ -37,7 +37,7 @@
  endif
  

--- a/packages/addons/addon-depends/go/patches/0001-add-ca-cert-location.patch
+++ b/packages/addons/addon-depends/go/patches/0001-add-ca-cert-location.patch
@@ -1,3 +1,8 @@
+From b861a8bb212e5927d310ed4bad26d6a74bc1b61f Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Fri, 22 Apr 2016 01:40:57 -0700
+Subject: [PATCH] add ca cert location
+
 diff --git a/src/crypto/x509/root_linux.go b/src/crypto/x509/root_linux.go
 index ad6ce5cae7..763c686fed 100644
 --- a/src/crypto/x509/root_linux.go

--- a/packages/addons/addon-depends/icu/patches/0001-ldflags.patch
+++ b/packages/addons/addon-depends/icu/patches/0001-ldflags.patch
@@ -1,6 +1,11 @@
-diff -Naur icu4c-67-1/icu-release-67-1/source/config/mh-linux icu4c-67-1-ldflags/icu-release-67-1/source/config/mh-linux
---- icu-release-67-1/source/config/mh-linux	2020-04-22 19:49:10.000000000 +0200
-+++ icu-release-67-1.ldflags/source/config/mh-linux	2020-09-05 17:58:05.635014182 +0200
+From 20cb0d64473ce69b50ebbb3b51f6287c0cf558f3 Mon Sep 17 00:00:00 2001
+From: thoradia <22841905+thoradia@users.noreply.github.com>
+Date: Fri, 23 Oct 2020 09:59:09 +0200
+Subject: [PATCH] ldflags
+
+diff --git a/source/config/mh-linux b/source/config/mh-linux
+--- a/source/config/mh-linux
++++ b/source/config/mh-linux
 @@ -23,7 +23,7 @@
  LD_RPATH_PRE = -Wl,-rpath,
  

--- a/packages/addons/addon-depends/inadyn/libconfuse/patches/0001-gettext-0.20-libconfuse.patch
+++ b/packages/addons/addon-depends/inadyn/libconfuse/patches/0001-gettext-0.20-libconfuse.patch
@@ -1,5 +1,11 @@
---- libconfuse-3.3/configure.ac	2020-06-25 05:21:59.000000000 +0000
-+++ libconfuse-3.3/configure.ac	2020-12-29 02:04:36.074750823 +0000
+From 358f0bfe3ed41d3895b136501a590ba01e0d4f15 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Tue, 29 Dec 2020 01:55:34 +0000
+Subject: [PATCH] gettext 0.20 libconfuse
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -29,7 +29,8 @@
  # Unfortunately CentOS7, RHEL7 ships 0.18.2.1, so for best compat.
  # level at this point in time we set 0.18.2.

--- a/packages/addons/addon-depends/libhdhomerun/patches/0001-shared-to-static.patch
+++ b/packages/addons/addon-depends/libhdhomerun/patches/0001-shared-to-static.patch
@@ -1,3 +1,9 @@
+From 1dafb9bb0a1eca99a42c5996075b5885586233c5 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Sat, 25 Dec 2021 22:51:16 +0100
+Subject: [PATCH] shared to static
+
+diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -3,6 +3,7 @@

--- a/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/0001-headers.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/0001-headers.patch
@@ -1,3 +1,8 @@
+From 59f7eb7c4001ca7d54e79103a9bb74892ab6c528 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:25:40 -0700
+Subject: [PATCH] headers
+
 diff --git a/tools/mpe2sec/mpe.c b/tools/mpe2sec/mpe.c
 index 18417af..3b71f64 100644
 --- a/tools/mpe2sec/mpe.c

--- a/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/0002-dont-build-dvbobjects.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/opencaster/patches/0002-dont-build-dvbobjects.patch
@@ -1,3 +1,8 @@
+From 59f7eb7c4001ca7d54e79103a9bb74892ab6c528 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:25:40 -0700
+Subject: [PATCH] dont build dvbobjects
+
 diff --git a/libs/Makefile b/libs/Makefile
 index 23d951b..c442057 100755
 --- a/libs/Makefile

--- a/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/0001-build.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/0001-build.patch
@@ -1,5 +1,11 @@
---- a/Makefile	2020-01-08 22:09:15.794660218 +0100
-+++ b/Makefile	2020-01-08 22:09:18.954615301 +0100
+From 16e6e8424c365142af0a5020f15031e36abd07a0 Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 08 Jan 2020 22:58:43 +0100
+Subject: [PATCH] build
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -412,6 +412,9 @@
  # ------------------------------------------------------------
  # Directory creation

--- a/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/0002-crossstrip.patch
+++ b/packages/addons/addon-depends/multimedia-tools-depends/tstools/patches/0002-crossstrip.patch
@@ -1,6 +1,11 @@
-diff -ur a/Makefile b/Makefile
---- a/Makefile	2015-10-30 17:34:51.000000000 +0100
-+++ b/Makefile	2019-12-14 12:58:16.655141460 +0100
+From 7273d940948298b35654da1bfb2ebba767d75d2a Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Sat, 14 Dec 2019 13:15:23 +0100
+Subject: [PATCH] crossstrip
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -43,7 +43,7 @@
  man1dir=$(mandir)/man1
  manext=.1

--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/patches/0001-remove-manpages.patch
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/patches/0001-remove-manpages.patch
@@ -1,5 +1,11 @@
---- libpcap-1.10.0/CMakeLists.txt	2020-12-29 21:16:30.000000000 +0000
-+++ libpcap-1.10.0/CMakeLists.txt	2021-01-02 04:34:31.834695073 +0000
+From 25a14c0c57023e4b0cf589bddb8d9022631c548d Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 27 Dec 2020 09:21:04 +0000
+Subject: [PATCH] remove manpages
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -2689,70 +2689,6 @@
      install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)
      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc DESTINATION lib/pkgconfig)

--- a/packages/addons/addon-depends/network-tools-depends/iftop/patches/0002-boo.patch
+++ b/packages/addons/addon-depends/network-tools-depends/iftop/patches/0002-boo.patch
@@ -1,3 +1,8 @@
+From f9eb76226d4119c0e28938ea2f17cae69ddc805a Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:29:24 -0700
+Subject: [PATCH] boo
+
 diff --git a/configure.ac b/configure.ac
 index 671241e..b6fece6 100644
 --- a/configure.ac

--- a/packages/addons/addon-depends/network-tools-depends/iftop/patches/0003-variable-to-be-local-due-to-pcap-1-10-0.patch
+++ b/packages/addons/addon-depends/network-tools-depends/iftop/patches/0003-variable-to-be-local-due-to-pcap-1-10-0.patch
@@ -1,6 +1,11 @@
-diff -Nuar iftop-77901c8c/iftop-dump.c iftop-pcap-1-10/iftop-dump.c
---- iftop-77901c8c/iftop-dump.c	2018-10-03 17:02:36.000000000 +0000
-+++ iftop-pcap-1-10/iftop-dump.c	2021-01-17 23:40:39.896124155 +0000
+From 8b8dc038b636dd0aae45966cb3d474c88c434bd7 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Mon, 18 Jan 2021 00:02:05 +0000
+Subject: [PATCH] variable to be local due to pcap 1 10 0
+
+diff --git a/iftop-dump.c b/iftop-dump.c
+--- a/iftop-dump.c
++++ b/iftop-dump.c
 @@ -64,7 +64,7 @@
  pthread_mutex_t tick_mutex;
  
@@ -25,9 +30,9 @@ diff -Nuar iftop-77901c8c/iftop-dump.c iftop-pcap-1-10/iftop-dump.c
          return pcap_geterr(pd);
      else
          return NULL;
-diff -Nuar iftop-77901c8c/iftop.c iftop-pcap-1-10/iftop.c
---- iftop-77901c8c/iftop.c	2018-10-03 17:02:36.000000000 +0000
-+++ iftop-pcap-1-10/iftop.c	2021-01-17 23:40:54.116240467 +0000
+diff --git a/iftop.c b/iftop.c
+--- a/iftop.c
++++ b/iftop.c
 @@ -74,7 +74,7 @@
  pthread_mutex_t tick_mutex;
  

--- a/packages/addons/addon-depends/network-tools-depends/lftp/patches/0001-link-readline-with-termcap.patch
+++ b/packages/addons/addon-depends/network-tools-depends/lftp/patches/0001-link-readline-with-termcap.patch
@@ -1,6 +1,11 @@
-diff -Naur a/configure b/configure
---- a/configure	2016-11-16 05:11:30.000000000 -0800
-+++ b/configure	2021-04-17 14:18:59.000000000 +0000
+From 80131787fae3fc7d6842f17c02d87f8c231b60e3 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Sat, 19 Nov 2016 11:26:11 -0800
+Subject: [PATCH] link readline with termcap
+
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
 @@ -55428,7 +55428,7 @@
  	fi
          readline_ld_flags="-L$readline_prefix/lib"

--- a/packages/addons/addon-depends/network-tools-depends/nmap/patches/0001-allow-build-with-automake-1-17.patch
+++ b/packages/addons/addon-depends/network-tools-depends/nmap/patches/0001-allow-build-with-automake-1-17.patch
@@ -1,6 +1,11 @@
-diff -Nur a/libpcre/aclocal.m4 b/libpcre/aclocal.m4
---- a/libpcre/aclocal.m4	2023-06-24 01:53:07.000000000 +0000
-+++ b/libpcre/aclocal.m4	2024-07-29 11:29:45.699525807 +0000
+From 7186f13746896f14a6e6c088977d082777be0d0b Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 29 Jul 2024 11:34:30 +0000
+Subject: [PATCH] allow build with automake 1 17
+
+diff --git a/libpcre/aclocal.m4 b/libpcre/aclocal.m4
+--- a/libpcre/aclocal.m4
++++ b/libpcre/aclocal.m4
 @@ -376,10 +376,10 @@
  # generated from the m4 files accompanying Automake X.Y.
  # (This private macro should not be called outside this file.)
@@ -23,9 +28,9 @@ diff -Nur a/libpcre/aclocal.m4 b/libpcre/aclocal.m4
  m4_ifndef([AC_AUTOCONF_VERSION],
    [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
  _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
-diff -Nur a/libpcre/configure b/libpcre/configure
---- a/libpcre/configure	2024-02-28 16:06:30.000000000 +0000
-+++ b/libpcre/configure	2024-07-29 11:25:14.134081052 +0000
+diff --git a/libpcre/configure b/libpcre/configure
+--- a/libpcre/configure
++++ b/libpcre/configure
 @@ -2895,7 +2895,7 @@
  
  
@@ -35,9 +40,9 @@ diff -Nur a/libpcre/configure b/libpcre/configure
  
  
  
-diff -Nur a/libssh2/aclocal.m4 b/libssh2/aclocal.m4
---- a/libssh2/aclocal.m4	2024-02-28 17:39:06.000000000 +0000
-+++ b/libssh2/aclocal.m4	2024-07-29 11:30:13.873078377 +0000
+diff --git a/libssh2/aclocal.m4 b/libssh2/aclocal.m4
+--- a/libssh2/aclocal.m4
++++ b/libssh2/aclocal.m4
 @@ -32,10 +32,10 @@
  # generated from the m4 files accompanying Automake X.Y.
  # (This private macro should not be called outside this file.)
@@ -60,9 +65,9 @@ diff -Nur a/libssh2/aclocal.m4 b/libssh2/aclocal.m4
  m4_ifndef([AC_AUTOCONF_VERSION],
    [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
  _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
-diff -Nur a/libssh2/configure b/libssh2/configure
---- a/libssh2/configure	2024-02-28 17:39:06.000000000 +0000
-+++ b/libssh2/configure	2024-07-29 11:25:39.590945455 +0000
+diff --git a/libssh2/configure b/libssh2/configure
+--- a/libssh2/configure
++++ b/libssh2/configure
 @@ -3243,7 +3243,7 @@
  fi
  

--- a/packages/addons/addon-depends/network-tools-depends/rar2fs/patches/0001-remove-man-pages-1.29.3.patch
+++ b/packages/addons/addon-depends/network-tools-depends/rar2fs/patches/0001-remove-man-pages-1.29.3.patch
@@ -1,6 +1,11 @@
-diff -Nur rar2fs-1.29.3.orig/Makefile.am rar2fs-1.29.3/Makefile.am
---- rar2fs-1.29.3.orig/Makefile.am	2020-11-08 19:41:41.000000000 +0000
-+++ rar2fs-1.29.3/Makefile.am	2021-01-01 11:33:42.609539322 +0000
+From c2617855a8f3557d193acc7507fec4b6f433227d Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Wed, 30 Dec 2020 11:59:40 +0000
+Subject: [PATCH] remove man pages 1.29.3
+
+diff --git a/Makefile.am b/Makefile.am
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -1,4 +1,4 @@
  ACLOCAL_AMFLAGS = -I m4
 -SUBDIRS = src man

--- a/packages/addons/addon-depends/podman/netavark/patches/0001-no-docs.patch
+++ b/packages/addons/addon-depends/podman/netavark/patches/0001-no-docs.patch
@@ -1,5 +1,11 @@
---- a/Makefile	2024-05-30 14:20:33.000000000 +0000
-+++ b/Makefile	2024-06-01 01:36:21.083916685 +0000
+From c9683fa5240594eab7d2f4a685b469ca5ad9e358 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 05 Feb 2023 14:08:47 +0000
+Subject: [PATCH] no docs
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -96,7 +96,6 @@
  .PHONY: install
  install: $(NV_UNIT_FILES)

--- a/packages/addons/addon-depends/podman/podman-bin/patches/0001-path-changes.patch
+++ b/packages/addons/addon-depends/podman/podman-bin/patches/0001-path-changes.patch
@@ -1,3 +1,8 @@
+From 79562db355cfedba14af84aa204f16015dbbb403 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 05 Feb 2023 09:36:17 +0000
+Subject: [PATCH] path changes
+
 diff --git a/pkg/rootless/rootless_linux.c b/pkg/rootless/rootless_linux.c
 index 7e8b3f78a..1a27842fd 100644
 --- a/pkg/rootless/rootless_linux.c

--- a/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/0001-dont-build-doc-and-examples.patch
+++ b/packages/addons/addon-depends/system-tools-depends/depends/libmtp/patches/0001-dont-build-doc-and-examples.patch
@@ -1,3 +1,9 @@
+From 285e221c5d392f0d118a138426ef145b071adc4c Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:37:14 -0700
+Subject: [PATCH] dont build doc and examples
+
+diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -1,4 +1,4 @@
@@ -6,6 +12,7 @@
  ACLOCAL_AMFLAGS=-I m4
  
  pkgconfigdir=$(libdir)/pkgconfig
+diff --git a/Makefile.in b/Makefile.in
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -166,7 +166,7 @@ am__uninstall_files_from_dir = { \

--- a/packages/addons/addon-depends/system-tools-depends/hd-idle/patches/0001-makefile.patch
+++ b/packages/addons/addon-depends/system-tools-depends/hd-idle/patches/0001-makefile.patch
@@ -1,3 +1,8 @@
+From a12648520ae79d44bd056a22e6a3173ecb45ffa9 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:37:14 -0700
+Subject: [PATCH] makefile
+
 diff --git a/Makefile b/Makefile
 index 130afd8..480032e 100644
 --- a/Makefile

--- a/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/0001-crosscompile.patch
+++ b/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/0001-crosscompile.patch
@@ -1,3 +1,8 @@
+From 41e6173800b1cb9bc820506363cc1bd51fc3f16d Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:37:14 -0700
+Subject: [PATCH] crosscompile
+
 diff --git a/Makefile b/Makefile
 index f98abbd..9d1d524 100755
 --- a/Makefile

--- a/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/0003-include-sys-time.patch
+++ b/packages/addons/addon-depends/system-tools-depends/hid_mapper/patches/0003-include-sys-time.patch
@@ -1,3 +1,8 @@
+From 41e6173800b1cb9bc820506363cc1bd51fc3f16d Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Mon, 25 Apr 2016 10:37:14 -0700
+Subject: [PATCH] include sys time
+
 diff --git a/hid.c b/hid.c
 index 2830b58..a652222 100644
 --- a/hid.c

--- a/packages/addons/addon-depends/system-tools-depends/screen/patches/0001-rename-pty-h-to-screen-pty-h.patch
+++ b/packages/addons/addon-depends/system-tools-depends/screen/patches/0001-rename-pty-h-to-screen-pty-h.patch
@@ -1,6 +1,11 @@
-diff -Nu screen-5.0.0/display.c screen-5.0.0/display.c
---- screen-5.0.0/display.c	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/display.c	2024-08-29 18:08:34.942979909 +0000
+From 932bb3d666b6ae281dbdf265947bbc275f666dd8 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 29 Aug 2024 09:49:06 +0000
+Subject: [PATCH] rename pty.h to screen-pty.h
+
+diff --git a/display.c b/display.c
+--- a/display.c
++++ b/display.c
 @@ -47,7 +47,7 @@
  #include "mark.h"
  #include "misc.h"
@@ -10,9 +15,9 @@ diff -Nu screen-5.0.0/display.c screen-5.0.0/display.c
  #include "resize.h"
  #include "termcap.h"
  #include "tty.h"
-diff -Nu screen-5.0.0/Makefile.in screen-5.0.0/Makefile.in
---- screen-5.0.0/Makefile.in	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/Makefile.in	2024-08-29 18:10:05.120409357 +0000
+diff --git a/Makefile.in b/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
 @@ -66,7 +66,7 @@
  	$(CC) $(LDFLAGS) -o $@ $(OFILES) $(LIBS)
  
@@ -46,9 +51,9 @@ diff -Nu screen-5.0.0/Makefile.in screen-5.0.0/Makefile.in
  comm.o: comm.c config.h os.h screen.h ansi.h sched.h acls.h comm.h \
   layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
   logfile.h
-diff -Nu screen-5.0.0/pty.c screen-5.0.0/pty.c
---- screen-5.0.0/pty.c	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/pty.c	2024-08-29 18:09:06.889919017 +0000
+diff --git a/pty.c b/pty.c
+--- a/pty.c
++++ b/pty.c
 @@ -28,7 +28,7 @@
  
  #include "config.h"
@@ -58,9 +63,9 @@ diff -Nu screen-5.0.0/pty.c screen-5.0.0/pty.c
  
  #include <sys/ioctl.h>
  
-diff -Nu screen-5.0.0/pty.h screen-5.0.0/pty.h
---- screen-5.0.0/pty.h	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/pty.h	1970-01-01 00:00:00.000000000 +0000
+diff --git a/pty.h b/pty.h
+--- a/pty.h
++++ b/pty.h
 @@ -1,11 +0,0 @@
 -#ifndef SCREEN_PTY_H
 -#define SCREEN_PTY_H
@@ -73,9 +78,9 @@ diff -Nu screen-5.0.0/pty.h screen-5.0.0/pty.h
 -extern int pty_preopen;
 -
 -#endif /* SCREEN_PTY_H */
-diff -Nu screen-5.0.0/screen-pty.h screen-5.0.0/screen-pty.h
---- screen-5.0.0/screen-pty.h	1970-01-01 00:00:00.000000000 +0000
-+++ screen-5.0.0/screen-pty.h	2024-08-28 19:55:03.000000000 +0000
+diff --git a/screen-pty.h b/screen-pty.h
+--- a/screen-pty.h
++++ b/screen-pty.h
 @@ -0,0 +1,11 @@
 +#ifndef SCREEN_PTY_H
 +#define SCREEN_PTY_H
@@ -88,9 +93,9 @@ diff -Nu screen-5.0.0/screen-pty.h screen-5.0.0/screen-pty.h
 +extern int pty_preopen;
 +
 +#endif /* SCREEN_PTY_H */
-diff -Nu screen-5.0.0/tty.c screen-5.0.0/tty.c
---- screen-5.0.0/tty.c	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/tty.c	2024-08-29 18:09:19.073355563 +0000
+diff --git a/tty.c b/tty.c
+--- a/tty.c
++++ b/tty.c
 @@ -44,7 +44,7 @@
  #include "screen.h"
  #include "fileio.h"
@@ -100,9 +105,9 @@ diff -Nu screen-5.0.0/tty.c screen-5.0.0/tty.c
  #include "telnet.h"
  #include "tty.h"
  
-diff -Nu screen-5.0.0/window.c screen-5.0.0/window.c
---- screen-5.0.0/window.c	2024-08-28 19:55:03.000000000 +0000
-+++ screen-5.0.0/window.c	2024-08-29 18:14:12.542433618 +0000
+diff --git a/window.c b/window.c
+--- a/window.c
++++ b/window.c
 @@ -48,7 +48,7 @@
  #include "mark.h"
  #include "misc.h"

--- a/packages/addons/addon-depends/system-tools-depends/st/patches/0001-le-fixes.patch
+++ b/packages/addons/addon-depends/system-tools-depends/st/patches/0001-le-fixes.patch
@@ -1,9 +1,16 @@
+From b03dd0a9e1380ca0d856ce5757c98f5276031216 Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Fri, 25 Dec 2020 16:15:09 +0100
+Subject: [PATCH] le fixes
+
 
  - XftColorAllocName() is failing on "#rrggbb", use XParseColor()
  - Xutf8TextListToTextProperty() needs locale to be set.
 
---- a/x.c	2020-06-19 11:29:45.000000000 +0200
-+++ b/x.c	2020-06-26 01:07:13.000000000 +0200
+---
+diff --git a/x.c b/x.c
+--- a/x.c
++++ b/x.c
 @@ -754,6 +754,7 @@
  xloadcolor(int i, const char *name, Color *ncolor)
  {

--- a/packages/addons/addon-depends/system-tools-depends/st/patches/0002-scrollback-20200419-72e3f6c.patch
+++ b/packages/addons/addon-depends/system-tools-depends/st/patches/0002-scrollback-20200419-72e3f6c.patch
@@ -1,3 +1,8 @@
+From b03dd0a9e1380ca0d856ce5757c98f5276031216 Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Fri, 25 Dec 2020 16:15:09 +0100
+Subject: [PATCH] scrollback 20200419 72e3f6c
+
 diff --git a/config.def.h b/config.def.h
 index 0895a1f..eef24df 100644
 --- a/config.def.h

--- a/packages/addons/service/boblightd/patches/0001-2.0.5-getopt-includes.patch
+++ b/packages/addons/service/boblightd/patches/0001-2.0.5-getopt-includes.patch
@@ -1,3 +1,8 @@
+From aac212f307fa25a643d7f86bd5cc1d1eabcf3969 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 13 Apr 2012 21:41:41 +0300
+Subject: [PATCH] 2.0.5 getopt includes
+
 diff --git a/src/clients/flagmanager.cpp b/src/clients/flagmanager.cpp
 index d9f3cbf..82eb978 100644
 --- a/src/clients/flagmanager.cpp

--- a/packages/addons/service/hyperion/patches/0003-fix-protobuf-cmake.patch
+++ b/packages/addons/service/hyperion/patches/0003-fix-protobuf-cmake.patch
@@ -1,3 +1,8 @@
+From 751854c996d81bb5f792aa9fa40a558a3042db28 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Wed, 09 Nov 2016 23:29:08 -0800
+Subject: [PATCH] fix protobuf cmake
+
 diff --git a/dependencies/CMakeLists.txt b/dependencies/CMakeLists.txt
 index fe3d463..6ae8760 100644
 --- a/dependencies/CMakeLists.txt

--- a/packages/addons/service/lcdd/patches/0001-0.5.6-dm140-henlar-v0.2.patch
+++ b/packages/addons/service/lcdd/patches/0001-0.5.6-dm140-henlar-v0.2.patch
@@ -1,3 +1,8 @@
+From 46b61328aaae17ec32b2c44614f4c9eb2216f1d4 Mon Sep 17 00:00:00 2001
+From: awiouy <awiouy@gmail.com>
+Date: Wed, 11 Jan 2017 00:41:26 +0100
+Subject: [PATCH] 0.5.6 dm140 henlar v0.2
+
 diff --git a/LCDd.conf b/LCDd.conf
 index 80be77e..35d53af 100644
 --- a/LCDd.conf

--- a/packages/addons/service/mariadb/patches/0002--fix-gcc14-build.patch
+++ b/packages/addons/service/mariadb/patches/0002--fix-gcc14-build.patch
@@ -1,5 +1,11 @@
---- a/tests/async_queries.c	2024-05-17 14:42:48.465859634 +0000
-+++ b/tests/async_queries.c	2024-05-17 14:42:36.322436756 +0000
+From b1feb5dbe365179cf1e5dc210ba4f180044bae55 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 17 May 2024 14:49:46 +0000
+Subject: [PATCH]  fix gcc14 build
+
+diff --git a/tests/async_queries.c b/tests/async_queries.c
+--- a/tests/async_queries.c
++++ b/tests/async_queries.c
 @@ -31,7 +31,9 @@
  #include <stdio.h>
  #include <string.h>

--- a/packages/addons/service/minidlna/patches/0001-fix-config.patch
+++ b/packages/addons/service/minidlna/patches/0001-fix-config.patch
@@ -1,4 +1,12 @@
+From 539f908adbc83d753828c259d5f5b128fb49414c Mon Sep 17 00:00:00 2001
+From: cvh <namerp@googlemail.com>
+Date: Thu, 25 Jan 2018 15:14:05 +0100
+Subject: [PATCH] fix config
+
 disabling editing of the configfiles at buildtime
+
+---
+diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -73,19 +73,6 @@ testupnpdescgen_LDADD = \

--- a/packages/addons/service/minidlna/patches/0002-ffmpeg7.patch
+++ b/packages/addons/service/minidlna/patches/0002-ffmpeg7.patch
@@ -1,5 +1,11 @@
---- a/libav.h	2023-05-31 09:25:59.000000000 +0100
-+++ b/libav.h	2024-11-30 21:51:58.063500472 +0000
+From 996bb4a713804a4032deaa7f936ab5b5be9da6ee Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 16 Dec 2024 10:26:20 +0000
+Subject: [PATCH] ffmpeg7
+
+diff --git a/libav.h b/libav.h
+--- a/libav.h
++++ b/libav.h
 @@ -174,7 +174,9 @@
  #define lav_codec_tag(s) s->codecpar->codec_tag
  #define lav_sample_rate(s) s->codecpar->sample_rate

--- a/packages/addons/service/mpd/patches/9999-link-against-static-libopenmpt.patch
+++ b/packages/addons/service/mpd/patches/9999-link-against-static-libopenmpt.patch
@@ -1,5 +1,11 @@
---- a/src/decoder/plugins/meson.build	2024-12-03 11:56:57.000000000 +0000
-+++ b/src/decoder/plugins/meson.build	2024-12-30 14:15:29.590502435 +0000
+From 01057f7522b4176b8de312678a6db6635df96275 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 30 Dec 2024 14:19:07 +0000
+Subject: [PATCH] link against static libopenmpt
+
+diff --git a/src/decoder/plugins/meson.build b/src/decoder/plugins/meson.build
+--- a/src/decoder/plugins/meson.build
++++ b/src/decoder/plugins/meson.build
 @@ -110,7 +110,7 @@
    ]
  endif

--- a/packages/addons/service/net-snmp/patches/0001-read-config.c.patch
+++ b/packages/addons/service/net-snmp/patches/0001-read-config.c.patch
@@ -1,5 +1,11 @@
---- a/snmplib/read_config.c	2014-12-08 14:23:22.000000000 -0600
-+++ b/snmplib/read_config.c	2017-03-30 12:21:16.351042803 -0500
+From dd6e075490cd39b706194f731a506058a3c5d131 Mon Sep 17 00:00:00 2001
+From: lsellens <lsellens@gmail.com>
+Date: Sat, 01 Apr 2017 19:09:58 -0500
+Subject: [PATCH] read config.c
+
+diff --git a/snmplib/read_config.c b/snmplib/read_config.c
+--- a/snmplib/read_config.c
++++ b/snmplib/read_config.c
 @@ -1642,7 +1642,7 @@
       * save a warning header to the top of the new file 
       */

--- a/packages/addons/service/net-snmp/patches/0002-net-snmp-create-v3-user.in.patch
+++ b/packages/addons/service/net-snmp/patches/0002-net-snmp-create-v3-user.in.patch
@@ -1,5 +1,11 @@
---- net-snmp-5.9/net-snmp-create-v3-user.in	2020-08-14 21:41:47.000000000 +0000
-+++ net-snmp-5.9/net-snmp-create-v3-user.in	2021-01-14 07:04:26.196982169 +0000
+From dd6e075490cd39b706194f731a506058a3c5d131 Mon Sep 17 00:00:00 2001
+From: lsellens <lsellens@gmail.com>
+Date: Sat, 01 Apr 2017 19:09:58 -0500
+Subject: [PATCH] net snmp create v3 user.in
+
+diff --git a/net-snmp-create-v3-user.in b/net-snmp-create-v3-user.in
+--- a/net-snmp-create-v3-user.in
++++ b/net-snmp-create-v3-user.in
 @@ -3,10 +3,8 @@
  # this shell script is designed to add new SNMPv3 users
  # to Net-SNMP config file.

--- a/packages/addons/service/proftpd/patches/0100-llu.patch
+++ b/packages/addons/service/proftpd/patches/0100-llu.patch
@@ -1,6 +1,11 @@
-diff -urN proftpd-1.3.4d-org/include/conf.h proftpd-1.3.4d-new/include/conf.h
---- proftpd-1.3.4d-org/include/conf.h	2011-05-23 22:35:35.000000000 +0200
-+++ proftpd-1.3.4d-new/include/conf.h	2013-07-20 12:25:28.000000000 +0200
+From 47eb715e7638e4a346a27c4153f0d09d3f3c5dcb Mon Sep 17 00:00:00 2001
+From: cvh <namerp@googlemail.com>
+Date: Wed, 07 Dec 2016 12:30:17 +0100
+Subject: [PATCH] llu
+
+diff --git a/include/conf.h b/include/conf.h
+--- a/include/conf.h
++++ b/include/conf.h
 @@ -360,13 +360,9 @@
  
  #endif

--- a/packages/addons/service/tigervnc/patches/0001-system-notests.patch
+++ b/packages/addons/service/tigervnc/patches/0001-system-notests.patch
@@ -1,5 +1,11 @@
---- a/CMakeLists.txt	2017-06-12 12:08:55.347685243 +0000
-+++ b/CMakeLists.txt	2017-06-12 12:09:01.337595834 +0000
+From 16688751818f9afd75334de925497a97c0d472d7 Mon Sep 17 00:00:00 2001
+From: awiouy <awiouy@gmail.com>
+Date: Fri, 09 Jun 2017 21:28:12 +0200
+Subject: [PATCH] system notests
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -300,7 +300,6 @@
    add_subdirectory(media)
  endif()

--- a/packages/audio/alsa-utils/patches/0001-gettext-fix.patch
+++ b/packages/audio/alsa-utils/patches/0001-gettext-fix.patch
@@ -1,5 +1,11 @@
---- a/configure.ac	2024-11-12 09:47:31.000000000 +0000
-+++ b/configure.ac	2025-02-28 21:46:40.319313458 +0000
+From 719a1064b41517ab5c0ce0264b1c9098b1c0211f Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 28 Feb 2025 21:51:37 +0000
+Subject: [PATCH] gettext fix
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -8,7 +8,7 @@
  AM_MAINTAINER_MODE([enable])
  

--- a/packages/audio/fluidsynth/patches/0001-libsndfile-use-static-libraries.patch
+++ b/packages/audio/fluidsynth/patches/0001-libsndfile-use-static-libraries.patch
@@ -1,3 +1,9 @@
+From 230cd0deecb8bc53a4d8023b1c54326a16c640f8 Mon Sep 17 00:00:00 2001
+From: heitbaum <6086324+heitbaum@users.noreply.github.com>
+Date: Wed, 18 Nov 2020 10:17:54 +0000
+Subject: [PATCH] libsndfile use static libraries
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -604,6 +604,7 @@ if ( enable-libsndfile )

--- a/packages/audio/libsndfile/patches/0001-add-required-static-libaries-to-pkg-config.patch
+++ b/packages/audio/libsndfile/patches/0001-add-required-static-libaries-to-pkg-config.patch
@@ -1,5 +1,11 @@
---- a/sndfile.pc.in	2021-01-24 23:22:23.000000000 +1100
-+++ b/sndfile.pc.in	2021-09-12 14:30:47.763655089 +1000
+From b2881a1cb8328399302518802d3ecc8facdf30b2 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 12 Sep 2021 11:56:35 +1000
+Subject: [PATCH] add required static libaries to pkg config
+
+diff --git a/sndfile.pc.in b/sndfile.pc.in
+--- a/sndfile.pc.in
++++ b/sndfile.pc.in
 @@ -8,6 +8,6 @@
  Requires:
  Requires.private: @EXTERNAL_XIPH_REQUIRE@ @EXTERNAL_MPEG_REQUIRE@

--- a/packages/audio/libsndfile/patches/1073-build-with-cmake-4.0.0.patch
+++ b/packages/audio/libsndfile/patches/1073-build-with-cmake-4.0.0.patch
@@ -1,3 +1,8 @@
+From a0d0a9321b89ebe3b7cfcc3a4b034fc16245e0a6 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 28 Mar 2025 05:37:29 +0000
+Subject: [PATCH] build with cmake 4.0.0
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e3d91c0ea..c41bbce03 100644
 --- a/CMakeLists.txt

--- a/packages/audio/pulseaudio/patches/1002-check-uid.patch
+++ b/packages/audio/pulseaudio/patches/1002-check-uid.patch
@@ -1,5 +1,11 @@
---- pulseaudio-4.0.orig/src/pulsecore/core-util.c	2014-01-12 23:31:26.281525000 -0800
-+++ pulseaudio-4.0/src/pulsecore/core-util.c	2014-01-12 23:32:32.977118803 -0800
+From 2e94f15c5206f15d0770e91144c481784818e7fb Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Fri, 16 Oct 2015 11:42:39 -0700
+Subject: [PATCH] check uid
+
+diff --git a/src/pulsecore/core-util.c b/src/pulsecore/core-util.c
+--- a/src/pulsecore/core-util.c
++++ b/src/pulsecore/core-util.c
 @@ -1447,10 +1447,6 @@
      if (stat(p, &st) < 0)
          return -errno;

--- a/packages/audio/sidplay-libs/patches/0001-m4-tests.patch
+++ b/packages/audio/sidplay-libs/patches/0001-m4-tests.patch
@@ -1,5 +1,12 @@
---- sidplay-libs-2.1.1/libsidplay/unix/my_macros.m4.orig	2004-06-14 22:08:04.000000000 +0200
-+++ sidplay-libs-2.1.1/libsidplay/unix/my_macros.m4	2013-11-18 01:23:32.195297135 +0100
+From 115fe45bc91b86b54c61de5e5d230484e6fc8901 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 03 Apr 2015 12:19:38 +0300
+Subject: [PATCH] m4 tests
+
+---
+diff --git a/libsidplay/unix/my_macros.m4 b/libsidplay/unix/my_macros.m4
+--- a/libsidplay/unix/my_macros.m4
++++ b/libsidplay/unix/my_macros.m4
 @@ -80,8 +80,8 @@
      AC_CACHE_VAL(test_cv_have_ios_binary,
      [

--- a/packages/audio/sidplay-libs/patches/0002-inherited.patch
+++ b/packages/audio/sidplay-libs/patches/0002-inherited.patch
@@ -1,5 +1,12 @@
---- sidplay-libs-2.1.1/libsidplay/include/sidplay/SmartPtr.h.old	2013-11-18 00:40:16.679173012 +0100
-+++ sidplay-libs-2.1.1/libsidplay/include/sidplay/SmartPtr.h	2013-11-18 00:41:22.451176157 +0100
+From 115fe45bc91b86b54c61de5e5d230484e6fc8901 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 03 Apr 2015 12:19:38 +0300
+Subject: [PATCH] inherited
+
+---
+diff --git a/libsidplay/include/sidplay/SmartPtr.h b/libsidplay/include/sidplay/SmartPtr.h
+--- a/libsidplay/include/sidplay/SmartPtr.h
++++ b/libsidplay/include/sidplay/SmartPtr.h
 @@ -211,16 +211,16 @@
  	{
  		if ( bufferLen >= 1 )

--- a/packages/audio/sidplay-libs/patches/0003-operator.patch
+++ b/packages/audio/sidplay-libs/patches/0003-operator.patch
@@ -1,5 +1,12 @@
---- sidplay-libs-2.1.1/libsidutils/include/sidplay/utils/SidUsage.h.orig	2013-11-18 00:58:06.111224154 +0100
-+++ sidplay-libs-2.1.1/libsidutils/include/sidplay/utils/SidUsage.h	2013-11-18 00:58:28.219225212 +0100
+From 115fe45bc91b86b54c61de5e5d230484e6fc8901 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 03 Apr 2015 12:19:38 +0300
+Subject: [PATCH] operator
+
+---
+diff --git a/libsidutils/include/sidplay/utils/SidUsage.h b/libsidutils/include/sidplay/utils/SidUsage.h
+--- a/libsidutils/include/sidplay/utils/SidUsage.h
++++ b/libsidutils/include/sidplay/utils/SidUsage.h
 @@ -33,7 +33,7 @@
      uint_least16_t length;  // usage scan length
  

--- a/packages/audio/sidplay-libs/patches/0004-includes.patch
+++ b/packages/audio/sidplay-libs/patches/0004-includes.patch
@@ -1,5 +1,12 @@
---- sidplay-libs-2.1.1/builders/hardsid-builder/src/hardsid-builder.cpp.orig	2004-06-14 22:07:57.000000000 +0200
-+++ sidplay-libs-2.1.1/builders/hardsid-builder/src/hardsid-builder.cpp	2013-11-18 01:01:50.399234880 +0100
+From 115fe45bc91b86b54c61de5e5d230484e6fc8901 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 03 Apr 2015 12:19:38 +0300
+Subject: [PATCH] includes
+
+---
+diff --git a/builders/hardsid-builder/src/hardsid-builder.cpp b/builders/hardsid-builder/src/hardsid-builder.cpp
+--- a/builders/hardsid-builder/src/hardsid-builder.cpp
++++ b/builders/hardsid-builder/src/hardsid-builder.cpp
 @@ -55,6 +55,7 @@
  
  #include "hardsid.h"
@@ -8,8 +15,9 @@
  
  
  #ifdef HAVE_MSWINDOWS
---- sidplay-libs-2.1.1/builders/resid-builder/src/resid.cpp.orig	2013-11-18 01:00:07.827229975 +0100
-+++ sidplay-libs-2.1.1/builders/resid-builder/src/resid.cpp	2013-11-18 01:00:21.563230632 +0100
+diff --git a/builders/resid-builder/src/resid.cpp b/builders/resid-builder/src/resid.cpp
+--- a/builders/resid-builder/src/resid.cpp
++++ b/builders/resid-builder/src/resid.cpp
 @@ -24,6 +24,7 @@
  
  #include "resid.h"
@@ -18,8 +26,9 @@
  
  
  char ReSID::m_credit[];
---- sidplay-libs-2.1.1/builders/resid-builder/src/resid-builder.cpp.orig	2013-11-18 01:00:39.727231501 +0100
-+++ sidplay-libs-2.1.1/builders/resid-builder/src/resid-builder.cpp	2013-11-18 01:00:57.415232346 +0100
+diff --git a/builders/resid-builder/src/resid-builder.cpp b/builders/resid-builder/src/resid-builder.cpp
+--- a/builders/resid-builder/src/resid-builder.cpp
++++ b/builders/resid-builder/src/resid-builder.cpp
 @@ -45,6 +45,7 @@
  
  #include "resid.h"

--- a/packages/audio/soxr/patches/0001-build-with-cmake-4.0.0.patch
+++ b/packages/audio/soxr/patches/0001-build-with-cmake-4.0.0.patch
@@ -1,5 +1,11 @@
---- a/CMakeLists.txt	2018-02-23 21:39:25.000000000 +0000
-+++ b/CMakeLists.txt	2025-03-28 00:22:35.418513539 +0000
+From fc615b6b2c8ad4810b78eef2d90fa2e52ecc342d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 28 Mar 2025 00:25:41 +0000
+Subject: [PATCH] build with cmake 4.0.0
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -1,7 +1,7 @@
  # SoX Resampler Library       Copyright (c) 2007-18 robs@users.sourceforge.net
  # Licence for this file: LGPL v2.1                  See LICENCE for details.

--- a/packages/compress/7-zip/patches/0008-Fix-Globally-suppress-GCC-16-Warray-bounds-false-pos.patch
+++ b/packages/compress/7-zip/patches/0008-Fix-Globally-suppress-GCC-16-Warray-bounds-false-pos.patch
@@ -1,9 +1,10 @@
+From 5af19526e44a45b15ababaa1e2c0b9d059027ee1 Mon Sep 17 00:00:00 2001
 From: YOKOTA Hiroshi <yokota.hgml@gmail.com>
 Date: Sun, 29 Mar 2026 15:08:33 +0900
-Subject: Fix: Globally suppress GCC 16+ -Warray-bounds false positives
- (Closes: #1132057)
+Subject: [PATCH] Fix: Globally suppress GCC 16+ -Warray-bounds false positives
 
 Forwarded: https://sourceforge.net/p/sevenzip/bugs/2604/
+Closes: #1132057
 
 [ Description ]
 Switching from local pragma fixes to global suppression for the

--- a/packages/compress/lzo/patches/0001-build-with-cmake-4.0.0.patch
+++ b/packages/compress/lzo/patches/0001-build-with-cmake-4.0.0.patch
@@ -1,5 +1,11 @@
---- a/CMakeLists.txt	2017-03-01 19:54:14.000000000 +0000
-+++ b/CMakeLists.txt	2025-03-27 23:36:08.260236301 +0000
+From 09d47b7fb876366f203d4af4ae382419c52210e1 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 27 Mar 2025 23:37:48 +0000
+Subject: [PATCH] build with cmake 4.0.0
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -8,7 +8,7 @@
  # All Rights Reserved.
  #

--- a/packages/databases/sqlite/patches/0001-always-use-memory-for-tempfiles.patch
+++ b/packages/databases/sqlite/patches/0001-always-use-memory-for-tempfiles.patch
@@ -10,6 +10,7 @@ Signed-off-by: Stefan Saraev <stefan@saraev.ca>
  sqlite3.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
+diff --git a/sqlite3.c b/sqlite3.c
 --- a/sqlite3.c
 +++ b/sqlite3.c
 @@ -45760,7 +45760,7 @@ static void unixRemapfile(

--- a/packages/debug/libunwind/patches/0002-add-dependant-static-libraries.patch
+++ b/packages/debug/libunwind/patches/0002-add-dependant-static-libraries.patch
@@ -1,5 +1,11 @@
---- a/src/unwind/libunwind.pc.in	2020-11-10 16:14:18.000000000 +0000
-+++ b/src/unwind/libunwind.pc.in	2021-12-05 08:16:04.467881118 +0000
+From e6169384f54b885a726643091f3b20310b27d9c8 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 05 Dec 2021 08:20:11 +0000
+Subject: [PATCH] add dependant static libraries
+
+diff --git a/src/unwind/libunwind.pc.in b/src/unwind/libunwind.pc.in
+--- a/src/unwind/libunwind.pc.in
++++ b/src/unwind/libunwind.pc.in
 @@ -6,6 +6,6 @@
  Name: libunwind
  Description: libunwind base library

--- a/packages/debug/memtester/patches/0001-cross-compile.patch
+++ b/packages/debug/memtester/patches/0001-cross-compile.patch
@@ -1,28 +1,30 @@
-Author: Helmut Grohne <helmut@subdivi.de>
-Description: make the build system honor $CC to facilitate cross builds
+From 26ba408a60c127da729b97ee026ee7d8b253eab1 Mon Sep 17 00:00:00 2001
+From: Helmut Grohne <helmut@subdivi.de>
+Date: Fri, 13 Apr 2018 10:15:06 +0200
+Subject: [PATCH] cross compile
 
-Index: memtester-4.3.0/conf-cc
-===================================================================
---- memtester-4.3.0.orig/conf-cc	2012-06-09 23:45:22.000000000 +0200
-+++ memtester-4.3.0/conf-cc	2015-09-12 20:36:27.000000000 +0200
+make the build system honor $CC to facilitate cross builds
+
+---
+diff --git a/conf-cc b/conf-cc
+--- a/conf-cc
++++ b/conf-cc
 @@ -1,3 +1,3 @@
 -cc -O2 -DPOSIX -D_POSIX_C_SOURCE=200809L -D_FILE_OFFSET_BITS=64 -DTEST_NARROW_WRITES -c
 +$CC -O2 -DPOSIX -D_POSIX_C_SOURCE=200809L -D_FILE_OFFSET_BITS=64 -DTEST_NARROW_WRITES -c
  
  This will be used to compile .c files.
-Index: memtester-4.3.0/conf-ld
-===================================================================
---- memtester-4.3.0.orig/conf-ld	2012-06-09 23:45:22.000000000 +0200
-+++ memtester-4.3.0/conf-ld	2015-09-12 20:36:33.000000000 +0200
+diff --git a/conf-ld b/conf-ld
+--- a/conf-ld
++++ b/conf-ld
 @@ -1,3 +1,3 @@
 -cc -s
 +$CC -s
  
  This will be used to link .o files into an executable.
-Index: memtester-4.3.0/Makefile
-===================================================================
---- memtester-4.3.0.orig/Makefile	2015-09-12 20:01:06.000000000 +0200
-+++ memtester-4.3.0/Makefile	2015-09-12 20:50:40.000000000 +0200
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -10,8 +10,6 @@
  # You don't need to edit these; change the contents of the conf-cc and conf-ld
  # files if you need to change the compile/link commands.  See the README for

--- a/packages/debug/strace/patches/0001-autoreconf.patch
+++ b/packages/debug/strace/patches/0001-autoreconf.patch
@@ -1,3 +1,8 @@
+From 25004b1bd93e9e61e802b80dba4b6e60a0d40ed2 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Mon, 27 Jan 2020 08:42:13 +0000
+Subject: [PATCH] autoreconf
+
 diff --git a/configure.ac b/configure.ac
 index 4e7bc2a89..3b762c94c 100644
 --- a/configure.ac

--- a/packages/devel/autoconf/patches/0001-man-exclude.patch
+++ b/packages/devel/autoconf/patches/0001-man-exclude.patch
@@ -1,3 +1,9 @@
+From 5f2281d3e2851549596c780466ba3c3364246168 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Fri, 29 Jan 2021 14:22:18 +0000
+Subject: [PATCH] man exclude
+
+diff --git a/Makefile.in b/Makefile.in
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -789,7 +789,6 @@ dist_man_MANS = \

--- a/packages/devel/binutils/patches/0001-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/0001-warn-for-uses-of-system-directories-when-link.patch
@@ -1,3 +1,8 @@
+From 7ab8e318659eb5d9adc758c78d084a95560b93fd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 15 Jan 2016 06:31:09 +0000
+Subject: [PATCH] warn for uses of system directories when cross linking
+
 simplified patch based on
 http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-devtools/binutils/binutils/0009-warn-for-uses-of-system-directories-when-cross-linki.patch
 just detect and skip system directories if used by mistake
@@ -5,17 +10,14 @@ just detect and skip system directories if used by mistake
 linker output in case of using /usr/lib path:
 /data/LibreELEC.tv/build.LibreELEC-Generic.x86_64-8.0-devel/toolchain/lib/gcc/x86_64-libreelec-linux-gnu/6.2.0/../../../../x86_64-libreelec-linux-gnu/bin/ld: warning: library search path "/usr/lib" is unsafe for cross-compilation, ignore it
 
-From 7ab8e318659eb5d9adc758c78d084a95560b93fd Mon Sep 17 00:00:00 2001
-From: Khem Raj <raj.khem@gmail.com>
-Date: Fri, 15 Jan 2016 06:31:09 +0000
-Subject: [PATCH 09/13] warn for uses of system directories when cross linking
-
+---
+diff --git a/ld/ldfile.c b/ld/ldfile.c
 --- a/ld/ldfile.c
 +++ b/ld/ldfile.c
 @@ -312,6 +312,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
      return;
- 
+
 +  /* skip those directories when linking */
 +  if ((!strncmp (name, "/lib", 4)) ||
 +      (!strncmp (name, "/usr/lib", 8)) ||

--- a/packages/devel/binutils/patches/0002-binutils-2-39-dont-error-on-missing-makeinfo.patch
+++ b/packages/devel/binutils/patches/0002-binutils-2-39-dont-error-on-missing-makeinfo.patch
@@ -1,3 +1,9 @@
+From 3802cb7b283b50ea387a7b0c41abb43fb86508c6 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 07 Aug 2022 10:54:35 +0000
+Subject: [PATCH] binutils 2 39 dont error on missing makeinfo
+
+diff --git a/bfd/Makefile.in b/bfd/Makefile.in
 --- a/bfd/Makefile.in
 +++ b/bfd/Makefile.in
 @@ -260,7 +260,7 @@ am__v_texidevnull_ = $(am__v_texidevnull

--- a/packages/devel/binutils/patches/0003-libctf-gcc-16.patch
+++ b/packages/devel/binutils/patches/0003-libctf-gcc-16.patch
@@ -1,5 +1,11 @@
---- a/include/ctf.h	2025-11-10 00:00:00.000000000 +0000
-+++ b/include/ctf.h	2025-11-16 22:34:45.000000000 +0000
+From cdbe0ad758b2024555c38802ad73603567073538 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 22 Nov 2025 14:23:41 +0000
+Subject: [PATCH] libctf gcc 16
+
+diff --git a/include/ctf.h b/include/ctf.h
+--- a/include/ctf.h
++++ b/include/ctf.h
 @@ -423,6 +423,10 @@
  #define CTF_K_CONST	12	/* ctt_type is base type.  */
  #define CTF_K_RESTRICT	13	/* ctt_type is base type.  */

--- a/packages/devel/cmake/patches/0001-disable-free-comp-methods.patch
+++ b/packages/devel/cmake/patches/0001-disable-free-comp-methods.patch
@@ -1,5 +1,12 @@
---- a/Utilities/cmcurl/lib/vtls/openssl.c.orig	2016-10-19 19:17:49.615923691 +0200
-+++ b/Utilities/cmcurl/lib/vtls/openssl.c	2016-10-19 19:22:50.849565684 +0200
+From 70c39c72b06564d13675447779fc1595311e227a Mon Sep 17 00:00:00 2001
+From: Jérôme Benoit <jerome.benoit@piment-noir.org>
+Date: Mon, 24 Oct 2016 19:39:41 +0200
+Subject: [PATCH] disable free comp methods
+
+---
+diff --git a/Utilities/cmcurl/lib/vtls/openssl.c b/Utilities/cmcurl/lib/vtls/openssl.c
+--- a/Utilities/cmcurl/lib/vtls/openssl.c
++++ b/Utilities/cmcurl/lib/vtls/openssl.c
 @@ -164,6 +164,11 @@
  #define HAVE_SSL_COMP_FREE_COMPRESSION_METHODS 1
  #endif

--- a/packages/devel/elfutils/patches/0001-make-executables-optional.patch
+++ b/packages/devel/elfutils/patches/0001-make-executables-optional.patch
@@ -8,6 +8,7 @@ Subject: [PATCH] make executables optional
  configure.ac | 5 +++++
  2 files changed, 10 insertions(+), 1 deletion(-)
 
+diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -29,7 +29,11 @@ AM_MAKEFLAGS = --no-print-directory
@@ -23,6 +24,7 @@ Subject: [PATCH] make executables optional
  
  EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING SECURITY \
  	     COPYING COPYING-GPLV2 COPYING-LGPLV3 CONDUCT
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -82,6 +82,11 @@ AS_IF([test "$use_locks" = yes],

--- a/packages/devel/elfutils/patches/0002-libelf--Add-libeu-objects-to-libelf.a-static-archive.patch
+++ b/packages/devel/elfutils/patches/0002-libelf--Add-libeu-objects-to-libelf.a-static-archive.patch
@@ -17,6 +17,7 @@ Signed-off-by: Mark Wielaard <mark@klomp.org>
  libelf/Makefile.am | 3 +++
  1 file changed, 3 insertions(+)
 
+diff --git a/libelf/Makefile.am b/libelf/Makefile.am
 --- a/libelf/Makefile.am
 +++ b/libelf/Makefile.am
 @@ -126,6 +126,9 @@ libelf.so: $(srcdir)/libelf.map $(libelf

--- a/packages/devel/fakeroot/patches/0001-disable-docs-tests.patch
+++ b/packages/devel/fakeroot/patches/0001-disable-docs-tests.patch
@@ -1,3 +1,9 @@
+From 618ccd9a332b0787f96b7fdcab120d89f7b4f281 Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 10 Jan 2021 04:07:19 +0000
+Subject: [PATCH] disable docs tests
+
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -748,9 +748,7 @@ AM_CONDITIONAL([MACOSX], [test x$macosx
@@ -11,6 +17,7 @@
  AC_OUTPUT
  
  dnl Local variables:
+diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -1,6 +1,6 @@

--- a/packages/devel/flex/patches/0001-use-flex-host-for-target-cross-compile.patch
+++ b/packages/devel/flex/patches/0001-use-flex-host-for-target-cross-compile.patch
@@ -1,3 +1,9 @@
+From 49cdf3874c8849b39d5064c6c6e9d925c83e6743 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 25 May 2025 13:15:28 +0000
+Subject: [PATCH] use flex host for target cross compile
+
+diff --git a/src/Makefile.am b/src/Makefile.am
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -100,7 +100,7 @@ stage1scan.c: scan.l stage1flex$(EXEEXT)

--- a/packages/devel/flex/patches/0002-nocrap.patch
+++ b/packages/devel/flex/patches/0002-nocrap.patch
@@ -1,3 +1,9 @@
+From 6b4ff6cb9cae1e206cb63d4541a8a272c5bc6535 Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 08 Jan 2020 13:00:45 +0100
+Subject: [PATCH] nocrap
+
+diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -43,10 +43,6 @@ EXTRA_DIST = \

--- a/packages/devel/glibc/patches/0001-Linux--Only-define-OPEN-TREE-.patch
+++ b/packages/devel/glibc/patches/0001-Linux--Only-define-OPEN-TREE-.patch
@@ -1,4 +1,3 @@
-
 From d12b017cddfeb9fe9920ba054ae3dfcb8e9238b8 Mon Sep 17 00:00:00 2001
 From: Florian Weimer <fweimer@redhat.com>
 Date: Wed, 4 Mar 2026 18:32:36 +0100

--- a/packages/devel/glibc/patches/0002-fix-dns-with-broken-routers.patch
+++ b/packages/devel/glibc/patches/0002-fix-dns-with-broken-routers.patch
@@ -1,11 +1,12 @@
-commit 45918e237cd32bb3d9a5fde83f81f83b52584771
-Author: Stefan Saraev <stefan@saraev.ca>
-Date:   Tue Oct 1 12:09:07 2013 +0300
+From 0c5caa599f59822091e2969b38a3eb0ad5f60ed9 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Tue, 1 Oct 2013 12:09:07 +0300
+Subject: [PATCH] fix dns with broken routers
 
-    fix dns with broken routers
-    
-    ref: https://fedoraproject.org/wiki/Networking/NameResolution/ADDRCONFIG
+ref: https://fedoraproject.org/wiki/Networking/NameResolution/ADDRCONFIG
 
+---
+diff --git a/nss/getaddrinfo.c b/nss/getaddrinfo.c
 --- a/nss/getaddrinfo.c
 +++ b/nss/getaddrinfo.c
 @@ -730,6 +730,38 @@ gaih_inet (const char *name, const struc
@@ -93,6 +94,7 @@ Date:   Tue Oct 1 12:09:07 2013 +0300
  		{
  		  if ((result = gethosts (fct, AF_INET, name, req, tmpbuf,
  					  res, &status, &no_data)) != 0)
+diff --git a/sysdeps/unix/sysv/linux/check_pf.c b/sysdeps/unix/sysv/linux/check_pf.c
 --- a/sysdeps/unix/sysv/linux/check_pf.c
 +++ b/sysdeps/unix/sysv/linux/check_pf.c
 @@ -224,7 +224,8 @@ make_request (int fd, pid_t pid)

--- a/packages/devel/glibc/patches/widevine-arm/0002-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
+++ b/packages/devel/glibc/patches/widevine-arm/0002-tls-libwidevinecdm.so-since-4.10.2252.0-has-TLS-with.patch
@@ -12,6 +12,7 @@ inside dl-init.c call_init()
  elf/dl-tls.c | 5 +++++
  1 file changed, 5 insertions(+)
 
+diff --git a/elf/dl-tls.c b/elf/dl-tls.c
 --- a/elf/dl-tls.c
 +++ b/elf/dl-tls.c
 @@ -220,6 +220,11 @@ void

--- a/packages/devel/intltool/patches/0001-fix-regex-expressions.patch
+++ b/packages/devel/intltool/patches/0001-fix-regex-expressions.patch
@@ -1,6 +1,12 @@
-=== modified file 'intltool-update.in'
---- a/intltool-update.in	2014-05-14 02:15:53 +0000
-+++ b/intltool-update.in	2016-01-19 15:59:38 +0000
+From fd456235952a134a12236bc98f892ced849f54f3 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Tue, 10 Oct 2017 20:47:37 +0200
+Subject: [PATCH] fix regex expressions
+
+---
+diff --git a/intltool-update.in b/intltool-update.in
+--- a/intltool-update.in
++++ b/intltool-update.in
 @@ -1062,7 +1062,7 @@
  	}
      }

--- a/packages/devel/libirman/patches/0001-fix-poll-include.patch
+++ b/packages/devel/libirman/patches/0001-fix-poll-include.patch
@@ -1,6 +1,11 @@
-diff -Naur a/config.h.in b/config.h.in
---- a/config.h.in	2016-05-18 18:19:56.000000000 +0200
-+++ b/config.h.in	2016-12-26 22:49:43.514203152 +0100
+From 8cfa64d80c3f89ecba7cd70a47f061eeecc76dbe Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Wed, 28 Dec 2016 20:01:39 +0100
+Subject: [PATCH] fix poll include
+
+diff --git a/config.h.in b/config.h.in
+--- a/config.h.in
++++ b/config.h.in
 @@ -21,6 +21,9 @@
  /* Define to 1 if you have the `mkfifo' function. */
  #undef HAVE_MKFIFO
@@ -21,9 +26,9 @@ diff -Naur a/config.h.in b/config.h.in
  /* Define to 1 if you have the <sys/stat.h> header file. */
  #undef HAVE_SYS_STAT_H
  
-diff -Naur a/configure.ac b/configure.ac
---- a/configure.ac	2016-05-18 18:19:41.000000000 +0200
-+++ b/configure.ac	2016-12-26 22:48:40.190031280 +0100
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -20,7 +20,7 @@
  
  dnl Checks for header files.

--- a/packages/devel/ncurses/patches/0001-terminfo-xterm.patch
+++ b/packages/devel/ncurses/patches/0001-terminfo-xterm.patch
@@ -1,6 +1,12 @@
+From 99d8ca22f1aebb6f61d2cbc6a9df9e09b8f8801d Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Thu, 27 Dec 2018 15:53:05 +0100
+Subject: [PATCH] terminfo xterm
 
 Remove recent xterm terminfo features to be compatible with other emulations
 
+---
+diff --git a/misc/terminfo.src b/misc/terminfo.src
 --- a/misc/terminfo.src
 +++ b/misc/terminfo.src
 @@ -5072,9 +5072,9 @@ xterm-xfree86|xterm terminal emulator (X

--- a/packages/devel/ncurses/patches/0002-alloc-fallbacks.patch
+++ b/packages/devel/ncurses/patches/0002-alloc-fallbacks.patch
@@ -1,5 +1,12 @@
+From 99d8ca22f1aebb6f61d2cbc6a9df9e09b8f8801d Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Thu, 27 Dec 2018 15:53:05 +0100
+Subject: [PATCH] alloc fallbacks
+
 Fix freeing not allocated fallback entries by allocating a copy.
 
+---
+diff --git a/ncurses/tinfo/tinfo_driver.c b/ncurses/tinfo/tinfo_driver.c
 --- a/ncurses/tinfo/tinfo_driver.c
 +++ b/ncurses/tinfo/tinfo_driver.c
 @@ -181,6 +181,8 @@ drv_CanHandle(TERMINAL_CONTROL_BLOCK * T

--- a/packages/devel/ncurses/patches/0003-fix-configure-pkgconfig.patch
+++ b/packages/devel/ncurses/patches/0003-fix-configure-pkgconfig.patch
@@ -1,5 +1,12 @@
+From 4fa3e0ef444f1cf57b9b86e7d840694c5ef43f4d Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Sat, 04 Dec 2021 15:27:26 +0100
+Subject: [PATCH] fix configure pkgconfig
+
 Fix configure option --with-pkg-config-libdir is broken for cross compilation
 
+---
+diff --git a/configure b/configure
 --- a/configure
 +++ b/configure
 @@ -4591,7 +4591,7 @@ echo $ECHO_N "checking for first directo

--- a/packages/devel/rapidjson/patches/0001-remove-custom-cxx-flags.patch
+++ b/packages/devel/rapidjson/patches/0001-remove-custom-cxx-flags.patch
@@ -1,3 +1,8 @@
+From 8ab344eb6830d5eaec3818cdf0cfbab5cab3bee2 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Fri, 24 Mar 2017 22:24:59 +0000
+Subject: [PATCH] remove custom cxx flags
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index ceda71b..efb259e 100644
 --- a/CMakeLists.txt

--- a/packages/devel/readline/patches/0001-display-null-prompt.patch
+++ b/packages/devel/readline/patches/0001-display-null-prompt.patch
@@ -1,3 +1,8 @@
+From 60b222a7b3007519239f96837482418a632ab3ad Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Wed, 06 Aug 2025 12:18:15 +0200
+Subject: [PATCH] display null prompt
+
 *** a/display.c	Fri May  2 09:20:32 2025
 --- b/display.c	Sun Jul  6 17:16:28 2025
 ***************

--- a/packages/emulation/libretro-bsnes-hd/patches/0001-disable-openmp.patch
+++ b/packages/emulation/libretro-bsnes-hd/patches/0001-disable-openmp.patch
@@ -1,3 +1,8 @@
+From 7c847c106d95d3515a075e8c63c36d789096d911 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 10 Apr 2023 16:12:06 +0200
+Subject: [PATCH] disable openmp
+
 diff --git a/bsnes/GNUmakefile b/bsnes/GNUmakefile
 index 58466fb..eceb96c 100644
 --- a/bsnes/GNUmakefile

--- a/packages/emulation/libretro-dosbox-pure/patches/0001-Makefile-optimization-and-libs.patch
+++ b/packages/emulation/libretro-dosbox-pure/patches/0001-Makefile-optimization-and-libs.patch
@@ -1,6 +1,11 @@
-diff -Naur dosbox_pure-4fdb557e415698aae5bd90b076f76437f5e9b0b4/Makefile dosbox_pure-4fdb557e415698aae5bd90b076f76437f5e9b0b4-2/Makefile
---- dosbox_pure-4fdb557e415698aae5bd90b076f76437f5e9b0b4/Makefile	2022-12-13 22:22:26.391256258 +0100
-+++ dosbox_pure-4fdb557e415698aae5bd90b076f76437f5e9b0b4-2/Makefile	2022-12-13 22:38:22.894452324 +0100
+From 7c847c106d95d3515a075e8c63c36d789096d911 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 10 Apr 2023 16:12:06 +0200
+Subject: [PATCH] Makefile optimization and libs
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -201,9 +201,9 @@
    ifeq ($(platform),vita)
      CFLAGS   := -DNDEBUG -O3 -fno-ident -fno-partial-inlining

--- a/packages/emulation/libretro-dosbox-pure/patches/0002-cross-compile-fix.patch
+++ b/packages/emulation/libretro-dosbox-pure/patches/0002-cross-compile-fix.patch
@@ -1,3 +1,9 @@
+From e71ade56d0ab2faa257a440af99c2e42feec0ffc Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sat, 09 Oct 2021 23:35:44 +0200
+Subject: [PATCH] cross compile fix
+
+diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -33,7 +33,7 @@ SOURCES := \

--- a/packages/emulation/libretro-mame2010/patches/0001-dont-force-objdump.patch
+++ b/packages/emulation/libretro-mame2010/patches/0001-dont-force-objdump.patch
@@ -1,3 +1,9 @@
+From 7c847c106d95d3515a075e8c63c36d789096d911 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 10 Apr 2023 16:12:06 +0200
+Subject: [PATCH] dont force objdump
+
+---
 diff --git a/Makefile b/Makefile
 index 65ece36..6fd017d 100644
 --- a/Makefile

--- a/packages/emulation/libretro-picodrive/patches/0001-remove-temporary-getoffs.patch
+++ b/packages/emulation/libretro-picodrive/patches/0001-remove-temporary-getoffs.patch
@@ -1,3 +1,8 @@
+From 7c847c106d95d3515a075e8c63c36d789096d911 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 10 Apr 2023 16:12:06 +0200
+Subject: [PATCH] remove temporary getoffs
+
 diff --git a/tools/mkoffsets.sh b/tools/mkoffsets.sh
 index d9a8db5..b82d6eb 100755
 --- a/tools/mkoffsets.sh

--- a/packages/emulation/libretro-stella/patches/0001-do-not-use-static-libgcc-libstdc++.patch
+++ b/packages/emulation/libretro-stella/patches/0001-do-not-use-static-libgcc-libstdc++.patch
@@ -1,3 +1,8 @@
+From 7c847c106d95d3515a075e8c63c36d789096d911 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Mon, 10 Apr 2023 16:12:06 +0200
+Subject: [PATCH] do not use static libgcc libstdc++
+
 diff --git a/src/libretro/Makefile b/src/libretro/Makefile
 index a170992343..6a828521e5 100644
 --- a/src/os/libretro/Makefile

--- a/packages/graphics/libprojectM/patches/0001-add-enable-gl-switch.patch
+++ b/packages/graphics/libprojectM/patches/0001-add-enable-gl-switch.patch
@@ -1,6 +1,12 @@
+From 542342c24f1514c9fca16c064b8a4faada169b30 Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Thu, 06 Jul 2023 19:23:52 -0700
+Subject: [PATCH] add enable gl switch
+
 diff --color -Naur a/configure.ac b/configure.ac
---- a/configure.ac	2021-02-20 11:40:39.000000000 -0800
-+++ b/configure.ac	2023-07-06 16:06:18.679702443 -0700
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -37,7 +37,8 @@
    enable_sdl=yes
  ], [

--- a/packages/graphics/vulkan/glslang/patches/1001-build-static-spirv-tools.patch
+++ b/packages/graphics/vulkan/glslang/patches/1001-build-static-spirv-tools.patch
@@ -1,3 +1,9 @@
+From aa384798e76ab79b642fef43d49b5c09a83cc454 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 15 Dec 2022 14:35:02 +0100
+Subject: [PATCH] build static spirv tools
+
+diff --git a/External/CMakeLists.txt b/External/CMakeLists.txt
 --- a/External/CMakeLists.txt
 +++ b/External/CMakeLists.txt
 @@ -71,7 +71,8 @@ endif()

--- a/packages/graphics/vulkan/vkmark/patches/0001-fix-sysroot.patch
+++ b/packages/graphics/vulkan/vkmark/patches/0001-fix-sysroot.patch
@@ -1,5 +1,11 @@
---- a/src/meson.build	2025-01-23 08:33:27.000000000 +0000
-+++ b/src/meson.build	2025-05-02 04:43:30.867280490 +0000
+From 89e1297427ef40b574b1ebded7e4fd22b1e428ab Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Fri, 02 May 2025 03:52:35 +0000
+Subject: [PATCH] fix sysroot
+
+diff --git a/src/meson.build b/src/meson.build
+--- a/src/meson.build
++++ b/src/meson.build
 @@ -1,7 +1,7 @@
  prog_python = find_program('python3')
  

--- a/packages/lang/Python3/patches/0001-default-is-optimized.patch
+++ b/packages/lang/Python3/patches/0001-default-is-optimized.patch
@@ -1,3 +1,8 @@
+From b86fdd54f74c4d4540fd5d5c102673df965ba251 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Sun, 08 Oct 2017 23:50:38 +0100
+Subject: [PATCH] default is optimized
+
 Refreshed MilhouseVH patch from Python3.7. Original message:
 
 Do *not* enable Py_OptimizeFlag=2 (or higher) as this will stop
@@ -5,6 +10,7 @@ __doc__ output from being generated which will prevent the qemu
 package for Generic from building.
 
 ---
+diff --git a/Python/initconfig.c b/Python/initconfig.c
 --- a/Python/initconfig.c
 +++ b/Python/initconfig.c
 @@ -469,7 +469,7 @@ int Py_VerboseFlag = 0; /* Needed by imp

--- a/packages/lang/Python3/patches/0002-Make-the-build-of-pyc-files-conditional.patch
+++ b/packages/lang/Python3/patches/0002-Make-the-build-of-pyc-files-conditional.patch
@@ -16,6 +16,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  configure.ac    | 6 ++++++
  2 files changed, 8 insertions(+)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2812,6 +2812,7 @@ libinstall:	all $(srcdir)/Modules/xxmodu
@@ -34,6 +35,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  
  # bpo-21536: Misc/python-config.sh is generated in the build directory
  # from $(srcdir)Misc/python-config.sh.in.
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1533,6 +1533,12 @@ fi

--- a/packages/lang/Python3/patches/0003-Disable-buggy-getaddrinfo-configure-test-when-cross-.patch
+++ b/packages/lang/Python3/patches/0003-Disable-buggy-getaddrinfo-configure-test-when-cross-.patch
@@ -9,6 +9,7 @@ Signed-off-by: Vanya Sergeev <vsergeev@gmail.com>
  configure.ac | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -5805,7 +5805,7 @@ fi]))

--- a/packages/lang/Python3/patches/0004-Add-an-option-to-disable-pydoc.patch
+++ b/packages/lang/Python3/patches/0004-Add-an-option-to-disable-pydoc.patch
@@ -19,6 +19,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  configure.ac    | 6 ++++++
  2 files changed, 14 insertions(+), 1 deletion(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2513,7 +2513,9 @@ bininstall: commoninstall altbininstall
@@ -60,6 +61,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  	@if [ -s Modules/python.exp -a \
  		"`echo $(MACHDEP) | sed 's/^\(...\).*/\1/'`" = "aix" ]; then \
  		echo; echo "Installing support files for building shared extension modules on AIX:"; \
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -4788,6 +4788,12 @@ AS_VAR_IF([posix_threads], [stub], [

--- a/packages/lang/Python3/patches/0005-Add-an-option-to-disable-IDLE.patch
+++ b/packages/lang/Python3/patches/0005-Add-an-option-to-disable-IDLE.patch
@@ -18,6 +18,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  configure.ac    | 6 ++++++
  2 files changed, 14 insertions(+), 1 deletion(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2511,7 +2511,9 @@ bininstall: commoninstall altbininstall
@@ -59,6 +60,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  ifeq (@PYDOC@,yes)
  	$(INSTALL_SCRIPT) $(SCRIPT_PYDOC) $(DESTDIR)$(BINDIR)/pydoc$(VERSION)
  endif
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -8188,6 +8188,12 @@ PY_STDLIB_MOD([xxlimited_35], [test "$TE

--- a/packages/lang/Python3/patches/0006-configure.ac-move-PY-STDLIB-MOD-SET-NA-further-up.patch
+++ b/packages/lang/Python3/patches/0006-configure.ac-move-PY-STDLIB-MOD-SET-NA-further-up.patch
@@ -11,6 +11,7 @@ Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
  configure.ac | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -95,6 +95,12 @@ AC_DEFUN([PY_CHECK_EMSCRIPTEN_PORT], [

--- a/packages/lang/Python3/patches/0007-Add-option-to-disable-the-sqlite3-module.patch
+++ b/packages/lang/Python3/patches/0007-Add-option-to-disable-the-sqlite3-module.patch
@@ -15,6 +15,7 @@ Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
  configure.ac    | 7 +++++++
  2 files changed, 11 insertions(+), 1 deletion(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2569,7 +2569,6 @@ LIBSUBDIRS=	asyncio \
@@ -36,6 +37,7 @@ Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
  TEST_MODULES=@TEST_MODULES@
  
  .PHONY: libinstall
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -4794,6 +4794,13 @@ AS_VAR_IF([posix_threads], [stub], [

--- a/packages/lang/Python3/patches/0008-Add-an-option-to-disable-the-tk-module.patch
+++ b/packages/lang/Python3/patches/0008-Add-an-option-to-disable-the-tk-module.patch
@@ -18,6 +18,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  configure.ac    | 7 +++++++
  2 files changed, 12 insertions(+), 3 deletions(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2571,7 +2571,6 @@ LIBSUBDIRS=	asyncio \
@@ -56,6 +57,7 @@ Signed-off-by: Adam Duskett <adam.duskett@amarulasolutions.com>
  COMPILEALL_OPTS=-j0
  
  ifeq (@PYDOC@,yes)
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -4807,6 +4807,13 @@ AC_ARG_ENABLE(pydoc,

--- a/packages/lang/Python3/patches/0009-Add-an-option-to-disable-the-curses-module.patch
+++ b/packages/lang/Python3/patches/0009-Add-an-option-to-disable-the-curses-module.patch
@@ -14,6 +14,7 @@ Signed-off-by: Adam Duskett <aduskett@gmail.com>
  configure.ac    | 7 +++++++
  2 files changed, 11 insertions(+), 1 deletion(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2555,7 +2555,6 @@ LIBSUBDIRS=	asyncio \
@@ -35,6 +36,7 @@ Signed-off-by: Adam Duskett <aduskett@gmail.com>
  COMPILEALL_OPTS=-j0
  
  ifeq (@PYDOC@,yes)
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -4801,6 +4801,13 @@ AC_ARG_ENABLE(sqlite3,

--- a/packages/lang/Python3/patches/0010-Add-an-option-to-disable-expat.patch
+++ b/packages/lang/Python3/patches/0010-Add-an-option-to-disable-expat.patch
@@ -20,6 +20,7 @@ Signed-off-by: Adam Duskett <aduskett@gmail.com>
  configure.ac    | 24 +++++++++++++-----------
  2 files changed, 17 insertions(+), 12 deletions(-)
 
+diff --git a/Makefile.pre.in b/Makefile.pre.in
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -2576,7 +2576,6 @@ LIBSUBDIRS=	asyncio \
@@ -41,6 +42,7 @@ Signed-off-by: Adam Duskett <aduskett@gmail.com>
  TEST_MODULES=@TEST_MODULES@
  
  .PHONY: libinstall
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -4064,17 +4064,19 @@ LIBS="$withval $LIBS"

--- a/packages/lang/Python3/patches/0011-configure.ac-fixup-CC-print-multiarch-output-for-mus.patch
+++ b/packages/lang/Python3/patches/0011-configure.ac-fixup-CC-print-multiarch-output-for-mus.patch
@@ -31,6 +31,7 @@ Signed-off-by: Vincent Fazio <vfazio@gmail.com>
  configure.ac | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1179,7 +1179,11 @@ AS_CASE([$ac_sys_system],

--- a/packages/lang/Python3/patches/0300-generate-legacy-pyc-bytecode.patch
+++ b/packages/lang/Python3/patches/0300-generate-legacy-pyc-bytecode.patch
@@ -22,6 +22,7 @@ https://www.python.org/dev/peps/pep-3147/#case-4-legacy-pyc-files-and-source-les
  Lib/py_compile.py | 5 +++++
  1 file changed, 5 insertions(+)
 
+diff --git a/Lib/py_compile.py b/Lib/py_compile.py
 --- a/Lib/py_compile.py
 +++ b/Lib/py_compile.py
 @@ -121,6 +121,11 @@ def compile(file, cfile=None, dfile=None

--- a/packages/lang/gcc/patches/0001-4.8.2-disable-multilib-i386-linux64.patch
+++ b/packages/lang/gcc/patches/0001-4.8.2-disable-multilib-i386-linux64.patch
@@ -1,6 +1,11 @@
-diff -Naur gcc-4.8.2/gcc/config/i386/t-linux64 gcc-4.8.2.patch/gcc/config/i386/t-linux64
---- gcc-4.8.2/gcc/config/i386/t-linux64	2013-01-10 21:38:27.000000000 +0100
-+++ gcc-4.8.2.patch/gcc/config/i386/t-linux64	2014-01-25 00:04:49.091673299 +0100
+From 906de5d22feb09af2fd4c116859001336d0df424 Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sat, 13 Apr 2013 10:26:53 +0200
+Subject: [PATCH] 4.8.2 disable multilib i386 linux64
+
+diff --git a/gcc/config/i386/t-linux64 b/gcc/config/i386/t-linux64
+--- a/gcc/config/i386/t-linux64
++++ b/gcc/config/i386/t-linux64
 @@ -33,6 +33,6 @@
  comma=,
  MULTILIB_OPTIONS    = $(subst $(comma),/,$(TM_MULTILIB_CONFIG))

--- a/packages/lang/gcc/patches/0003-crosscompile-badness.patch
+++ b/packages/lang/gcc/patches/0003-crosscompile-badness.patch
@@ -1,7 +1,13 @@
+From 3f7fead6dd3730ab2c6f2c90b8f79fc085f5cba6 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sat, 25 Jan 2014 01:03:30 +0200
+Subject: [PATCH] crosscompile badness
+
 Index: gcc-4.4+svnr145550/gcc/incpath.cc
 ===================================================================
---- gcc-4.4+svnr145550.orig/gcc/incpath.cc	2009-04-04 13:48:31.000000000 -0700
-+++ gcc-4.4+svnr145550/gcc/incpath.cc	2009-04-04 14:49:29.000000000 -0700
+diff --git a/gcc/incpath.cc b/gcc/incpath.cc
+--- a/gcc/incpath.cc
++++ b/gcc/incpath.cc
 @@ -417,6 +417,26 @@
    p->construct = 0;
    p->user_supplied_p = user_supplied_p;

--- a/packages/lang/llvm/patches/0001-14.0.0-force-disable-cmakelist-options.patch
+++ b/packages/lang/llvm/patches/0001-14.0.0-force-disable-cmakelist-options.patch
@@ -1,5 +1,11 @@
---- a/llvm/CMakeLists.txt	2022-04-02 06:26:04.688530539 +0000
-+++ b/llvm/CMakeLists.txt	2022-04-02 06:44:00.015717360 +0000
+From 927c2c938683b1e11d350824865602386288ce07 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 23 Mar 2022 10:10:13 +0000
+Subject: [PATCH] 14.0.0 force disable cmakelist options
+
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
 @@ -616,7 +616,7 @@
  
  option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default

--- a/packages/linux-driver-addons/dvb/crazycat/patches/disable-pci/0001-disable-partly-pci.patch
+++ b/packages/linux-driver-addons/dvb/crazycat/patches/disable-pci/0001-disable-partly-pci.patch
@@ -1,3 +1,9 @@
+From 8882b95bd4c4f6827b1a30862fa4e5b13caaf35a Mon Sep 17 00:00:00 2001
+From: CvH <namerp@googlemail.com>
+Date: Sun, 21 Jul 2019 21:21:07 +0200
+Subject: [PATCH] disable partly pci
+
+diff --git a/v4l/scripts/make_kconfig.pl b/v4l/scripts/make_kconfig.pl
 --- a/v4l/scripts/make_kconfig.pl
 +++ b/v4l/scripts/make_kconfig.pl
 @@ -626,6 +626,8 @@ ($$)

--- a/packages/linux-driver-addons/dvb/dvb-latest/patches/disable-pci/0001-disable-partly-pci.patch
+++ b/packages/linux-driver-addons/dvb/dvb-latest/patches/disable-pci/0001-disable-partly-pci.patch
@@ -1,3 +1,9 @@
+From 8882b95bd4c4f6827b1a30862fa4e5b13caaf35a Mon Sep 17 00:00:00 2001
+From: CvH <namerp@googlemail.com>
+Date: Sun, 21 Jul 2019 21:21:07 +0200
+Subject: [PATCH] disable partly pci
+
+diff --git a/v4l/scripts/make_kconfig.pl b/v4l/scripts/make_kconfig.pl
 --- a/v4l/scripts/make_kconfig.pl
 +++ b/v4l/scripts/make_kconfig.pl
 @@ -626,6 +626,8 @@ ($$)

--- a/packages/linux-firmware/rtl8723bs_bt/patches/0001-Makefile.patch
+++ b/packages/linux-firmware/rtl8723bs_bt/patches/0001-Makefile.patch
@@ -1,3 +1,8 @@
+From eff30ed6608eceecfa8c589c151e3eefcb46a0d1 Mon Sep 17 00:00:00 2001
+From: Adam Green <greena88@gmail.com>
+Date: Wed, 13 Dec 2017 00:58:43 +0000
+Subject: [PATCH] Makefile
+
 diff --git a/Makefile b/Makefile
 index 52506b9..fd196f3 100644
 --- a/Makefile

--- a/packages/linux-firmware/rtl8723bs_bt/patches/0002-firmware-path.patch
+++ b/packages/linux-firmware/rtl8723bs_bt/patches/0002-firmware-path.patch
@@ -1,5 +1,11 @@
---- a/hciattach_rtk.c	2016-07-18 00:47:52.000000000 +0100
-+++ b/hciattach_rtk.c	2017-12-15 04:27:39.481299996 +0000
+From eff30ed6608eceecfa8c589c151e3eefcb46a0d1 Mon Sep 17 00:00:00 2001
+From: Adam Green <greena88@gmail.com>
+Date: Wed, 13 Dec 2017 00:58:43 +0000
+Subject: [PATCH] firmware path
+
+diff --git a/hciattach_rtk.c b/hciattach_rtk.c
+--- a/hciattach_rtk.c
++++ b/hciattach_rtk.c
 @@ -1419,7 +1419,7 @@
  	int ret = 0;
  	struct stat st;

--- a/packages/multimedia/libbluray/patches/0001-set-headless-false.patch
+++ b/packages/multimedia/libbluray/patches/0001-set-headless-false.patch
@@ -12,6 +12,7 @@ temporary folder is set to /storage/.kodi/userdata/addon_data/tools.jre.zulu/lib
  src/libbluray/bdj/bdj.c | 2 ++
  1 file changed, 2 insertions(+)
 
+diff --git a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
 --- a/src/libbluray/bdj/bdj.c
 +++ b/src/libbluray/bdj/bdj.c
 @@ -903,6 +903,10 @@ static int _create_jvm(void *jvm_lib, co

--- a/packages/multimedia/media-driver/patches/1974-suppress-dangling-pointer-warning-in-mhw-state-heap-g.patch
+++ b/packages/multimedia/media-driver/patches/1974-suppress-dangling-pointer-warning-in-mhw-state-heap-g.patch
@@ -1,5 +1,11 @@
---- a/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c	2025-11-27 10:21:23.000000000 +0000
-+++ b/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c	2025-11-27 10:21:23.000000000 +0000
+From 0df62044fc57b30a7e2f19603df323f14bca7606 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 30 Apr 2026 16:53:58 +0000
+Subject: [PATCH] suppress dangling pointer warning in mhw state heap g
+
+diff --git a/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c b/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c
+--- a/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c
++++ b/media_driver/agnostic/gen8/hw/mhw_state_heap_g8.c
 @@ -831,7 +831,9 @@
          mhw_state_heap_g8_X::SAMPLER_STATE_CMD          unormSampler;
          mhw_state_heap_g8_X::SAMPLER_INDIRECT_STATE_CMD indirectState;

--- a/packages/multimedia/zvbi/patches/0001-fix-static-linking.patch
+++ b/packages/multimedia/zvbi/patches/0001-fix-static-linking.patch
@@ -1,3 +1,9 @@
+From f41dc173f515ae144a776b855de2c17268eaa1e2 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Sat, 11 Jan 2020 18:16:41 +0000
+Subject: [PATCH] fix static linking
+
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -244,7 +244,7 @@ dnl (PNG page export)

--- a/packages/multimedia/zvbi/patches/0002-gettext.patch
+++ b/packages/multimedia/zvbi/patches/0002-gettext.patch
@@ -1,5 +1,11 @@
---- a/configure.ac	2025-02-26 20:29:12.903050209 +0000
-+++ b/configure.ac	2025-02-26 20:29:06.246129502 +0000
+From f0d5f5f43f05f6c8aea48c7765fd58a735733045 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 26 Feb 2025 10:39:03 +0000
+Subject: [PATCH] gettext
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -499,7 +499,7 @@
  # If issues found with using a different gettext version than below and
  # performing a crossbuild, update AM_GNU_GETTEXT_VERSION to match and

--- a/packages/multimedia/zvbi/patches/0003-ssize-max.patch
+++ b/packages/multimedia/zvbi/patches/0003-ssize-max.patch
@@ -1,5 +1,13 @@
+From f41dc173f515ae144a776b855de2c17268eaa1e2 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Sat, 11 Jan 2020 18:16:41 +0000
+Subject: [PATCH] ssize max
+
 Linear memory extents over SSIZE_MAX are undefined, so there is no
 point in protecting against them.
+
+---
+diff --git a/src/export.c b/src/export.c
 --- a/src/export.c
 +++ b/src/export.c
 @@ -1056,8 +1056,6 @@

--- a/packages/multimedia/zvbi/patches/0004-fix-clang-support.patch
+++ b/packages/multimedia/zvbi/patches/0004-fix-clang-support.patch
@@ -1,3 +1,9 @@
+From f41dc173f515ae144a776b855de2c17268eaa1e2 Mon Sep 17 00:00:00 2001
+From: MilhouseVH <milhouseVH.github@nmacleod.com>
+Date: Sat, 11 Jan 2020 18:16:41 +0000
+Subject: [PATCH] fix clang support
+
+diff --git a/src/misc.h b/src/misc.h
 --- a/src/misc.h
 +++ b/src/misc.h
 @@ -52,17 +52,6 @@

--- a/packages/network/bluez/patches/0001-add-obexd-policy.patch
+++ b/packages/network/bluez/patches/0001-add-obexd-policy.patch
@@ -1,3 +1,8 @@
+From 2d7faa8b220b825f95d4e5f17e0948e1daaa0874 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Tue, 06 Aug 2013 12:37:04 +0300
+Subject: [PATCH] add obexd policy
+
 diff --git a/src/bluetooth.conf b/src/bluetooth.conf
 index 8a1e258..31b7542 100644
 --- a/src/bluetooth.conf

--- a/packages/network/bluez/patches/0002-storagedir.patch
+++ b/packages/network/bluez/patches/0002-storagedir.patch
@@ -1,6 +1,11 @@
-diff -Naur bluez-5.7/configure.ac bluez-5.7.patch/configure.ac
---- bluez-5.7/configure.ac	2013-06-26 18:17:07.000000000 +0200
-+++ bluez-5.7.patch/configure.ac	2013-07-12 20:21:17.000000000 +0200
+From 541b9953dd44fbb3d46be38d7243f3c812863d2a Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Fri, 12 Jul 2013 20:37:41 +0200
+Subject: [PATCH] storagedir
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -238,10 +238,13 @@
  	prefix="${ac_default_prefix}"
  fi

--- a/packages/network/bluez/patches/0006-fix-obexd-after-5-73.patch
+++ b/packages/network/bluez/patches/0006-fix-obexd-after-5-73.patch
@@ -1,3 +1,8 @@
+From 4bc9f3e35b959b641577e1dd182f52e28bc7c87b Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 09 Mar 2024 08:05:30 +0000
+Subject: [PATCH] fix obexd after 5 73
+
 diff --git a/Makefile.obexd b/Makefile.obexd
 index b7e9f2d33..9a9e9a0a0 100644
 --- a/Makefile.obexd

--- a/packages/network/connman/patches/0001-do-not-cleanup-routes.patch
+++ b/packages/network/connman/patches/0001-do-not-cleanup-routes.patch
@@ -1,3 +1,8 @@
+From 01bf6480e8a0a13089f41ed28a9055295066baa0 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Fri, 09 Jan 2015 21:25:29 +0200
+Subject: [PATCH] do not cleanup routes
+
 diff --git a/src/device.c b/src/device.c
 index 0fda950..eb09e53 100644
 --- a/src/device.c

--- a/packages/network/connman/patches/0002-ipv6-disabled-by-default.patch
+++ b/packages/network/connman/patches/0002-ipv6-disabled-by-default.patch
@@ -1,9 +1,9 @@
-commit 707a0d73d7231b1821072712a7771c7aef140e21
-Author: Stefan Saraev <stefan@saraev.ca>
-Date:   Tue Jul 23 11:28:10 2013 +0300
+From 707a0d73d7231b1821072712a7771c7aef140e21 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Tue, 23 Jul 2013 11:28:10 +0300
+Subject: [PATCH] ipv6 disabled by default
 
-    ipv6 disabled by default
-
+---
 diff --git a/src/ipconfig.c b/src/ipconfig.c
 index fbeff8f..3eb61c4 100644
 --- a/src/ipconfig.c

--- a/packages/network/libshairplay/patches/0001-read-airportkey-from-etc.patch
+++ b/packages/network/libshairplay/patches/0001-read-airportkey-from-etc.patch
@@ -1,5 +1,11 @@
---- shairplay-0.9.0.orig/src/shairplay.c
-+++ shairplay-0.9.0/src/shairplay.c
+From ca707042cc4088fd9dc8d5d2c36309b3c91401bf Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sun, 05 May 2013 21:39:27 +0200
+Subject: [PATCH] read airportkey from etc
+
+diff --git a/src/shairplay.c b/src/shairplay.c
+--- a/src/shairplay.c
++++ b/src/shairplay.c
 @@ -313,9 +313,12 @@ main(int argc, char *argv[])
  
  	raop = raop_init_from_keyfile(10, &raop_cbs, "airport.key", NULL);

--- a/packages/network/openssh/patches/0001-keydir.patch
+++ b/packages/network/openssh/patches/0001-keydir.patch
@@ -1,3 +1,9 @@
+From 3df253529b24a73a50367890d32d17135419450a Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sun, 03 Aug 2014 15:23:00 +0200
+Subject: [PATCH] keydir
+
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -5516,6 +5516,19 @@ AC_ARG_WITH([superuser-path],
@@ -38,6 +44,7 @@
  echo "                    Manpage format: $MANTYPE"
  echo "                       PAM support: $PAM_MSG"
  echo "                   OSF SIA support: $SIA_MSG"
+diff --git a/Makefile.in b/Makefile.in
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -34,8 +34,10 @@ TEST_SHELL=@TEST_SHELL@
@@ -66,6 +73,7 @@
  	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
  	-e 's|/etc/moduli|$(sysconfdir)/moduli|g' \
  	-e 's|/etc/ssh/moduli|$(sysconfdir)/moduli|g' \
+diff --git a/pathnames.h b/pathnames.h
 --- a/pathnames.h
 +++ b/pathnames.h
 @@ -18,6 +18,10 @@

--- a/packages/network/openssh/patches/0002-silence-missing-identity-error.patch
+++ b/packages/network/openssh/patches/0002-silence-missing-identity-error.patch
@@ -1,3 +1,9 @@
+From 60d8f2245761d64546eeb2eb3f44fe89984cf08d Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sun, 24 Mar 2013 15:06:00 +0200
+Subject: [PATCH] silence missing identity error
+
+diff --git a/sshconnect2.c b/sshconnect2.c
 --- a/sshconnect2.c
 +++ b/sshconnect2.c
 @@ -1532,9 +1532,7 @@ load_identity_file(Identity *id)

--- a/packages/network/openssh/patches/0003-source-etc-environment.patch
+++ b/packages/network/openssh/patches/0003-source-etc-environment.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] openssh: source /etc/environment
  session.c | 2 --
  1 file changed, 2 deletions(-)
 
+diff --git a/session.c b/session.c
 --- a/session.c
 +++ b/session.c
 @@ -1036,7 +1036,6 @@ do_setup_env(struct ssh *ssh, Session *s

--- a/packages/network/rpcbind/patches/0001-1.2.6-vulnerability-fixes-1.patch
+++ b/packages/network/rpcbind/patches/0001-1.2.6-vulnerability-fixes-1.patch
@@ -1,11 +1,14 @@
-Submitted By: Ken Moffat <ken at linuxfromscratch dot org>
-Date: 2017-05-29
-Initial Package Version: 0.2.4 (also affects earlier versions)
-Upstream Status: Unknown
-Origin: Guido Vranken
-Description: Fixes CVE-2017-8779 (DOS by remote attackers - memory consumption
+From 6f69aa697ef6cfb6f853922a3ef3e97e1c8badbd Mon Sep 17 00:00:00 2001
+From: Ken Moffat <ken@linuxfromscratch.org>
+Date: Mon, 29 May 2017 00:00:00 +0000
+Subject: [PATCH] 1.2.6 vulnerability fixes 1
+
+Fixes CVE-2017-8779 (DOS by remote attackers - memory consumption
 without subsequent free).
 
+Origin: Guido Vranken
+
+---
 diff --git a/src/rpcb_svc_com.c b/src/rpcb_svc_com.c
 index 5862c26..e11f61b 100644
 --- a/src/rpcb_svc_com.c

--- a/packages/network/samba/patches/0951-no-man-4.16.patch
+++ b/packages/network/samba/patches/0951-no-man-4.16.patch
@@ -1,3 +1,8 @@
+From 08de0299286cb7fe04b191917482135090b6915f Mon Sep 17 00:00:00 2001
+From: heitbaum <6086324+heitbaum@users.noreply.github.com>
+Date: Sat, 05 Dec 2020 07:58:54 +0000
+Subject: [PATCH] no man 4.16
+
 diff --git a/docs-xml/wscript_build b/docs-xml/wscript_build
 --- a/docs-xml/wscript_build	2020-12-05 09:01:19.652459634 +0000
 +++ b/docs-xml/wscript_build	2020-12-05 09:10:10.639446971 +0000

--- a/packages/security/nss/patches/0001-3.15.5-standalone-1.patch
+++ b/packages/security/nss/patches/0001-3.15.5-standalone-1.patch
@@ -1,13 +1,16 @@
-Submitted By:            Armin K. <krejzi at email dot com>
-Date:                    2013-07-02
-Initial Package Version: 3.15
-Upstream Status:         Not applicable
-Origin:                  Based on dj's original patch, rediffed and modified for 3.15
-Description:             Adds auto-generated nss.pc and nss-config script, and allows
-                         building without nspr in the source tree.
+From 224963e9fc756a4819702ff2148a604e41cb9e32 Mon Sep 17 00:00:00 2001
+From: Armin K. <krejzi@email.com>
+Date: Tue, 02 Jul 2013 00:00:00 +0000
+Subject: [PATCH] 3.15.5 standalone 1
 
---- a/nss/config/Makefile	1970-01-01 01:00:00.000000000 +0100
-+++ b/nss/config/Makefile	2013-07-02 14:53:56.684750636 +0200
+Adds auto-generated nss.pc and nss-config script, and allows
+building without nspr in the source tree.
+Origin: Based on dj's original patch, rediffed and modified for 3.15
+
+---
+diff --git a/nss/config/Makefile b/nss/config/Makefile
+--- a/nss/config/Makefile
++++ b/nss/config/Makefile
 @@ -0,0 +1,40 @@
 +CORE_DEPTH = ..
 +DEPTH      = ..
@@ -49,8 +52,9 @@ Description:             Adds auto-generated nss.pc and nss-config script, and a
 +
 +dummy: all export libs
 +
---- a/nss/config/nss-config.in	1970-01-01 01:00:00.000000000 +0100
-+++ b/nss/config/nss-config.in	2013-07-02 14:52:58.328084334 +0200
+diff --git a/nss/config/nss-config.in b/nss/config/nss-config.in
+--- a/nss/config/nss-config.in
++++ b/nss/config/nss-config.in
 @@ -0,0 +1,153 @@
 +#!/bin/sh
 +
@@ -205,8 +209,9 @@ Description:             Adds auto-generated nss.pc and nss-config script, and a
 +      echo $libdirs
 +fi      
 +
---- a/nss/config/nss.pc.in	1970-01-01 01:00:00.000000000 +0100
-+++ b/nss/config/nss.pc.in	2013-07-02 14:52:58.328084334 +0200
+diff --git a/nss/config/nss.pc.in b/nss/config/nss.pc.in
+--- a/nss/config/nss.pc.in
++++ b/nss/config/nss.pc.in
 @@ -0,0 +1,12 @@
 +prefix=@prefix@
 +exec_prefix=@exec_prefix@
@@ -220,8 +225,9 @@ Description:             Adds auto-generated nss.pc and nss-config script, and a
 +Libs: -L@libdir@ -lnss@NSS_MAJOR_VERSION@ -lnssutil@NSS_MAJOR_VERSION@ -lsmime@NSS_MAJOR_VERSION@ -lssl@NSS_MAJOR_VERSION@ -lsoftokn@NSS_MAJOR_VERSION@
 +Cflags: -I${includedir}
 +
---- a/nss/Makefile.orig	2020-12-19 09:07:22.015285016 +0000
-+++ a/nss/Makefile	2020-12-19 09:17:06.966350898 +0000
+diff --git a/nss/Makefile b/nss/Makefile
+--- a/nss/Makefile
++++ b/nss/Makefile
 @@ -48,7 +48,6 @@
  #######################################################################
  
@@ -230,8 +236,9 @@ Description:             Adds auto-generated nss.pc and nss-config script, and a
  	$(MAKE) all
  	$(MAKE) latest
  
---- a/nss/manifest.mn	2013-05-28 23:43:24.000000000 +0200
-+++ b/nss/manifest.mn	2013-07-02 14:52:58.331417666 +0200
+diff --git a/nss/manifest.mn b/nss/manifest.mn
+--- a/nss/manifest.mn
++++ b/nss/manifest.mn
 @@ -10,7 +10,7 @@
  
  RELEASE = nss

--- a/packages/security/nss/patches/0002-skip-shlibsign.patch
+++ b/packages/security/nss/patches/0002-skip-shlibsign.patch
@@ -1,10 +1,15 @@
-diff -Naur nss-3.29.5.orig/nss/cmd/shlibsign/Makefile nss-3.29.5/nss/cmd/shlibsign/Makefile
---- nss-3.29.5.orig/nss/cmd/shlibsign/Makefile	2017-09-08 10:56:01.663876686 +0200
-+++ nss-3.29.5/nss/cmd/shlibsign/Makefile	2017-09-08 10:57:19.659306831 +0200
+From 6cadc2e38b1cefe879fb97fd192e39cb102c4d3c Mon Sep 17 00:00:00 2001
+From: Radostan Riedel <raybuntu@gmail.com>
+Date: Wed, 18 Oct 2017 19:42:55 +0000
+Subject: [PATCH] skip shlibsign
+
+diff --git a/nss/cmd/shlibsign/Makefile b/nss/cmd/shlibsign/Makefile
+--- a/nss/cmd/shlibsign/Makefile
++++ b/nss/cmd/shlibsign/Makefile
 @@ -100,7 +100,9 @@
      endif
  endif
- 
+
 +ifndef SKIP_SHLIBSIGN
  libs: install
  ifdef CHECKLOC

--- a/packages/security/nss/patches/0003-disable-host-cflags.patch
+++ b/packages/security/nss/patches/0003-disable-host-cflags.patch
@@ -1,12 +1,17 @@
-diff -Naur nss-3.29.5.orig/nspr/config/autoconf.mk.in nss-3.29.5/nspr/config/autoconf.mk.in
---- nss-3.29.5.orig/nspr/config/autoconf.mk.in	2017-09-08 11:03:27.572619156 +0200
-+++ nss-3.29.5/nspr/config/autoconf.mk.in	2017-09-08 11:03:41.100520343 +0200
+From 6cadc2e38b1cefe879fb97fd192e39cb102c4d3c Mon Sep 17 00:00:00 2001
+From: Radostan Riedel <raybuntu@gmail.com>
+Date: Wed, 18 Oct 2017 19:42:55 +0000
+Subject: [PATCH] disable host cflags
+
+diff --git a/nspr/config/autoconf.mk.in b/nspr/config/autoconf.mk.in
+--- a/nspr/config/autoconf.mk.in
++++ b/nspr/config/autoconf.mk.in
 @@ -104,7 +104,7 @@
  RESOLVE_LINK_SYMBOLS = @RESOLVE_LINK_SYMBOLS@
- 
+
  HOST_CC		= @HOST_CC@
 -HOST_CFLAGS	= @HOST_CFLAGS@
 +#HOST_CFLAGS	= @HOST_CFLAGS@
  HOST_LDFLAGS	= @HOST_LDFLAGS@
- 
+
  DEFINES		= @DEFINES@ @DEFS@

--- a/packages/security/nss/patches/0004-fix-build-of-cmd-with-nssutil.patch
+++ b/packages/security/nss/patches/0004-fix-build-of-cmd-with-nssutil.patch
@@ -1,5 +1,11 @@
---- a/nss/cmd/platlibs.mk	2024-08-24 11:00:43.573034453 +0000
-+++ b/nss/cmd/platlibs.mk	2024-08-24 11:00:46.506390708 +0000
+From 7feb1cd5a559ecdb6e7bb7107c50d293c5320af2 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sat, 24 Aug 2024 06:11:13 +0000
+Subject: [PATCH] fix build of cmd with nssutil
+
+diff --git a/nss/cmd/platlibs.mk b/nss/cmd/platlibs.mk
+--- a/nss/cmd/platlibs.mk
++++ b/nss/cmd/platlibs.mk
 @@ -181,6 +181,7 @@
  	-l$(SQLITE_LIB_NAME) \
  	-L$(NSSUTIL_LIB_DIR) \

--- a/packages/sysutils/dosfstools/patches/0001-silence-backup-boot-sector-diff.patch
+++ b/packages/sysutils/dosfstools/patches/0001-silence-backup-boot-sector-diff.patch
@@ -1,6 +1,13 @@
+From 0c2157aea5574d689eff7852b8ef6d3605fecfa2 Mon Sep 17 00:00:00 2001
+From: mglae <mglmail@arcor.de>
+Date: Sat, 21 Mar 2020 11:44:52 +0100
+Subject: [PATCH] silence backup boot sector diff
+
 
 Do not print backup boot sector diff in non interactive mode to avoid log spam.
 
+---
+diff --git a/src/boot.c b/src/boot.c
 --- a/src/boot.c
 +++ b/src/boot.c
 @@ -302,6 +302,9 @@ static void check_backup_boot(DOS_FS * f

--- a/packages/sysutils/fuse/patches/0001-aarch64-support.patch
+++ b/packages/sysutils/fuse/patches/0001-aarch64-support.patch
@@ -1,3 +1,8 @@
+From 342b515b2e2d554efd0822ca42f24fb2375ab04a Mon Sep 17 00:00:00 2001
+From: Lukas Rusak <lorusak@gmail.com>
+Date: Wed, 10 Feb 2016 08:28:35 +0100
+Subject: [PATCH] aarch64 support
+
 fuse: add aarch64 support
 
 u64/u32 is not defined in sys/types.h, include linux/types.h like

--- a/packages/sysutils/fuse/patches/0002-dont-run-update-rc.d.patch
+++ b/packages/sysutils/fuse/patches/0002-dont-run-update-rc.d.patch
@@ -1,5 +1,11 @@
---- a/util/Makefile.am	2017-06-23 22:47:36.762827097 +0200
-+++ b/util/Makefile.am	2017-06-23 22:47:47.358852950 +0200
+From 9186cc843d722e1c6eef8807736d10dfeed3ee86 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 23 Jun 2017 23:03:28 +0200
+Subject: [PATCH] dont run update rc.d
+
+diff --git a/util/Makefile.am b/util/Makefile.am
+--- a/util/Makefile.am
++++ b/util/Makefile.am
 @@ -39,10 +39,6 @@
  	$(INSTALL_PROGRAM) $(builddir)/mount.fuse $(DESTDIR)$(MOUNT_FUSE_PATH)/mount.fuse
  	$(MKDIR_P) $(DESTDIR)$(INIT_D_PATH)

--- a/packages/sysutils/fuse/patches/0003-fix-configure-ac.patch
+++ b/packages/sysutils/fuse/patches/0003-fix-configure-ac.patch
@@ -1,5 +1,11 @@
---- a/configure.ac	2021-07-25 10:21:45.000000000 +0000
-+++ b/configure.ac	2024-12-30 12:29:55.969242866 +0000
+From 8a132d0340947dda2d7b8f3e8a0955f0f1efa24d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 30 Dec 2024 11:53:40 +0000
+Subject: [PATCH] fix configure ac
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -72,6 +72,8 @@
      done
     ])

--- a/packages/sysutils/libhid/patches/0001-0.2.16-automake-1.13.patch
+++ b/packages/sysutils/libhid/patches/0001-0.2.16-automake-1.13.patch
@@ -1,6 +1,11 @@
-diff -Naur libhid-0.2.16/configure.ac libhid-0.2.16.patch/configure.ac
---- libhid-0.2.16/configure.ac	2007-04-01 22:32:10.000000000 +0200
-+++ libhid-0.2.16.patch/configure.ac	2013-01-12 17:23:25.129691249 +0100
+From 3eacaa69f0b8c6a7473e2b3c8a02ccf4649c487b Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sat, 12 Jan 2013 18:04:38 +0100
+Subject: [PATCH] 0.2.16 automake 1.13
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -21,7 +21,7 @@
  
  AC_INIT(MD_INIT_NAME, MD_INIT_VERSION, MD_INIT_ADDRESS)

--- a/packages/sysutils/libhid/patches/0002-disable-docs.patch
+++ b/packages/sysutils/libhid/patches/0002-disable-docs.patch
@@ -1,5 +1,11 @@
---- a/doc/Makefile.am	2014-12-23 16:37:21.000000000 +0000
-+++ b/doc/Makefile.am	2020-12-27 02:49:58.084611309 +0000
+From 517ed274d6025e44f4637af198a1b37fdeff85ed Mon Sep 17 00:00:00 2001
+From: heitbaum <rudi@heitbaum.com>
+Date: Sun, 27 Dec 2020 02:58:08 +0000
+Subject: [PATCH] disable docs
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
 @@ -1,7 +1,7 @@
  # AM_MAKEFLAGS = @MAKEFLAGS@
  ACLOCAL_AMFLAGS = -I m4

--- a/packages/sysutils/libhid/patches/0003-use-pkgconfig.patch
+++ b/packages/sysutils/libhid/patches/0003-use-pkgconfig.patch
@@ -1,6 +1,11 @@
-diff -Naur libhid-0.2.16/m4/md_check_libusb018b.m4 libhid-0.2.16.patch/m4/md_check_libusb018b.m4
---- libhid-0.2.16/m4/md_check_libusb018b.m4	2004-05-26 02:37:41.000000000 +0200
-+++ libhid-0.2.16.patch/m4/md_check_libusb018b.m4	2016-01-10 00:07:24.000000000 +0100
+From 28cd331e5f9abeacf7028a933879e1f3e6af9c9c Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sun, 10 Jan 2016 00:17:59 +0100
+Subject: [PATCH] use pkgconfig
+
+diff --git a/m4/md_check_libusb018b.m4 b/m4/md_check_libusb018b.m4
+--- a/m4/md_check_libusb018b.m4
++++ b/m4/md_check_libusb018b.m4
 @@ -2,8 +2,8 @@
    [
      AC_CHECK_HEADERS([usb.h])

--- a/packages/sysutils/lirc/patches/0100-disable-python.patch
+++ b/packages/sysutils/lirc/patches/0100-disable-python.patch
@@ -1,3 +1,8 @@
+From 5e541035a75269057fdbee21030cd8a1b4e556d9 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Sat, 12 Aug 2017 11:03:10 +0200
+Subject: [PATCH] disable python
+
 diff --git a/Makefile.am b/Makefile.am
 --- a/Makefile.am
 +++ b/Makefile.am
@@ -107,6 +112,7 @@ diff --git a/configure.ac b/configure.ac
  AX_REPORT_CONDITIONAL([HAVE_PYTHON35])
  
  AS_IF([test x$HAVE_PYMOD_YAML != xyes], AC_MSG_WARN([
+diff --git a/tools/Makefile.am b/tools/Makefile.am
 --- a/tools/Makefile.am
 +++ b/tools/Makefile.am
 @@ -71,12 +71,17 @@ xmode2_SOURCES          = xmode2.cpp

--- a/packages/sysutils/systemd/patches/0001-move-etc-systemd-system-to-storage-.config-system.d.patch
+++ b/packages/sysutils/systemd/patches/0001-move-etc-systemd-system-to-storage-.config-system.d.patch
@@ -1,9 +1,9 @@
-commit 43aba5ffffc6d35ed97db035c5818c76652b06de
-Author: Matthias Reichl <hias@horus.com>
-Date:   Mon Sep 28 23:55:13 2020 +0200
+From 43aba5ffffc6d35ed97db035c5818c76652b06de Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 28 Sep 2020 23:55:13 +0200
+Subject: [PATCH] move /etc/systemd/system to /storage/.config/system.d
 
-    move /etc/systemd/system to /storage/.config/system.d
-
+---
 diff --git a/meson.build b/meson.build
 index dbbddb68e2..4592cd1094 100644
 --- a/meson.build

--- a/packages/sysutils/util-linux/patches/0001-fix-pkgconf.patch
+++ b/packages/sysutils/util-linux/patches/0001-fix-pkgconf.patch
@@ -10,6 +10,7 @@ Subject: [PATCH] fix pkgconf
  libuuid/uuid.pc.in           |    6 +++---
  4 files changed, 12 insertions(+), 12 deletions(-)
 
+diff --git a/libblkid/blkid.pc.in b/libblkid/blkid.pc.in
 --- a/libblkid/blkid.pc.in
 +++ b/libblkid/blkid.pc.in
 @@ -1,7 +1,7 @@
@@ -23,6 +24,7 @@ Subject: [PATCH] fix pkgconf
  
  Name: blkid
  Description: Block device id library
+diff --git a/libmount/mount.pc.in b/libmount/mount.pc.in
 --- a/libmount/mount.pc.in
 +++ b/libmount/mount.pc.in
 @@ -10,9 +10,9 @@
@@ -38,6 +40,7 @@ Subject: [PATCH] fix pkgconf
  
  Name: mount
  Description: mount library
+diff --git a/libsmartcols/smartcols.pc.in b/libsmartcols/smartcols.pc.in
 --- a/libsmartcols/smartcols.pc.in
 +++ b/libsmartcols/smartcols.pc.in
 @@ -1,7 +1,7 @@
@@ -51,6 +54,7 @@ Subject: [PATCH] fix pkgconf
  
  Name: smartcols
  Description: table or tree library
+diff --git a/libuuid/uuid.pc.in b/libuuid/uuid.pc.in
 --- a/libuuid/uuid.pc.in
 +++ b/libuuid/uuid.pc.in
 @@ -1,7 +1,7 @@

--- a/packages/sysutils/util-linux/patches/0002-fix-gettext.patch
+++ b/packages/sysutils/util-linux/patches/0002-fix-gettext.patch
@@ -1,3 +1,9 @@
+From 511ad49fd1104bcfc133bce7b860e17c821d17a5 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 20 Mar 2025 13:27:47 +0000
+Subject: [PATCH] fix gettext
+
+diff --git a/configure.ac b/configure.ac
 --- a/configure.ac
 +++ b/configure.ac
 @@ -300,7 +300,7 @@ UL_YEAR2038_INIT

--- a/packages/sysutils/v4l-utils/patches/0999-pending-t2-descriptor.patch
+++ b/packages/sysutils/v4l-utils/patches/0999-pending-t2-descriptor.patch
@@ -1,6 +1,7 @@
-Subject: libdvbv5: modify T2 delivery system descriptor
-Author:  Martin Vallevand <mvallevand@gmail.com>
-Date:    Fri Jan 2 18:50:48 2026 -0500
+From b1fcc27d835931eeed40a29751156857ba50ef77 Mon Sep 17 00:00:00 2001
+From: Martin Vallevand <mvallevand@gmail.com>
+Date: Fri, 02 Jan 2026 23:50:48 +0000
+Subject: [PATCH] libdvbv5: modify T2 delivery system descriptor
 
 ETSI EN 300 468 6.4.4.3 specifies the frequency loop length in the T2
 delivery system descriptor in bytes but libdvbv5 populates  it as the
@@ -12,13 +13,11 @@ and buffer overflows.
 
 Signed-off-by: Martin Vallevand <mvallevand@gmail.com>
 Signed-off-by: Hans Verkuil <hverkuil+cisco@kernel.org>
-
+Link: http://git.linuxtv.org/cgit.cgi/v4l-utils.git/commit/?id=95ad25f6a77a0a6650f5f657ac2c5046efcd04a0
+---
  lib/libdvbv5/descriptors/desc_t2_delivery.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
----
-
-http://git.linuxtv.org/cgit.cgi/v4l-utils.git/commit/?id=95ad25f6a77a0a6650f5f657ac2c5046efcd04a0
 diff --git a/lib/libdvbv5/descriptors/desc_t2_delivery.c b/lib/libdvbv5/descriptors/desc_t2_delivery.c
 index f88718d350db..5d245cc973c5 100644
 --- a/lib/libdvbv5/descriptors/desc_t2_delivery.c

--- a/packages/textproc/xmlstarlet/patches/0001-usage2c.awk-fix-wrong-basename-regexp.patch
+++ b/packages/textproc/xmlstarlet/patches/0001-usage2c.awk-fix-wrong-basename-regexp.patch
@@ -1,11 +1,10 @@
-Upstream-Status: Submitted [sourceforge]
-
 From 75d789d0ea9716c9a9ae72f42a2fcfa907cf4a12 Mon Sep 17 00:00:00 2001
 From: Matthieu Crapet <mcrapet@gmail.com>
 Date: Mon, 30 Jun 2014 13:52:25 +0200
 Subject: [PATCH] usage2c.awk: fix wrong basename regexp
 
 Previously not matching with filename argument with absolute path.
+Upstream-Status: Submitted [sourceforge]
 
 Signed-off-by: Matthieu Crapet <mcrapet@gmail.com>
 ---

--- a/packages/tools/hdparm/patches/0001-9.42-cflags.patch
+++ b/packages/tools/hdparm/patches/0001-9.42-cflags.patch
@@ -1,6 +1,11 @@
-diff -Naur hdparm-9.39/Makefile hdparm-9.39.patch/Makefile
---- hdparm-9.39/Makefile	2012-01-06 17:05:37.000000000 +0100
-+++ hdparm-9.39.patch/Makefile	2012-07-28 05:22:53.271127964 +0200
+From 164a086d8036ea982a4086c39af36dd1940ed510 Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Sat, 28 Jul 2012 05:25:08 +0200
+Subject: [PATCH] 9.42 cflags
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -13,7 +13,7 @@
  CC ?= gcc
  STRIP ?= strip

--- a/packages/tools/mtools/patches/0001-fix-install.patch
+++ b/packages/tools/mtools/patches/0001-fix-install.patch
@@ -1,8 +1,15 @@
+From 83147370f8c4943eba20bb7722ebf2ed96a6f924 Mon Sep 17 00:00:00 2001
+From: Peter Vicman <peter.vicman@gmail.com>
+Date: Thu, 28 Apr 2016 12:01:15 +0200
+Subject: [PATCH] fix install
+
 removes installing of floppyd, manuals and info
 should fix occasional mtools installation problems few of us had
 
---- a/Makefile.in	2025-02-05 12:30:43.000000000 +0000
-+++ b/Makefile.in	2025-02-23 04:28:25.663710133 +0000
+---
+diff --git a/Makefile.in b/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
 @@ -226,8 +226,8 @@
  uninstall-info:
  	cd $(DESTDIR)$(infodir) && rm -f mtools.info*

--- a/packages/tools/plymouth-lite/patches/0100-link-static.patch
+++ b/packages/tools/plymouth-lite/patches/0100-link-static.patch
@@ -1,3 +1,8 @@
+From 2a5c2bef16c4ace766e61d830b09d59970f58cfd Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sat, 26 Apr 2014 18:29:36 +0300
+Subject: [PATCH] link static
+
 diff --git a/Makefile b/Makefile
 index 6ab27ef..17d12a0 100644
 --- a/Makefile

--- a/packages/tools/populatefs/patches/0001-fix-compilation-issue.patch
+++ b/packages/tools/populatefs/patches/0001-fix-compilation-issue.patch
@@ -1,6 +1,11 @@
-diff -Nur a/src/mod_path.c b/src/mod_path.c
---- a/src/mod_path.c	2016-02-24 04:15:10.000000000 +0100
-+++ b/src/mod_path.c	2018-08-22 16:58:11.884462070 +0200
+From 4d6eb422bc4905bbc370791ba3ae659f97c59399 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Thu, 23 Aug 2018 07:08:13 +0200
+Subject: [PATCH] fix compilation issue
+
+diff --git a/src/mod_path.c b/src/mod_path.c
+--- a/src/mod_path.c
++++ b/src/mod_path.c
 @@ -1,6 +1,7 @@
  #include <stdio.h>
  #include <stdlib.h>

--- a/packages/wayland/compositor/sway/patches/1001-static-ipc-socket.patch
+++ b/packages/wayland/compositor/sway/patches/1001-static-ipc-socket.patch
@@ -1,3 +1,9 @@
+From 26cffee2b4d992f1f936b65430a2e6e4ef254bd5 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 03 Feb 2022 11:09:05 +0100
+Subject: [PATCH] static ipc socket
+
+diff --git a/sway/ipc-server.c b/sway/ipc-server.c
 --- a/sway/ipc-server.c
 +++ b/sway/ipc-server.c
 @@ -138,7 +138,7 @@ struct sockaddr_un *ipc_user_sockaddr(vo

--- a/packages/wayland/compositor/sway/patches/1002-allow-running-as-root.patch
+++ b/packages/wayland/compositor/sway/patches/1002-allow-running-as-root.patch
@@ -1,3 +1,8 @@
+From 26cffee2b4d992f1f936b65430a2e6e4ef254bd5 Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Thu, 03 Feb 2022 11:09:05 +0100
+Subject: [PATCH] allow running as root
+
 Since wayland requires XDG_RUNTIME_DIR--- a/sway/main.c
 +++ b/sway/main.c
 @@ -112,7 +112,8 @@

--- a/packages/wayland/compositor/sway/patches/1003-do-not-use-git-version.patch
+++ b/packages/wayland/compositor/sway/patches/1003-do-not-use-git-version.patch
@@ -1,3 +1,9 @@
+From f3bd0106abd9f4fbf8ef0e5afbe0dc1e90c065d5 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 27 Nov 2022 10:21:30 +0000
+Subject: [PATCH] do not use git version
+
+diff --git a/meson.build b/meson.build
 --- a/meson.build
 +++ b/meson.build
 @@ -158,18 +158,6 @@

--- a/packages/x11/driver/xf86-video-intel/patches/1001-prefer-iris-and-crocus-over-i965.patch
+++ b/packages/x11/driver/xf86-video-intel/patches/1001-prefer-iris-and-crocus-over-i965.patch
@@ -1,5 +1,11 @@
---- /src/sna/sna_dri2.c
-+++ /src/sna/sna_dri2.c
+From d90a20d23cbfc5137dfa4b5fb6227541fa5cc2bf Mon Sep 17 00:00:00 2001
+From: SupervisedThinking <supervisedthinking@gmail.com>
+Date: Wed, 22 Dec 2021 23:31:30 +0100
+Subject: [PATCH] prefer iris and crocus over i965
+
+diff --git a/src/sna/sna_dri2.c b/src/sna/sna_dri2.c
+--- a/src/sna/sna_dri2.c
++++ b/src/sna/sna_dri2.c
 @@ -3707,8 +3707,10 @@
  			return has_i830_dri() ? "i830" : "i915";
  		else if (sna->kgem.gen < 040)

--- a/packages/x11/other/fluxbox/patches/0001-hack-avoid-potential-SIGFPE-in-Menu-updateMenu.patch
+++ b/packages/x11/other/fluxbox/patches/0001-hack-avoid-potential-SIGFPE-in-Menu-updateMenu.patch
@@ -7,9 +7,9 @@ Subject: [PATCH] hack: avoid potential SIGFPE in Menu::updateMenu()
  src/FbTk/Menu.cc |    1 +
  1 files changed, 1 insertions(+), 0 deletions(-)
 
-diff -Naur fluxbox-1.3.7/src/FbTk/Menu.cc fluxbox-1.3.7.patch/src/FbTk/Menu.cc
---- fluxbox-1.3.7/src/FbTk/Menu.cc	2015-02-08 11:44:45.357187009 +0100
-+++ fluxbox-1.3.7.patch/src/FbTk/Menu.cc	2015-02-15 21:37:37.322872231 +0100
+diff --git a/src/FbTk/Menu.cc b/src/FbTk/Menu.cc
+--- a/src/FbTk/Menu.cc
++++ b/src/FbTk/Menu.cc
 @@ -390,6 +390,7 @@
  }
  

--- a/packages/x11/other/fluxbox/patches/0005-dont-build-fbrun.patch
+++ b/packages/x11/other/fluxbox/patches/0005-dont-build-fbrun.patch
@@ -1,6 +1,11 @@
-diff -Naur fluxbox-1.3.6/Makefile.am fluxbox-1.3.6.patch/Makefile.am
---- fluxbox-1.3.6/Makefile.am	2015-01-05 15:14:15.320478262 +0100
-+++ fluxbox-1.3.6.patch/Makefile.am	2015-01-10 20:39:20.376934793 +0100
+From 5d26964a7c0553e922b53105a8a3e5636d586a30 Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Wed, 18 Feb 2015 20:08:26 +0100
+Subject: [PATCH] dont build fbrun
+
+diff --git a/Makefile.am b/Makefile.am
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -79,7 +79,6 @@
  include src/Makemodule.am
  include src/tests/Makemodule.am

--- a/packages/x11/util/xorg-launch-helper/patches/0001-automake-1.14.patch
+++ b/packages/x11/util/xorg-launch-helper/patches/0001-automake-1.14.patch
@@ -1,6 +1,11 @@
-diff -Naur xorg-launch-helper-4/configure.ac xorg-launch-helper-4.patch/configure.ac
---- xorg-launch-helper-4/configure.ac	2012-10-23 21:17:54.000000000 +0200
-+++ xorg-launch-helper-4.patch/configure.ac	2013-12-06 15:57:17.948725894 +0100
+From f9a80baa15a94ca5d1b0a9d62f439772aa20050e Mon Sep 17 00:00:00 2001
+From: Stephan Raue <stephan@openelec.tv>
+Date: Fri, 06 Dec 2013 17:36:45 +0100
+Subject: [PATCH] automake 1.14
+
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -3,7 +3,7 @@
  
  AC_PREREQ([2.68])


### PR DESCRIPTION
Add From/From:/Date:/Subject: headers derived from git history to all 
patches that were plain diffs without git metadata.

- Body text running directly into the diff now has the required
  --- separator inserted.
- Old-style GNU diff headers (diff -Naur, diff -Nur, diff -Nu)
  converted to diff --git syntax; version-prefixed paths
  (pkg-1.2.3/file) stripped to bare a/ and b/ prefixes.
- Orphaned --- a/file / +++ b/file pairs without a preceding
  diff --git line now have the diff --git header added.

- rebased on #11295