### PR TITLE
iptables: enable IPv4/IPv6 extensions to build libipt_REJECT.so and libip6t_REJECT.so

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -12,13 +12,20 @@ PKG_DEPENDS_TARGET="autotools:host gcc:host linux:host libmnl libnftnl"
 PKG_LONGDESC="IP packet filter administration."
 PKG_TOOLCHAIN="autotools"
 
-PKG_CONFIGURE_OPTS_TARGET+=" --enable-nftables --disable-ipv4 --disable-ipv6"
+PKG_CONFIGURE_OPTS_TARGET+=" --enable-nftables"
 
 post_configure_target() {
   libtool_remove_rpath libtool
 }
 
 post_makeinstall_target() {
+  safe_remove ${INSTALL}/usr/sbin/iptables-legacy
+  safe_remove ${INSTALL}/usr/sbin/iptables-legacy-restore
+  safe_remove ${INSTALL}/usr/sbin/iptables-legacy-save
+  safe_remove ${INSTALL}/usr/sbin/ip6tables-legacy
+  safe_remove ${INSTALL}/usr/sbin/ip6tables-legacy-restore
+  safe_remove ${INSTALL}/usr/sbin/ip6tables-legacy-save
+
   mkdir -p ${INSTALL}/usr/config/iptables/
     cp -PR ${PKG_DIR}/config/README ${INSTALL}/usr/config/iptables/
 


### PR DESCRIPTION
Remove --disable-ipv4 and --disable-ipv6 from PKG_CONFIGURE_OPTS_TARGET to allow the REJECT target extensions to be built. Without these .so files, iptables-nft (nf_tables backend) cannot resolve the REJECT target and fails with "Chain 'REJECT' does not exist".

- fixes https://forum.libreelec.tv/thread/30424-firewall-not-working/?postID=205648#post205648
- follow up to #11225


```bash
nuc12:~ # iptables -I INPUT -p tcp --dport 1112 -j REJECT
nuc12:~ # iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
REJECT     tcp  --  anywhere             anywhere             tcp dpt:1112 reject-with icmp-port-unreachable

nuc12:~ # lsmod | grep -i reject
ipt_REJECT             12288  1
nf_reject_ipv4         12288  1 ipt_REJECT
x_tables               28672  7 xt_conntrack,nft_compat,xt_tcpudp,xt_addrtype,xt_set,ipt_REJECT,xt_MASQUERADE
``` 