### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet8-runtime"
-PKG_VERSION="8.0.26"
+PKG_VERSION="8.0.27"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="5fe42fef4dd28548e7fb38a3db6554c5e1f303dd5b0cf559e78f0300b8bcf96b"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.26/aspnetcore-runtime-8.0.26-linux-arm64.tar.gz"
+    PKG_SHA256="bbae812d442b525e3bfe2535fee8484f039ca064a4399adffa4f7529d920c492"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.27/aspnetcore-runtime-8.0.27-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="5272e62ed8c87b6e93358fa826cc9da9b1e490c6d8a99d837240a48207fa3408"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.26/aspnetcore-runtime-8.0.26-linux-arm.tar.gz"
+    PKG_SHA256="46f0410557760037b01c0f189e8965b5061e9c33e7385404e4139a5aae93f27a"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.27/aspnetcore-runtime-8.0.27-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="6ca320e839f1b8a788dd93492f6040bb3c3a230ff335bf3a36ee27f2fbd449e5"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.26/aspnetcore-runtime-8.0.26-linux-x64.tar.gz"
+    PKG_SHA256="101ba21953842d2b8668a43d5d49bc27be44747764921f374bc0176284bd6f09"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.27/aspnetcore-runtime-8.0.27-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet9-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet9-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet9-runtime"
-PKG_VERSION="9.0.15"
+PKG_VERSION="9.0.16"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="b9957022aa5b1c1b7da699fe1e54b4987b75bf816e19a151cd3d5e172074337a"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.15/aspnetcore-runtime-9.0.15-linux-arm64.tar.gz"
+    PKG_SHA256="134335c35cecf0e67ba9989b1c0ddb8970e64b1b6053a57a3a47a1912214bf87"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.16/aspnetcore-runtime-9.0.16-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="8682c4c62ca4981bd02cc5fc870f8028d70e268baaa667cd0a3319819ac3000b"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.15/aspnetcore-runtime-9.0.15-linux-arm.tar.gz"
+    PKG_SHA256="9ef5ca65ce5075331789c215de281783e84677fa658587027485c236d1d65a75"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.16/aspnetcore-runtime-9.0.16-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="729408dde882b71f5679c391039edf80de4d1f79e9bafafff099ae8f39ca0d0c"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.15/aspnetcore-runtime-9.0.15-linux-x64.tar.gz"
+    PKG_SHA256="153087f9397cb3df5da69e25b0720135ced9013215df505f38b4940b2dca4c58"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.16/aspnetcore-runtime-9.0.16-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="2.0.16"
-PKG_SHA256="f93836f943967c8fe608e90fd6dc2c419ce00cfa0ca5266caa86c22ae290f169"
-PKG_REV="0"
+PKG_VERSION="2.1.0"
+PKG_SHA256="9fe7ed66682e3662593a68571e8f13c45158e0997dd0aca28f07ed883a6e0a27"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"

--- a/packages/audio/openal-soft/package.mk
+++ b/packages/audio/openal-soft/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openal-soft"
-PKG_VERSION="1.25.1"
-PKG_SHA256="5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24"
+PKG_VERSION="1.25.2"
+PKG_SHA256="fb27e5839aa11f0e5b9d33756965291fad5d6909ab928ea1f796f4a1a6877894"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openal.org/"
 PKG_URL="https://github.com/kcat/openal-soft/archive/${PKG_VERSION}.tar.gz"

--- a/packages/audio/taglib/package.mk
+++ b/packages/audio/taglib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="taglib"
-PKG_VERSION="2.2.1"
-PKG_SHA256="7e76b5299dcef427c486bffe455098470c8da91cf3ccb9ea804893df57389b5e"
+PKG_VERSION="2.3"
+PKG_SHA256="7349f6fd942418bc7009ebe743eb7c9d055f02921ec56fa436ec25007c47fd38"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://taglib.org"
 PKG_URL="https://taglib.org/releases/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/linux-firmware/intel-ucode/package.mk
+++ b/packages/linux-firmware/intel-ucode/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="intel-ucode"
-PKG_VERSION="20260227"
-PKG_SHA256="fcac5a08d7559a2ce4ad3b1ce5d59619c8adb364b9c51988fedd94220392bb37"
+PKG_VERSION="20260512"
+PKG_SHA256="5a07ce745d0bd8b360a4713564d46d5e38be797316a52abedaff0761e1b02370"
 PKG_ARCH="x86_64"
 PKG_LICENSE="other"
 PKG_SITE="https://downloadcenter.intel.com/search?keyword=linux+microcode"

--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.24.1"
-PKG_SHA256="217151ca318a5576f8e0de72ba0acdf08157ecf12adac42d1af86db0b09a5f5a"
+PKG_VERSION="4.24.2"
+PKG_SHA256="ac24583f271a82ac324f7c6fad7327f65b591ad3492e1dccfee988e2c1c81dd1"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pyinstaller/package.mk
+++ b/packages/python/devel/pyinstaller/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pyinstaller"
-PKG_VERSION="1.0.0"
-PKG_SHA256="c6d691331621cf3fec4822f5c6f83cab3705f79b316225dc454127411677c71f"
+PKG_VERSION="1.0.1"
+PKG_SHA256="052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
 PKG_LICENSE="MIT"
 PKG_SITE="https://pypi.org/project/installer/"
 PKG_URL="https://files.pythonhosted.org/packages/source/i/installer/installer-${PKG_VERSION}.tar.gz"

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="ab0de6af57fbbbc47aed976425d0ed7b9d85e47a"
-PKG_SHA256="cf321ba8109cbcbacb116dda79eaac5324178a6f3df043f81a4fadb77a16f1d3"
+PKG_VERSION="061dfd3abd1155aa068738deec8feac3fe7806e1"
+PKG_SHA256="02ae511b0cce543cafcbb33e0d77db3cad1b07d8d5967eb60467f78b16362d9b"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"


### PR DESCRIPTION
- syncthing: update to 2.1.0 and addon (1)
- openal-soft: update to 1.25.2
- pyinstaller: update to 1.0.1
- taglib: update to 2.3
- samba: update to 4.24.2
- bcm2835-utils: update to githash 061dfd3
- intel-ucode: update to 20260512
- dotnet-runtime: update to 8.0.27 and 9.0.16 and addon (1)
  - aspnet9-runtime: update to 9.0.16
  - aspnet8-runtime: update to 8.0.27