### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="e9341f05882778096d85f8cc34222b5b731bad9561980c377b9e8477dfb1ebc2"
+PKG_SHA256="df1d83df1ffd4045e0a514ef4ea9e2dcb75cd57d6da48d02fd34c25ccbc3e49d"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="055a478ea9010a19d0d4674c0d0e87ade37a4223"
+export PKG_GIT_COMMIT="98f14649600f05480629d5c481878b1e1bcb7c17"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.4.3"
-PKG_SHA256="3dd4e709e1928ba90cf7bcd31025e13dda5517867989972b38f8fe4bd6f3dab6"
+PKG_VERSION="29.5.0"
+PKG_SHA256="406f6ba2f369e384e39bebe837859a888413dd71608ace7a9b0dc7d550dbd570"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="Moby is an open-source project created by Docker to enable and acc
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="56be73107b381194c27938965bca74c4e2bb475b"
+export PKG_GIT_COMMIT="ff8d90ae98c160c3c8751412edbf95ec557217c5"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/gnupg-depends/libksba/package.mk
+++ b/packages/addons/addon-depends/gnupg-depends/libksba/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libksba"
-PKG_VERSION="1.7.0"
-PKG_SHA256="e1d3a5745911f5a663fddecf526541c4241052a9e4cafbc92dc7f4096c7efdac"
+PKG_VERSION="1.8.0"
+PKG_SHA256="296b9db9095749f2aa104202d7ab7fd09ad10710e00780a709c9754b1a1d9292"
 PKG_LICENSE="GPL-3.0"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/libksba/libksba-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mpd"
-PKG_VERSION="0.24.10"
-PKG_SHA256="867f10fd83cde20c240617222b38fbf6885f902015d0da424a28fbafc675e1dd"
-PKG_REV="1"
+PKG_VERSION="0.24.11"
+PKG_SHA256="106ef64c43844a7c8c895e92571474acdf273080250409ba65b974c37c86c967"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.musicpd.org"

--- a/packages/addons/tools/gnupg/package.mk
+++ b/packages/addons/tools/gnupg/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnupg"
-PKG_REV="0"
-PKG_VERSION="2.5.19"
-PKG_SHA256="722aa8a426dd9b44e0d194b73bfee3a3e617d65674cd4d1d062e6df29f1788c6"
+PKG_REV="1"
+PKG_VERSION="2.5.20"
+PKG_SHA256="6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6"
 PKG_LICENSE="GPL-3.0"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-${PKG_VERSION}.tar.bz2"

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.6.4"
-PKG_SHA256="e31ae906dc7fee1c56ccc4279247b385685b926b3f900cebd910d4bd4403d86b"
+PKG_VERSION="1.6.5"
+PKG_SHA256="4c9f7e85a760a4169cd4bc668bafea90fe4838aaf3f08a93f11bb9222809d490"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="3.13.3"
-PKG_SHA256="446a4ae9741cb8f3eeb98c949d25f91b48cb2b8569cae975c4b737392e9024fc"
+PKG_VERSION="3.14.0"
+PKG_SHA256="55852c50eadc1a27229d4840ea14c84f20ede7d85d41cc5827434c63eea1436d"
 PKG_LICENSE="BSD"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://storage.googleapis.com/aom-releases/libaom-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/open-vm-tools/package.mk
+++ b/packages/sysutils/open-vm-tools/package.mk
@@ -4,12 +4,12 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="open-vm-tools"
-PKG_VERSION="13.0.10"
-PKG_SHA256="c301276edbed4b7f2c291678dc952e671c589265eb5233300e0be7287c7268ae"
+PKG_VERSION="13.1.0"
+PKG_SHA256="67a23d505aca77127b081445f758e269b1009e8824cf7f6f2d6efafb0b14d0fd"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/vmware/open-vm-tools"
-PKG_URL="https://github.com/vmware/open-vm-tools/releases/download/stable-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}-25056151.tar.gz"
+PKG_URL="https://github.com/vmware/open-vm-tools/releases/download/stable-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}-25218885.tar.gz"
 PKG_DEPENDS_TARGET="toolchain fuse3 glib libdnet libtirpc"
 PKG_LONGDESC="open-vm-tools: open source implementation of VMware Tools"
 PKG_TOOLCHAIN="autotools"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.31.1"
-PKG_SHA256="e0bb6537de892ce7c63fc5be9ad373eae894b7655c92220ef00316cc33097356"
+PKG_VERSION="1.31.2"
+PKG_SHA256="1daebac6cb5b8946139c9669a7e5c0e4c8f17320de232a6b9bf470f37dc569e4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"


### PR DESCRIPTION
- docker: update to 29.5.0 and addon (2)
  - cli: update to 29.5.0
  - moby: update to 29.5.0
- mpd: update to 0.24.11 and addon (2)
- aom: update to 3.14.0
- open-vm-tools: update to 13.1.0
- libinput: update to 1.31.2
- libksba: update to 1.8.0
- pipewire: update to 1.6.5
- gnupg: update to 2.5.20 and addon (1)