### PR TITLE
externalhelper: fix audio device handling

### DIFF
--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""

--- a/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
@@ -46,7 +46,7 @@ msgid "Custom..."
 msgstr ""
 
 msgctxt "#30108"
-msgid "Custom configuration filename"
+msgid "Custom display configuration file"
 msgstr ""
 
 msgctxt "#30109"

--- a/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
@@ -52,3 +52,15 @@ msgstr ""
 msgctxt "#30109"
 msgid "Configuration override files and custom configurations are read from /storage/.config/kanshi"
 msgstr ""
+
+msgctxt "#30110"
+msgid "Use custom audio device"
+msgstr ""
+
+msgctxt "#30111"
+msgid "Custom audio device"
+msgstr ""
+
+msgctxt "#30112"
+msgid "For ALSA devices enter 'ALSA:' followed by the full PCM name like shown in aplay -L\neg ALSA:sysdefault:CARD=MyCard or ALSA:iec958:CARD=MyCard,DEV=1"
+msgstr ""

--- a/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
+++ b/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
@@ -49,7 +49,10 @@ def get_display_config_setting() -> str | None:
             return '1280x720'
         case 999:
             custom = addon.getSettingString('customdisplayconfig')
-            if custom is None or custom.strip() == '':
+            if custom is None:
+                return None
+            custom = custom.strip()
+            if custom == '':
                 return None
             else:
                 return custom

--- a/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
+++ b/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
@@ -62,9 +62,7 @@ def get_kodi_keyboard_layout() -> str | None:
     return get_kodi_setting('input.libinputkeyboardlayout')
 
 
-def get_kodi_audio_device() -> str | None:
-    device = get_kodi_setting('audiooutput.audiodevice')
-
+def translate_kodi_audio_device(device: str | None) -> str | None:
     if device is None:
         return None
 
@@ -74,12 +72,29 @@ def get_kodi_audio_device() -> str | None:
         return device
     elif device.startswith('ALSA:'):
         alsadev = device[5:]
-        if alsadev.startswith('@'):
+        if alsadev == '@' or alsadev == '@:':
             return 'ALSA:sysdefault'
+        elif alsadev.startswith('@:'):
+            devpos = alsadev.find(',DEV=')
+            if devpos >= 0:
+                dev = alsadev[2:devpos]
+            else:
+                dev = alsadev[2:]
+            if len(dev) > 0:
+                return f'ALSA:sysdefault:{dev}'
+            else:
+                return 'ALSA:sysdefault'
         else:
             return device
     else:
         return 'ALSA:sysdefault'
+
+
+def get_kodi_audio_device() -> str | None:
+    device = get_kodi_setting('audiooutput.audiodevice')
+    translated_device = translate_kodi_audio_device(device)
+    xbmc.log(f'audio device {device} translated to {translated_device}', xbmc.LOGDEBUG)
+    return translated_device
 
 
 def run_external_program(executable: str, args: list | None = None, env: dict | None = None, name: str = '') -> bool:

--- a/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
+++ b/packages/addons/tools/externalhelper/source/resources/lib/externalhelper/utils.py
@@ -97,6 +97,20 @@ def get_kodi_audio_device() -> str | None:
     return translated_device
 
 
+def get_audio_device() -> str | None:
+    if addon.getSettingBool('customaudio'):
+        audiodev = addon.getSettingString('customaudiodevice')
+        if audiodev is None:
+            return None
+        audiodev = audiodev.strip()
+        if audiodev.strip() == '':
+            return None
+        xbmc.log(f'using custom audio device {audiodev}')
+        return audiodev
+    else:
+        return get_kodi_audio_device()
+
+
 def run_external_program(executable: str, args: list | None = None, env: dict | None = None, name: str = '') -> bool:
     addon = xbmcaddon.Addon(ADDON_ID)
 
@@ -108,7 +122,7 @@ def run_external_program(executable: str, args: list | None = None, env: dict | 
 
     # try to determine keyboard layout
     layout = get_kodi_keyboard_layout()
-    audiodev = get_kodi_audio_device()
+    audiodev = get_audio_device()
     displayconfig = get_display_config_setting()
 
     environment = {}

--- a/packages/addons/tools/externalhelper/source/resources/settings.xml
+++ b/packages/addons/tools/externalhelper/source/resources/settings.xml
@@ -35,6 +35,24 @@
                         <heading>30108</heading>
                     </control>
                 </setting>
+                <setting id="customaudio" type="boolean" label="30110">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="customaudiodevice" type="string" label="30111" help="30112">
+                    <level>0</level>
+                    <default>ALSA:sysdefault</default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <dependencies>
+                        <dependency type="visible" setting="customaudio">true</dependency>
+                    </dependencies>
+                    <control type="edit" format="string">
+                        <heading>30111</heading>
+                    </control>
+                </setting>
             </group>
         </category>
     </section>


### PR DESCRIPTION
This fixes the "no audio in flatpak addons" issue reported on the forums:
https://forum.libreelec.tv/thread/13512-flatpak-support/?postID=205783#post205783

Also add an option to manually specify an audio device instead of using the same device as configured in kodi