### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="df1d83df1ffd4045e0a514ef4ea9e2dcb75cd57d6da48d02fd34c25ccbc3e49d"
+PKG_SHA256="de3cdd74a66f4cfe843983e4ca8d2133cf5eecc8ad8b5450cec0b7ccd59f921d"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="98f14649600f05480629d5c481878b1e1bcb7c17"
+export PKG_GIT_COMMIT="2518b52d948a0cbee071d394c03c86a3005636ba"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.5.0"
-PKG_SHA256="406f6ba2f369e384e39bebe837859a888413dd71608ace7a9b0dc7d550dbd570"
+PKG_VERSION="29.5.1"
+PKG_SHA256="26646ad2a39a41ecdc85261f32c491188c995f95130f487332b4c64afaf4cdb4"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_TOOLCHAIN="manual"
 PKG_NO_REFRESH_PATCHES="tools/moby/gen-patches.sh"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="ff8d90ae98c160c3c8751412edbf95ec557217c5"
+export PKG_GIT_COMMIT="dd24a3adc1db4c762fb1b26b35c08ffd936f2d8f"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/flatpak-depends/libxmlb/package.mk
+++ b/packages/addons/addon-depends/flatpak-depends/libxmlb/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxmlb"
-PKG_VERSION="0.3.26"
-PKG_SHA256="1a34bcfa58617675dafd5251921506b31afcc8384de4d1cb09b62a3ead8460a3"
+PKG_VERSION="0.3.27"
+PKG_SHA256="e7a6d493e25b38a85fb3c46ec25be0b4eeae851a5ed1b850c8dd04e7c0a7cef8"
 PKG_LICENSE="LGPL-2.1"
 PKG_SITE="https://github.com/hughsie/libxmlb"
 PKG_URL="https://github.com/hughsie/libxmlb/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/podman/gpgme/package.mk
+++ b/packages/addons/addon-depends/podman/gpgme/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpgme"
-PKG_VERSION="2.0.1"
-PKG_SHA256="821ab0695c842eab51752a81980c92b0410c7eadd04103f791d5d2a526784966"
+PKG_VERSION="2.1.0"
+PKG_SHA256="841c5ea53fc26259f4fbf0e8bde982dea1b8a1ca0cb77e681c82b050566bf92b"
 PKG_LICENSE="gpgme"
 PKG_SITE="https://gnupg.org/software/gpgme/index.html"
 PKG_URL="https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/tailscale/package.mk
+++ b/packages/addons/service/tailscale/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tailscale"
-PKG_VERSION="1.96.4"
-PKG_REV="0"
+PKG_VERSION="1.98.2"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://tailscale.com"
@@ -19,17 +19,17 @@ PKG_ADDON_ICON_SIZE="170"
 PKG_ADDON_TYPE="xbmc.service"
 
 case "${ARCH}" in
-  x86_64)
+  "x86_64")
+    PKG_SHA256="aae02be635e8bffbdaecefb3518344357d39d904c1bbe1e7ca95cd0cbb8ad21c"
     TAILSCALE_ARCH="amd64"
-    PKG_SHA256="a1cba18826b1f91cb25ef7f5b8259b5258339b42db7867af9269e21829ea78cc"
     ;;
-  arm)
+  "arm")
+    PKG_SHA256="58df1d721f2bfdb4ccbd92c26e4a839473d8105d3b761bcd258cc10cda307868"
     TAILSCALE_ARCH="arm"
-    PKG_SHA256="6c8731f096147aaf9e187b39f892692fb2bd56dc2eb1fb8fd06982164f339869"
     ;;
-  aarch64)
+  "aarch64")
+    PKG_SHA256="6f56441fedd4309fb949e8f257d7bd93bc157191968918b906a781fc25029ad4"
     TAILSCALE_ARCH="arm64"
-    PKG_SHA256="a27249bc70d7b37a68f8be7f5c4507ea5f354e592dce43cb5d4f3e742b313c3c"
     ;;
 esac
 

--- a/packages/databases/mariadb-connector-c/package.mk
+++ b/packages/databases/mariadb-connector-c/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.4.8"
-PKG_SHA256="ced7e5063c91fe2bfafd9d63a759490fe53e81df80599a9abad01c570c202f0c"
+PKG_VERSION="3.4.9"
+PKG_SHA256="2c70b74393d589df0bde9b3e17cb7b571d30a45aaf006eda7a273120fb660f3a"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://mariadb.org/"
 PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/databases/mariadb-connector-c/patches/0001-fix-build-error-on-32-bit-systems.patch
+++ b/packages/databases/mariadb-connector-c/patches/0001-fix-build-error-on-32-bit-systems.patch
@@ -14,7 +14,7 @@ diff --git a/libmariadb/mariadb_stmt.c b/libmariadb/mariadb_stmt.c
 index 1f4782e2291e..927cba8588ac 100644
 --- a/libmariadb/mariadb_stmt.c
 +++ b/libmariadb/mariadb_stmt.c
-@@ -538,7 +538,7 @@ unsigned char *mysql_net_store_length(un
+@@ -539,7 +539,7 @@ unsigned char *mysql_net_store_length(un
      return packet + 3;
    }
    *packet++ = 254;

--- a/packages/python/devel/lxml/package.mk
+++ b/packages/python/devel/lxml/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="lxml"
-PKG_VERSION="6.1.0"
-PKG_SHA256="bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13"
+PKG_VERSION="6.1.1"
+PKG_SHA256="ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://lxml.de"
 PKG_URL="https://github.com/lxml/lxml/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="util-linux"
-PKG_VERSION="2.42"
-PKG_SHA256="3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9"
+PKG_VERSION="2.42.1"
+PKG_SHA256="82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f"
 PKG_LICENSE="GPL"
 PKG_URL="https://www.kernel.org/pub/linux/utils/util-linux/v$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host autoconf:host automake:host intltool:host libtool:host pkg-config:host"

--- a/tools/update-functions/tailscale
+++ b/tools/update-functions/tailscale
@@ -1,0 +1,16 @@
+function update_package() {
+  # update tailscale package to "pkgver" version
+  echo "Starting update of tailscale to $pkgver."
+  sed -e "s|^PKG_VERSION=.*|PKG_VERSION=\"${pkgver}\"|" -i "${pkgmk}"
+  sed -e "s|^PKG_VERSION=.*|PKG_VERSION=\"${pkgver}\"|" -i "${pkgmk}"
+
+  sha1url="https://pkgs.tailscale.com/stable/tailscale_${pkgver}_arm64.tgz"
+  sha2url="https://pkgs.tailscale.com/stable/tailscale_${pkgver}_arm.tgz"
+  sha3url="https://pkgs.tailscale.com/stable/tailscale_${pkgver}_amd64.tgz"
+
+  sha1=$(get_sha ${sha1url})
+  sha2=$(get_sha ${sha2url})
+  sha3=$(get_sha ${sha3url})
+
+  update_multiple_sha $pkgmk $sha1 $sha2 $sha3
+}


### PR DESCRIPTION
- tailscale: update to 1.98.2 and addon (1)
- tools/update-functions: add tailscale
- util-linux: update to 2.42.1
- docker: update to 29.5.1 and addon (3)
  - cli: update to 29.5.1
  - moby: update to 29.5.1
- mariadb-connector-c: update to 3.4.9
- lxml: update to 6.1.1
- libxmlb: update to 0.3.27
- gpgme: update to 2.1.0