### PR TITLE
Package updates

### DIFF
--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11960"
-PKG_SHA256="007631fcb3ebab29d5a0fe160fb4ba00fd5a6aed9653f4caee04556bdc65aef4"
-PKG_REV="2"
+PKG_VERSION="11961"
+PKG_SHA256="5ccb30e7378bb33c08b41c11b297d7c28a5c4542e9ebbc88b8669fbc9d43737d"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/addons/service/oscam/patches/0001-link-with-ludev.patch
+++ b/packages/addons/service/oscam/patches/0001-link-with-ludev.patch
@@ -9,18 +9,18 @@ Subject: [PATCH] link with ludev
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4b08cfc0..2eadd8e2 100644
+index f31b956b..e9891c94 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -742,7 +742,7 @@
+@@ -748,7 +748,7 @@ add_executable (${exe_name} ${exe_srcs}
  if (OSCamOperatingSystem MATCHES "Mac OS X")
  	target_link_libraries (${exe_name} ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt minilzo)
  else (OSCamOperatingSystem MATCHES "Mac OS X")
 -	target_link_libraries (${exe_name} -Wl,--start-group ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt -Wl,--end-group minilzo)
 +	target_link_libraries (${exe_name} -Wl,--start-group ${csoscam} ${csmodules} ${csreaders} csctapi cscrypt -Wl,--end-group minilzo udev)
  endif (OSCamOperatingSystem MATCHES "Mac OS X")
- if (WITH_SIGNING EQUAL 1)
- 	SIGN_COMMAND_OSCAM()
+ if (BUILD_TESTS)
+ 	# Test binary stays plain: no sign/upx — see Makefile rationale.
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
 index 49649863..1c368dac 100644
 --- a/utils/CMakeLists.txt
@@ -35,5 +35,5 @@ index 49649863..1c368dac 100644
  
  message (STATUS "Utils: operating system: ${OSCamOperatingSystem}")
 -- 
-2.51.0
+2.53.0
 

--- a/packages/addons/service/oscam/patches/0002-pcsc-pthread.patch
+++ b/packages/addons/service/oscam/patches/0002-pcsc-pthread.patch
@@ -8,10 +8,10 @@ Subject: [PATCH 2/4] pcsc pthread
  1 file changed, 1 insertion(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2eadd8e2..9e8b0fc9 100644
+index e9891c94..061702f2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -815,6 +815,7 @@
+@@ -826,6 +826,7 @@ if (NOT OSCamOperatingSystem MATCHES "Wi
  		target_link_libraries (${exe_name} imp_pcsclite)
  	else (PCSCDIR OR STATICPCSC)
  		target_link_libraries (${exe_name} pcsclite)
@@ -20,5 +20,5 @@ index 2eadd8e2..9e8b0fc9 100644
  endif (NOT OSCamOperatingSystem MATCHES "Windows/Cygwin")
  endif (NOT OSCamOperatingSystem MATCHES "Mac OS X")
 -- 
-2.51.0
+2.53.0
 

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libde265"
-PKG_VERSION="1.0.18"
-PKG_SHA256="800478f3bf35f0621b14928ceb317579f3e8b23de4bd2aac29b6cb8be962bbd8"
+PKG_VERSION="1.0.19"
+PKG_SHA256="bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.21.2"
-PKG_SHA256="75f530b7154bc93e7ecf846edfc0416bf5f490612de8c45983c36385aa742b42"
+PKG_VERSION="1.22.0"
+PKG_SHA256="8bd20cfa3201997b8f63266cddfabea2e1481467d7f992e6a2595e0bec691fc2"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kernel-firmware"
-PKG_VERSION="20260410"
-PKG_SHA256="b7812ed6d59f6b09ecceddaa0be842a7e82a79cc0e46ca60478a4ebf02f1e178"
+PKG_VERSION="20260519"
+PKG_SHA256="b14e7197a290a7e5569f5ef790cde289bddc47e32126f2eb262a8e677fc39727"
 PKG_LICENSE="other"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="22.0.2-Piers"
 PKG_SHA256="09a5e35fd2eee28cdf530f439e29e7cf1f4d0eee72f501e3e4f059c66cec7acc"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/network/rsync/package.mk
+++ b/packages/network/rsync/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsync"
-PKG_VERSION="3.4.2"
-PKG_SHA256="ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315"
+PKG_VERSION="3.4.3"
+PKG_SHA256="c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://rsync.samba.org"
 PKG_URL="https://download.samba.org/pub/rsync/src/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/patches/0003-disable-host-cflags.patch
+++ b/packages/security/nss/patches/0003-disable-host-cflags.patch
@@ -4,9 +4,10 @@ Date: Wed, 18 Oct 2017 19:42:55 +0000
 Subject: [PATCH] disable host cflags
 
 diff --git a/nspr/config/autoconf.mk.in b/nspr/config/autoconf.mk.in
+index ba95532..f0038f9 100644
 --- a/nspr/config/autoconf.mk.in
 +++ b/nspr/config/autoconf.mk.in
-@@ -104,7 +104,7 @@ DSO_LDOPTS	= @DSO_LDOPTS@
+@@ -103,7 +103,7 @@ DSO_LDOPTS	= @DSO_LDOPTS@
  RESOLVE_LINK_SYMBOLS = @RESOLVE_LINK_SYMBOLS@
  
  HOST_CC		= @HOST_CC@
@@ -15,3 +16,6 @@ diff --git a/nspr/config/autoconf.mk.in b/nspr/config/autoconf.mk.in
  HOST_LDFLAGS	= @HOST_LDFLAGS@
  
  DEFINES		= @DEFINES@ @DEFS@
+-- 
+2.53.0
+

--- a/packages/sysutils/open-vm-tools/patches/0783-fix-initialization-discards-const-qualifier-from-poi.patch
+++ b/packages/sysutils/open-vm-tools/patches/0783-fix-initialization-discards-const-qualifier-from-poi.patch
@@ -114,10 +114,10 @@ index 0135e6a0..922b4efe 100644
  
     if ((p = strchr(label, ':')) != NULL) {
 diff --git a/libvmtools/i18n.c b/libvmtools/i18n.c
-index 3085f72d..f61406d1 100644
+index 4caeb16e..2c0a35a7 100644
 --- a/libvmtools/i18n.c
 +++ b/libvmtools/i18n.c
-@@ -698,7 +698,7 @@ VMTools_BindTextDomain(const char *domai
+@@ -711,7 +711,7 @@ VMTools_BindTextDomain(const char *domai
         * If we couldn't find the catalog file for the user's language, see if
         * we can find a more generic language (e.g., for "en_US", also try "en").
         */
@@ -127,7 +127,7 @@ index 3085f72d..f61406d1 100644
           if (usrlang == NULL) {
              usrlang = Util_SafeStrdup(lang);
 diff --git a/services/plugins/vix/vixTools.c b/services/plugins/vix/vixTools.c
-index 654512c5..5c79ca12 100644
+index 694371d1..c2ef00a7 100644
 --- a/services/plugins/vix/vixTools.c
 +++ b/services/plugins/vix/vixTools.c
 @@ -925,7 +925,7 @@ VixToolsBuildUserEnvironmentTable(const
@@ -140,5 +140,5 @@ index 654512c5..5c79ca12 100644
  
        whereToSplit = strchr(*envp, '=');
 -- 
-2.51.0
+2.53.0
 


### PR DESCRIPTION
- imagedecoder.heif: update libheif to 1.22.0 and addon (3)
  - libde265: update to 1.0.19
  - libheif: update to 1.22.0
- oscam: update to 11961 and addon (3)
- rsync: update to 3.4.3
- open-vm-tools: refresh-patches
- nss: refresh-patches
- kernel-firmware: update to 20260519