### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="de3cdd74a66f4cfe843983e4ca8d2133cf5eecc8ad8b5450cec0b7ccd59f921d"
+PKG_SHA256="e5cf80d9e0b6630bb2e97decf664ad5f0c732b296b7c47030044c3a7287bbddb"
 PKG_LICENSE="ASL"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="2518b52d948a0cbee071d394c03c86a3005636ba"
+export PKG_GIT_COMMIT="79eb04c7d8e1d73247cb7fe011eecc645063e0f0"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.3.0"
-PKG_SHA256="915ef1d9fab5fbd8e3726bfb80c901fd87aa25e938bed5194df132853036ed58"
+PKG_VERSION="2.3.1"
+PKG_SHA256="9de4cb8bfb27964a8ffd95e35326b7279ea2e2a6506da16c2533d3f523f12c11"
 PKG_LICENSE="APL"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="2976f38ccbfcda5ef1364d63d60b0a304e4bf94a"
+export PKG_GIT_COMMIT="64b425cf570b3b8dd1d4cc46da7c1fce65c6651a"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.5.1"
-PKG_SHA256="26646ad2a39a41ecdc85261f32c491188c995f95130f487332b4c64afaf4cdb4"
+PKG_VERSION="29.5.2"
+PKG_SHA256="1235ed325d324c76f52e52beaa1dac85c92a073bf2f9fcc5bb9f67e35a668028"
 PKG_LICENSE="ASL"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_TOOLCHAIN="manual"
 PKG_NO_REFRESH_PATCHES="tools/moby/gen-patches.sh"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="dd24a3adc1db4c762fb1b26b35c08ffd936f2d8f"
+export PKG_GIT_COMMIT="568f755ebeb1ac9c6a8febbda6cd371ea0a9630b"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="ASL"
 PKG_SITE="http://www.docker.com/"

--- a/packages/debug/valgrind/package.mk
+++ b/packages/debug/valgrind/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="valgrind"
-PKG_VERSION="3.27.0"
-PKG_SHA256="5b5937de8257ee8f51698ea71b9711adce98061aa07daa4a685efc3af9215bef"
+PKG_VERSION="3.27.1"
+PKG_SHA256="5d589152eb8071c02feab8ce6ab719e431a1fbc3e2b1700f5432632a8b9264dc"
 PKG_LICENSE="GPL"
 PKG_SITE="https://valgrind.org/"
 PKG_URL="https://sourceware.org/pub/valgrind/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/fakeroot/package.mk
+++ b/packages/devel/fakeroot/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fakeroot"
-PKG_VERSION="1.38"
-PKG_SHA256="37504619270923546f36d98107f44a3c3be41c8ccd57dfd722311819623fe002"
+PKG_VERSION="1.38.1"
+PKG_SHA256="37c5063942efe2e2aeefd6e71ae2690bcb9b7d512c53bc6409b54d0730cbdac1"
 PKG_LICENSE="GPL3"
 PKG_SITE="https://tracker.debian.org/pkg/fakeroot"
 PKG_URL="http://ftp.debian.org/debian/pool/main/f/fakeroot/${PKG_NAME}_${PKG_VERSION}.orig.tar.gz"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.88.1"
-PKG_SHA256="51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e"
+PKG_VERSION="2.89.0"
+PKG_SHA256="205bf5dab175de68f11e33be7bb36d4ad4c5a5097d8c0c88a8682b257b6293dc"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/utfcpp/package.mk
+++ b/packages/devel/utfcpp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="utfcpp"
-PKG_VERSION="4.1.0"
-PKG_SHA256="9a45cbeefacf512879971eaf57fe52133b73a0152d5354f3adeaf8d103cff0f3"
+PKG_VERSION="4.1.1"
+PKG_SHA256="1ca68016f0abc24172998e39ce0d8f8e2b7a26f7579a0ff85d4e1b9a7aea56f8"
 PKG_LICENSE="BSL"
 PKG_SITE="https://github.com/nemtrif/utfcpp"
 PKG_URL="https://github.com/nemtrif/utfcpp/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="llvm"
-PKG_VERSION="22.1.5"
-PKG_SHA256="7972b87b705a003ce70ab55f9f0fb495d156887cba0eb296d284731139118e2c"
+PKG_VERSION="22.1.6"
+PKG_SHA256="6e0b376a1f6d9873e7dfb09ae6e04b9c7024400f01733fa4c29be69d5c138bc2"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://llvm.org/"
 PKG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${PKG_VERSION}/llvm-project-${PKG_VERSION/-/}.src.tar.xz"

--- a/packages/python/devel/trove-classifiers/package.mk
+++ b/packages/python/devel/trove-classifiers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="trove-classifiers"
-PKG_VERSION="2026.5.7.17"
-PKG_SHA256="c5d469f4623f3a361f960532feafabb8d30a63d987c9815f380450ad72c56f33"
+PKG_VERSION="2026.5.20.19"
+PKG_SHA256="c04d2431fb42e316c302cce63064ede9801bac498b2bbeb81ee7d2711ba81113"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/pypa/trove-classifiers"
 PKG_URL="https://github.com/pypa/trove-classifiers/archive/refs/tags/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- docker: update to 29.5.2 and addon (4)
  - cli: update to 29.5.2
  - moby: update to 29.5.2
  - containerd: update to 2.3.1
- fakeroot: update to 1.38.1
- trove-classifiers: update to 2026.5.20.19
- utfcpp: update to 4.1.1
- valgrind: update to 3.27.1
- glib: update to 2.89.0
- llvm: update to 22.1.6