### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/at-spi2-core/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="at-spi2-core"
-PKG_VERSION="2.60.3"
-PKG_SHA256="21056bc04e43e8ed34fdafd916a0ddcc29ec03a4ce6cf5aacac1ddf6ef185ef7"
-PKG_LICENSE="OSS"
+PKG_VERSION="2.60.4"
+PKG_SHA256="1a1f5ba9805917f41fc6aa6823dcf887a291d607a427e2d5afb6b5dfa65070c7"
+PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://www.gnome.org/"
 PKG_URL="https://download.gnome.org/sources/at-spi2-core/${PKG_VERSION:0:4}/at-spi2-core-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain atk dbus glib libxml2 libXtst"

--- a/packages/addons/service/tailscale/package.mk
+++ b/packages/addons/service/tailscale/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tailscale"
-PKG_VERSION="1.98.2"
-PKG_REV="1"
+PKG_VERSION="1.98.3"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://tailscale.com"
@@ -20,15 +20,15 @@ PKG_ADDON_TYPE="xbmc.service"
 
 case "${ARCH}" in
   "x86_64")
-    PKG_SHA256="aae02be635e8bffbdaecefb3518344357d39d904c1bbe1e7ca95cd0cbb8ad21c"
+    PKG_SHA256="a53002b0052317179d3fcace99dcd94c87b634dbb453da06b7374a4420c8160a"
     TAILSCALE_ARCH="amd64"
     ;;
   "arm")
-    PKG_SHA256="58df1d721f2bfdb4ccbd92c26e4a839473d8105d3b761bcd258cc10cda307868"
+    PKG_SHA256="5bddc6e257480e239a13dabb13baecc5986dc2cefb45f7a38dda2abaa30ba784"
     TAILSCALE_ARCH="arm"
     ;;
   "aarch64")
-    PKG_SHA256="6f56441fedd4309fb949e8f257d7bd93bc157191968918b906a781fc25029ad4"
+    PKG_SHA256="d26ce4a1a259621fc76d16c7baf3f3a4252f356dfa9d9769484782f766ca1b7f"
     TAILSCALE_ARCH="arm64"
     ;;
 esac

--- a/packages/multimedia/aom/package.mk
+++ b/packages/multimedia/aom/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aom"
-PKG_VERSION="3.14.0"
-PKG_SHA256="55852c50eadc1a27229d4840ea14c84f20ede7d85d41cc5827434c63eea1436d"
-PKG_LICENSE="BSD"
+PKG_VERSION="3.14.1"
+PKG_SHA256="44bf90dbd23e734d50e70a8c41c285193922938bd0d3bc2ee56764d181d55ef5"
+PKG_LICENSE="BSD-2-Clause"
 PKG_SITE="https://www.webmproject.org"
 PKG_URL="https://storage.googleapis.com/aom-releases/libaom-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"

--- a/packages/python/devel/trove-classifiers/package.mk
+++ b/packages/python/devel/trove-classifiers/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="trove-classifiers"
-PKG_VERSION="2026.5.20.19"
-PKG_SHA256="c04d2431fb42e316c302cce63064ede9801bac498b2bbeb81ee7d2711ba81113"
+PKG_VERSION="2026.5.22.10"
+PKG_SHA256="2b0e91573d8b62396e6a0d6068c2676696af81745ca6c16a3b66300c53939185"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/pypa/trove-classifiers"
 PKG_URL="https://github.com/pypa/trove-classifiers/archive/refs/tags/${PKG_VERSION}.tar.gz"

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="061dfd3abd1155aa068738deec8feac3fe7806e1"
-PKG_SHA256="02ae511b0cce543cafcbb33e0d77db3cad1b07d8d5967eb60467f78b16362d9b"
+PKG_VERSION="a9af6dba7094359aea3803aff3e88c8040d5f8c3"
+PKG_SHA256="6df640f93c9652a2f443d178a8ae20c559ded5f023cbb492052e8bf6edc7fb55"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"


### PR DESCRIPTION
- at-spi2-core: update to 2.60.4
- aom: update to 3.14.1
- bcm2835-utils: update to githash a9af6db
- trove-classifiers: update to 2026.5.22.10
- tailscale: update to 1.98.3 and addon (2)