### PR TITLE
Use GITHUB_ACTIONS instead of GHA_AUTO and IS_REPO

### DIFF
--- a/tools/update-functions/tvheadend43
+++ b/tools/update-functions/tvheadend43
@@ -1,13 +1,11 @@
-if [[ "${GHA_AUTO}" != "true" ]]; then
-  function get_pkg_ver() {
-    local github_repos=tvheadend/tvheadend
-  
-    local upstream_default_branch=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}" | jq -r '.default_branch')
-    local upstream_latest_commit=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}/git/refs/heads/${upstream_default_branch}" | jq -r '.object.url')
-  
-    pkgver=$(echo ${upstream_latest_commit} | sed 's#.*/##')
-  }
-fi
+function get_pkg_ver() {
+  local github_repos=tvheadend/tvheadend
+
+  local upstream_default_branch=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}" | jq -r '.default_branch')
+  local upstream_latest_commit=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}/git/refs/heads/${upstream_default_branch}" | jq -r '.object.url')
+
+  pkgver=$(echo ${upstream_latest_commit} | sed 's#.*/##')
+}
 
 function update_package() {
   [ -d tvheadend.git ] || git clone https://github.com/tvheadend/tvheadend.git tvheadend.git
@@ -16,7 +14,7 @@ function update_package() {
     git checkout master
     git fetch
     git pull --rebase
-    git checkout ${fullhash}
+    git checkout ${pkgver}
     TVH_VER=$(support/version)
     git checkout master
     tvhver=${TVH_VER/\~[a-z0-9]*/}

--- a/tools/update-pkg
+++ b/tools/update-pkg
@@ -76,19 +76,20 @@ if [[ ! -v run_sub_package && $(type -t is_sub_package) == function ]]; then
   exit 1
 fi
 
-if [[ "${GHA_AUTO}" == "true" ]]; then
-  # CI mode provides its own inputs.
-  :
+if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+  # Runner supplies correct inputs.
+  # No $2 means a self-versioning package — call get_pkg_ver() to fetch it.
+  [[ $# -eq 1 ]] && [[ $(type -t get_pkg_ver) == function ]] && get_pkg_ver
 else
-  # Manual mode validates package/version args.
+  # Local: enforce version discipline.
   if [[ $(type -t get_pkg_ver) == function ]]; then
     get_pkg_ver
-    [ $# -eq 2 ] && {
+    [[ $# -eq 2 ]] && {
       printf "Error: %s does not allow for specification of version\nUsage: $0 PKG_NAME\n" ${pkgname}
       exit 1
     }
   else
-    [ $# -ne 2 ] && {
+    [[ $# -ne 2 ]] && {
       echo "Usage: $0 PKG_NAME PKG_VERSION"
       exit 1
     }


### PR DESCRIPTION
- fix complementary with https://github.com/LibreELEC/actions/pull/118

GITHUB_ACTIONS is set automatically by every GitHub Actions runner.

For GHA, if $2 absent call get_pkg_ver() to self-fetch;
         if $2 present use it directly.
Local,   if get_pkg_ver() defined run self-fetch and block explicit
           version arg;
         if get_pkg_ver() is absent require $2.