### PR TITLE
Package updates

### DIFF
--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.6.5"
-PKG_SHA256="4c9f7e85a760a4169cd4bc668bafea90fe4838aaf3f08a93f11bb9222809d490"
+PKG_VERSION="1.6.6"
+PKG_SHA256="b2a0a8de6946b8145a453639c936555beb0cbf2f2486e0b1c676cffdaaf029d9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libde265"
-PKG_VERSION="1.0.19"
-PKG_SHA256="bb19a0b485d2643e0eeb7e91f3ab32d1ad617e7c487dbedc91214ca3dbd8d7eb"
+PKG_VERSION="1.1.0"
+PKG_SHA256="afc19dd28e2fc523de5952bba5224ee1d28e286c72436d2843df126cca1181fd"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.22.0"
-PKG_SHA256="8bd20cfa3201997b8f63266cddfabea2e1481467d7f992e6a2595e0bec691fc2"
+PKG_VERSION="1.22.2"
+PKG_SHA256="eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="22.0.2-Piers"
 PKG_SHA256="09a5e35fd2eee28cdf530f439e29e7cf1f4d0eee72f501e3e4f059c66cec7acc"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/tools/flashrom/package.mk
+++ b/packages/tools/flashrom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="flashrom"
-PKG_VERSION="1.5.1"
-PKG_SHA256="1f934b076ed49eace203655ec249fc7861a6b8e87fe4aef732e47b6e485b6293"
+PKG_VERSION="1.7.0"
+PKG_SHA256="4328ace9833f7efe7c334bdd73482cde8286819826cc00149e83fba96bf3ab4f"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://www.flashrom.org"
 PKG_URL="https://download.flashrom.org/releases/${PKG_NAME}-v${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- flashrom: update to 1.7.0
- pipewire: update to 1.6.6
- imagedecoder.heif: update libheif to 1.22.2 and addon (4)
  - libheif: update to 1.22.2
  - libde265: update to 1.1.0