### PR TITLE
[le12.2] samba: update to 4.22.10

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="samba"
-PKG_VERSION="4.22.9"
-PKG_SHA256="15f8fa92d235573880353347167c37f3988c977adcf2e057c4a8f08105477bfc"
+PKG_VERSION="4.22.10"
+PKG_SHA256="e601437cde4845a42e7818379cd0ad5fc4fa518a7cf5284cc0a2657e79b30c34"
 PKG_LICENSE="GPLv3+"
 PKG_SITE="https://www.samba.org"
 PKG_URL="https://download.samba.org/pub/samba/stable/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Release notes:
- https://www.samba.org/samba/history/samba-4.22.10.html