### PR TITLE
add wayvnc for flatpack sessions

### DIFF
--- a/packages/addons/addon-depends/externalhelper-depends/aml/package.mk
+++ b/packages/addons/addon-depends/externalhelper-depends/aml/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="aml"
+PKG_VERSION="1.0.0"
+PKG_SHA256="b2b8f743213af39f40e8bc611147d69e2ea9e010b9b19cb65246582338f28d96"
+PKG_LICENSE="ISC"
+PKG_SITE="https://github.com/any1/aml"
+PKG_URL="https://github.com/any1/aml/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain pkg-config:host"
+PKG_SHORTDESC="Another Main Loop libary"
+
+PKG_DEPENDS_CONFIG="wayland wayland-protocols"

--- a/packages/addons/addon-depends/externalhelper-depends/jansson/package.mk
+++ b/packages/addons/addon-depends/externalhelper-depends/jansson/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="jansson"
+PKG_VERSION="2.15.0"
+PKG_SHA256="070a629590723228dc3b744ae90e965a569efb9c535b3309b52e80e75d8eb3be"
+PKG_ARCH="any"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/akheron/jansson"
+PKG_URL="https://github.com/akheron/jansson/releases/download/v${PKG_VERSION}/jansson-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SHORTDESC="C library for encoding, decoding and manipulating JSON data"
+
+PKG_CMAKE_OPTS_TARGET="-DJANSSON_BUILD_SHARED_LIBS=ON \
+                       -DJANSSON_BUILD_DOCS=OFF \
+                       -DJANSSON_COVERAGE=OFF \
+                       -DJANSSON_EXAMPLES=OFF \
+                       -DJANSSON_TEST_WITH_VALGRIND=OFF \
+                       -DJANSSON_WITHOUT_TESTS=OFF \
+                       -DUSE_DTOA=OFF"

--- a/packages/addons/addon-depends/externalhelper-depends/neatvnc/package.mk
+++ b/packages/addons/addon-depends/externalhelper-depends/neatvnc/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="neatvnc"
+PKG_VERSION="1.0.0"
+PKG_SHA256="993dedc30e72981650770c04438e9759537e4677010e2dab5e792c39afe74601"
+PKG_LICENSE="ISC"
+PKG_SITE="https://github.com/any1/neatvnc"
+PKG_URL="https://github.com/any1/neatvnc/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain aml ffmpeg gnutls jansson libjpeg-turbo libxkbcommon mesa pixman"
+PKG_SHORTDESC="VNC server library that is intended to be fast and neat"
+
+PKG_DEPENDS_CONFIG="wayland wayland-protocols"
+
+PKG_MESON_OPTS_TARGET="-Dexamples=false \
+                       -Dgbm=enabled \
+                       -Dh264=enabled \
+                       -Djpeg=enabled \
+                       -Dnettle=disabled \
+                       -Dtests=false \
+					   -Dtls=enabled"

--- a/packages/addons/addon-depends/externalhelper-depends/wayvnc/package.mk
+++ b/packages/addons/addon-depends/externalhelper-depends/wayvnc/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="wayvnc"
+PKG_VERSION="0.10.0"
+PKG_SHA256="fcfda018d0e07ec00a80071420c8cc2a75885dc6d5e55bb50a9b12353754338f"
+PKG_LICENSE="ISC"
+PKG_SITE="https://github.com/any1/wayvnc"
+PKG_URL="https://github.com/any1/wayvnc/archive/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain aml jansson libdrm mesa neatvnc wayland wayland-protocols"
+PKG_SHORTDESC="A VNC server for wlroots based Wayland compositors"
+PKG_BUILD_FLAGS="-sysroot"
+
+PKG_DEPENDS_CONFIG="wayland wayland-protocols"
+
+PKG_MESON_OPTS_TARGET="-Dman-pages=disabled \
+                       -Dpam=disabled \
+                       -Dscreencopy-dmabuf=enabled \
+                       -Dsystemtap=false \
+                       -Dtests=false"

--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -7,7 +7,7 @@ PKG_REV="3"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain seatd wayland wlroots kanshi cage"
+PKG_DEPENDS_TARGET="toolchain seatd wayland wlroots kanshi cage wayvnc"
 PKG_SECTION="tools"
 PKG_SHORTDESC="External programs helper"
 PKG_LONGDESC="Tools to run external programs in a minimal wayland session"
@@ -25,12 +25,16 @@ addon() {
     cp -P $(get_install_dir seatd)/usr/bin/{seatd,seatd-launch} "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
     cp -P $(get_install_dir cage)/usr/bin/cage "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
     cp -P $(get_install_dir kanshi)/usr/bin/kanshi "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
+	cp -P $(get_install_dir wayvnc)/usr/bin/wayvnc "${ADDON_BUILD}/${PKG_ADDON_ID}/bin"
 
-    for f in seatd seatd-launch cage kanshi; do
+    for f in seatd seatd-launch cage kanshi wayvnc; do
       patchelf --add-rpath '${ORIGIN}/../lib.private' "${ADDON_BUILD}/${PKG_ADDON_ID}/bin/${f}"
     done
 
   mkdir -p "${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private"
+    cp -L $(get_install_dir aml)/usr/lib/libaml.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/
+    cp -L $(get_install_dir jansson)/usr/lib/libjansson.so.4 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/
+    cp -L $(get_install_dir neatvnc)/usr/lib/libneatvnc.so.1 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/
     cp -L $(get_install_dir seatd)/usr/lib/libseat.so.1 "${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private"
     cp -L $(get_install_dir wayland)/usr/lib/libwayland-{client,server}.so.0 "${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private"
     cp -L $(get_install_dir wlroots)/usr/lib/libwlroots*.so "${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private"

--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="3"
+PKG_REV="4"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""

--- a/packages/addons/tools/externalhelper/source/bin/wayland-session-helper
+++ b/packages/addons/tools/externalhelper/source/bin/wayland-session-helper
@@ -6,6 +6,7 @@
 
 addondir=$(dirname "$(dirname "$0")")
 
+# choose the kanshi display configuration
 CONF=""
 if [ -n "${KODI_DISPLAY_CONFIG}" ]; then
   CONF="/storage/.config/kanshi/${KODI_DISPLAY_CONFIG}"
@@ -26,9 +27,20 @@ if [ -z "${CONF}" ]; then
 fi
 echo "using kanshi configuration ${CONF}"
 
+# launch kanshi display configuration
 kanshi -c "${CONF}" &
 KANSHI_PID=$!
 
+# run WayVNC if enabled
+WAYVNC_PID=$(${addondir}/bin/wayvnc-session-helper)
+
+# continue with the remaining session command
 "$@"
 
+# stop kanshi when the session ends
 kill -TERM "${KANSHI_PID}"
+
+# stop wayvnc when the session ends
+if [ -n "${WAYVNC_PID}" ]; then
+  kill -TERM "${WAYVNC_PID}"
+fi

--- a/packages/addons/tools/externalhelper/source/bin/wayvnc-session-helper
+++ b/packages/addons/tools/externalhelper/source/bin/wayvnc-session-helper
@@ -1,0 +1,70 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+. /etc/profile
+
+oe_setup_addon tools.externalhelper
+
+# exit if wayvnc is not enabled
+if [ "${WAYVNC_ENABLE}" != "true" ]; then
+  exit 0
+fi
+
+# get local ip address for wayvnc to bind to
+WAYVNC_LOCAL_IP=$(ip -4 addr show scope global | grep inet | awk '{print $2}' | cut -d/ -f1)
+
+# port for wayvnc to listen on
+WAYVNC_PORT="${WAYVNC_PORT:-5900}"
+
+# config files for wayvnc
+WAYVNC_CONFIG_FILE="$ADDON_HOME/wayvnc.config"
+WAYVNC_OPENSSL_FILE="$ADDON_HOME/openssl.cnf"
+
+# bind address + port
+WAYVNC_CMD="wayvnc ${WAYVNC_LOCAL_IP:-127.0.0.1} ${WAYVNC_PORT}"
+
+# optional password
+if [ "${WAYVNC_PASSWORD_ENABLE}" = "true" ] && [ -n "${WAYVNC_PASSWORD}" ]; then
+  # generate TLS certificates if not already present
+  if [ ! -f "$ADDON_HOME/tls_key.pem" ] || [ ! -f "$ADDON_HOME/tls_cert.pem" ]; then
+    cat >"${WAYVNC_OPENSSL_FILE}" <<'EOF'
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[ req_distinguished_name ]
+CN = localhost
+[ v3_req ]
+subjectAltName = @alt_names
+[ alt_names ]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+    openssl req -x509 -newkey ed25519 \
+      -nodes -days 3650 \
+      -keyout "$ADDON_HOME/tls_key.pem" -out "$ADDON_HOME/tls_cert.pem" \
+      -config "${WAYVNC_OPENSSL_FILE}"
+  fi
+
+  WAYVNC_CONFIG_CONTENT="$(
+    cat <<EOF
+use_relative_paths=true
+enable_auth=true
+username=${WAYVNC_USERNAME}
+password=${WAYVNC_PASSWORD}
+private_key_file=tls_key.pem
+certificate_file=tls_cert.pem
+EOF
+  )"
+
+  # only update the WayVNC config file when content has changed
+  if [ ! -f "${WAYVNC_CONFIG_FILE}" ] || ! echo -n "$WAYVNC_CONFIG_CONTENT" | cmp -s - "${WAYVNC_CONFIG_FILE}"; then
+    echo -n "$WAYVNC_CONFIG_CONTENT" >"${WAYVNC_CONFIG_FILE}"
+  fi
+  WAYVNC_CMD="${WAYVNC_CMD} --config ${WAYVNC_CONFIG_FILE}"
+fi
+
+# launch wayvnc with the configured options
+${WAYVNC_CMD} >&2 &
+echo "$!"

--- a/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/tools/externalhelper/source/resources/language/resource.language.en_gb/strings.po
@@ -64,3 +64,27 @@ msgstr ""
 msgctxt "#30112"
 msgid "For ALSA devices enter 'ALSA:' followed by the full PCM name like shown in aplay -L\neg ALSA:sysdefault:CARD=MyCard or ALSA:iec958:CARD=MyCard,DEV=1"
 msgstr ""
+
+msgctxt "#30200"
+msgid "VNC"
+msgstr ""
+
+msgctxt "#30201"
+msgid "Enable VNC"
+msgstr ""
+
+msgctxt "#30202"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30203"
+msgid "Enable Password"
+msgstr ""
+
+msgctxt "#30204"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30205"
+msgid "Password"
+msgstr ""

--- a/packages/addons/tools/externalhelper/source/resources/settings.xml
+++ b/packages/addons/tools/externalhelper/source/resources/settings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <settings version="1">
     <section id="tools.externalhelper">
         <category id="general" label="30100">
@@ -6,7 +6,7 @@
                 <setting id="confirmstart" type="boolean" label="30101">
                     <level>0</level>
                     <default>true</default>
-                    <control type="toggle"/>
+                    <control type="toggle" />
                 </setting>
                 <setting id="displayconfig" type="integer" label="30102" help="30109">
                     <level>0</level>
@@ -20,7 +20,7 @@
                             <option label="30107">999</option>  <!-- custom -->
                         </options>
                     </constraints>
-                    <control type="spinner" format="string"/>
+                    <control type="spinner" format="string" />
                 </setting>
                 <setting id="customdisplayconfig" type="string" label="30108">
                     <level>0</level>
@@ -52,6 +52,62 @@
                     <control type="edit" format="string">
                         <heading>30111</heading>
                     </control>
+                </setting>
+            </group>
+        </category>
+        <category id="VNC" label="30200">
+            <group id="1">
+                <setting id="WAYVNC_ENABLE" type="boolean" label="30201" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="WAYVNC_PORT" type="integer" label="30202" help="5900">
+                    <level>0</level>
+                    <default>5900</default>
+                    <control type="edit" format="integer">
+                        <heading>30202</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="WAYVNC_ENABLE" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
+                <setting id="WAYVNC_PASSWORD_ENABLE" type="boolean" label="30203" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                    <dependencies>
+                        <dependency type="visible" setting="WAYVNC_ENABLE" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
+                <setting id="WAYVNC_USERNAME" type="string" label="30204" help="">
+                    <level>0</level>
+                    <default>libreelec</default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30204</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="WAYVNC_ENABLE" operator="is">true</dependency>
+                        <dependency type="visible" setting="WAYVNC_PASSWORD_ENABLE" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
+                <setting id="WAYVNC_PASSWORD" type="string" label="30205" help="">
+                    <level>0</level>
+                    <default />
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30205</heading>
+                        <hidden>true</hidden>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="WAYVNC_ENABLE" operator="is">true</dependency>
+                        <dependency type="visible" setting="WAYVNC_PASSWORD_ENABLE" operator="is">true</dependency>
+                    </dependencies>
                 </setting>
             </group>
         </category>


### PR DESCRIPTION
- adds wayvnc for the wayland session at flatpack
- allows using vnc with or without password
- to set a password there is a tls cert needed (is generated automatically by the script) otherwise password does not work at all
- wayvnc does not bind to 0.0.0.0 to avoid leaking to the internet