### PR TITLE
kodi: bump to c61e5d12 and update reardonia/integration-test patches

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="adea3eed9f55f3dbb6aceb292eff0018d4e1f501"
-PKG_SHA256="aa498abc542cc04cace9125e644019da1e97a5b9a1695d26eca4a3755e8d8c18"
+PKG_VERSION="c61e5d12099f0f4e9d38fdd0ec0fd0b9d6cd304a"
+PKG_SHA256="a03e71f84819854f0151800ee2d5a611492d926484049e9b8bee369c38dc5ee1"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-WinSystemGbm-move-HDR-transfer-function-check-into-S.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-WinSystemGbm-move-HDR-transfer-function-check-into-S.patch
@@ -1,7 +1,7 @@
-From e360be0c67f53ba433b75b2a6364ff41cc1b7ec6 Mon Sep 17 00:00:00 2001
+From 05f352b3943450f378401ce88d1ddaf275377bb8 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Tue, 7 Apr 2026 11:23:14 -0400
-Subject: [PATCH 01/24] WinSystemGbm: move HDR transfer function check into
+Subject: [PATCH 01/25] WinSystemGbm: move HDR transfer function check into
  SetHDR
 
 Move the color_transfer check (PQ/HLG) from individual renderer

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-WinSystemGbm-cache-EOTF-and-colorimetry-in-SetHDR.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-WinSystemGbm-cache-EOTF-and-colorimetry-in-SetHDR.patch
@@ -1,7 +1,7 @@
-From bec7207c534a63cb833250a7027498f2c8382901 Mon Sep 17 00:00:00 2001
+From 9ecb1eace45025db62de9a989f6500a7029835b1 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Mon, 30 Mar 2026 19:52:52 -0400
-Subject: [PATCH 02/24] WinSystemGbm: cache EOTF and colorimetry in SetHDR
+Subject: [PATCH 02/25] WinSystemGbm: cache EOTF and colorimetry in SetHDR
 
 Store the current EOTF and colorimetry when SetHDR is called so other
 components (e.g. screenshot capture) can query the active HDR state

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-GBM-use-CDRMPropertyBlob-for-HDR_OUTPUT_METADATA.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-GBM-use-CDRMPropertyBlob-for-HDR_OUTPUT_METADATA.patch
@@ -1,7 +1,7 @@
-From 9d2e53793cd8620ef1fabc6c47f5f4feebe40e9c Mon Sep 17 00:00:00 2001
+From 8d132b29a0aad9ac06bbe80b8f7fff5d000df32a Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Mon, 20 Apr 2026 11:30:59 -0400
-Subject: [PATCH 03/24] GBM: use CDRMPropertyBlob for HDR_OUTPUT_METADATA
+Subject: [PATCH 03/25] GBM: use CDRMPropertyBlob for HDR_OUTPUT_METADATA
 
 CDRMPropertyBlob (introduced in the previous commit) is now used for
 the HDR_OUTPUT_METADATA blob member in CWinSystemGbm. Replaces the

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-HDRUtils-factor-video-metadata-helpers-out-of-DRMPRI.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-HDRUtils-factor-video-metadata-helpers-out-of-DRMPRI.patch
@@ -1,7 +1,7 @@
-From e62b261ab289a4e685a5c4dc602d4a485fb47559 Mon Sep 17 00:00:00 2001
+From 20a2a881c7937bf835029819bb07c767edef2829 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Tue, 10 Mar 2026 11:44:30 -0400
-Subject: [PATCH 04/24] HDRUtils: factor video metadata helpers out of DRMPRIME
+Subject: [PATCH 04/25] HDRUtils: factor video metadata helpers out of DRMPRIME
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-GBM-add-SetColorimetry-with-BT709-SMPTE170M-BT2020-s.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-GBM-add-SetColorimetry-with-BT709-SMPTE170M-BT2020-s.patch
@@ -1,7 +1,7 @@
-From fd2c0b11c9675c022f6d1a57288542f35680e3d7 Mon Sep 17 00:00:00 2001
+From 5dc1dfb1b1b2a56a52de9b96f9ce7d14d66339a7 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Tue, 10 Mar 2026 11:44:49 -0400
-Subject: [PATCH 05/24] GBM: add SetColorimetry with BT709/SMPTE170M/BT2020
+Subject: [PATCH 05/25] GBM: add SetColorimetry with BT709/SMPTE170M/BT2020
  signaling
 
 Add SetColorimetry() virtual to CWinSystemBase with GBM implementation

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-Colorimetry-add-ColorimetryToString-consolidate-infe.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-Colorimetry-add-ColorimetryToString-consolidate-infe.patch
@@ -1,7 +1,7 @@
-From 7564cc83dc44ae42600f8c44e9ad6b19d8f368bf Mon Sep 17 00:00:00 2001
+From fa05dca7c54576292d509e8a912ac02da5900d48 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sun, 8 Mar 2026 23:00:24 -0400
-Subject: [PATCH 06/24] Colorimetry: add ColorimetryToString, consolidate
+Subject: [PATCH 06/25] Colorimetry: add ColorimetryToString, consolidate
  inference logic
 
 - Add ColorimetryToString() to HDRUtils as single source for DRM

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-Renderers-pair-SetColorimetry-with-SetHDR-in-all-Lin.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-Renderers-pair-SetColorimetry-with-SetHDR-in-all-Lin.patch
@@ -1,7 +1,7 @@
-From 4e45edba0d818bc9e31dc803e11f1750756df3f1 Mon Sep 17 00:00:00 2001
+From b54f570aea57d888d77ea74ac42b7fc8ff9455eb Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Mon, 20 Apr 2026 10:36:54 -0400
-Subject: [PATCH 07/24] Renderers: pair SetColorimetry with SetHDR in all Linux
+Subject: [PATCH 07/25] Renderers: pair SetColorimetry with SetHDR in all Linux
  renderers
 
 LinuxRendererGLES already called SetColorimetry, but LinuxRendererGL,

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0008-DRMPRIME-handle-Colorimetry-HDR-in-renderer-not-in-b.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0008-DRMPRIME-handle-Colorimetry-HDR-in-renderer-not-in-b.patch
@@ -1,7 +1,7 @@
-From 7b57a88ef0f5b38de7158b04aadb9bb0bcec3590 Mon Sep 17 00:00:00 2001
+From 6971be8b0f21a26d8336d6b3530029e851baa80e Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sun, 17 May 2026 00:40:33 -0400
-Subject: [PATCH 08/24] DRMPRIME: handle Colorimetry & HDR in renderer not in
+Subject: [PATCH 08/25] DRMPRIME: handle Colorimetry & HDR in renderer not in
  bridge
 
 Move SetHDR / SetGuiCompositing ownership from CVideoLayerBridgeDRMPRIME

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0009-GBM-enable-YUV422-support-for-GL-and-GLES-renderers.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0009-GBM-enable-YUV422-support-for-GL-and-GLES-renderers.patch
@@ -1,7 +1,7 @@
-From 3d9a3db275f7a7132275bf26e0471fc2d54d7e7a Mon Sep 17 00:00:00 2001
+From bae58767a922e9d4c0a796b739f37f34fd1c3bb9 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sat, 4 Apr 2026 10:50:06 -0400
-Subject: [PATCH 09/24] GBM: enable YUV422 support for GL and GLES renderers
+Subject: [PATCH 09/25] GBM: enable YUV422 support for GL and GLES renderers
 
 Add YUV422P (planar) and YUYV422/UYVY422 (packed) format support for
 GBM platforms. Register CProcessInfoGBM for GL context (was GLES-only),

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0010-LinuxRendererGLES-check-GL_EXT_texture_format_BGRA88.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0010-LinuxRendererGLES-check-GL_EXT_texture_format_BGRA88.patch
@@ -1,7 +1,7 @@
-From 0c077560a0ae071d1c144f4bf3e455c4afabfa97 Mon Sep 17 00:00:00 2001
+From 8b3e08fa9ac3a22b69276fcc0ffd5223d6da0a05 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sat, 4 Apr 2026 10:50:23 -0400
-Subject: [PATCH 10/24] LinuxRendererGLES: check GL_EXT_texture_format_BGRA8888
+Subject: [PATCH 10/25] LinuxRendererGLES: check GL_EXT_texture_format_BGRA8888
  for packed 422
 
 Packed YUV422 texture upload uses GL_BGRA_EXT which requires

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0011-GBM-enable-YUV444P-support-for-GL-and-GLES-renderers.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0011-GBM-enable-YUV444P-support-for-GL-and-GLES-renderers.patch
@@ -1,7 +1,7 @@
-From 55d41c5795d25884ef3eff47e6635aa6129d1449 Mon Sep 17 00:00:00 2001
+From f7cf4aadb325c1d37460e0835ad067dfc531df3d Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sun, 19 Apr 2026 20:42:53 -0400
-Subject: [PATCH 11/24] GBM: enable YUV444P support for GL and GLES renderers
+Subject: [PATCH 11/25] GBM: enable YUV444P support for GL and GLES renderers
 
 Extend the YUV422 render path to also handle YUV444P (planar 4:4:4).
 ProcessInfoGBM advertises the format, BaseRenderer maps it to

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0012-LinuxRendererGL-GLES-rename-YV12-helpers-to-reflect-.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0012-LinuxRendererGL-GLES-rename-YV12-helpers-to-reflect-.patch
@@ -1,7 +1,7 @@
-From bb707a8069f16b878b93e7d37e0379a834b30971 Mon Sep 17 00:00:00 2001
+From a85573cf3fd89c6365c3bb66f65da19a3b76eff3 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sun, 19 Apr 2026 21:12:08 -0400
-Subject: [PATCH 12/24] LinuxRendererGL/GLES: rename YV12 helpers to reflect
+Subject: [PATCH 12/25] LinuxRendererGL/GLES: rename YV12 helpers to reflect
  actual formats
 
 The Create/Delete/Upload helpers named after YV12 have handled

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0013-GBM-422-444-extend-for-8bit-content-via-av_pix_fmt.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0013-GBM-422-444-extend-for-8bit-content-via-av_pix_fmt.patch
@@ -1,7 +1,7 @@
-From e08a5261bb8537f35dbe7d8ca8efb3189a50a876 Mon Sep 17 00:00:00 2001
+From 164729e8fe1de98980fbd4cce2e0f192e5b5adfd Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Thu, 7 May 2026 10:29:50 -0400
-Subject: [PATCH 13/24] GBM/422-444: extend for >8bit content via av_pix_fmt
+Subject: [PATCH 13/25] GBM/422-444: extend for >8bit content via av_pix_fmt
 
 Extend YUV422P/YUV444P support to >8bit (9/10/12/14/16-bit) content.
 Replaces per-format hardcoded checks with libavutil av_pix_fmt-based

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0014-GBM-gate-8bit-formats-on-GL_EXT_texture_norm16-at-ru.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0014-GBM-gate-8bit-formats-on-GL_EXT_texture_norm16-at-ru.patch
@@ -1,7 +1,7 @@
-From dfd478f5167ced9c1493004387fdcf810c7cbf4f Mon Sep 17 00:00:00 2001
+From 36b420f177685c92e924383e82e26d0e4c466179 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Thu, 7 May 2026 11:12:52 -0400
-Subject: [PATCH 14/24] GBM: gate >8bit formats on GL_EXT_texture_norm16 at
+Subject: [PATCH 14/25] GBM: gate >8bit formats on GL_EXT_texture_norm16 at
  runtime
 
 Advertise YUV420P/YUV422P/YUV444P at 9/10/12/14/16-bit from

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0015-LinuxRendererGLES-refuse-unsupported-pix_fmt-in-Conf.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0015-LinuxRendererGLES-refuse-unsupported-pix_fmt-in-Conf.patch
@@ -1,7 +1,7 @@
-From 96e0248cf511c815d0fef85c41b60c7c0036661e Mon Sep 17 00:00:00 2001
+From d9591ee6bc16dec5a432f6356625b5eb240bc4b9 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 15 May 2026 22:18:14 -0400
-Subject: [PATCH 15/24] LinuxRendererGLES: refuse unsupported pix_fmt in
+Subject: [PATCH 15/25] LinuxRendererGLES: refuse unsupported pix_fmt in
  Configure
 
 The renderer is CPU-upload only, but Configure accepted m_format blindly

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0016-VAAPI-introduce-CCapabilities-for-fourcc-capability-.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0016-VAAPI-introduce-CCapabilities-for-fourcc-capability-.patch
@@ -1,7 +1,7 @@
-From 8f3a7aa3cade89c318dc6d1c154e992ac8464418 Mon Sep 17 00:00:00 2001
+From b65e89af200fc579021083b418b9749098d63dc1 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 09:35:57 -0400
-Subject: [PATCH 16/24] VAAPI: introduce CCapabilities for fourcc capability
+Subject: [PATCH 16/25] VAAPI: introduce CCapabilities for fourcc capability
  tracking
 
 Replace CDecoder's static bool m_capGeneral / m_capDeepColor pair with a

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0017-VAAPI-GLES-hardware-decode-for-12-bit-4-2-0-P012-P01.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0017-VAAPI-GLES-hardware-decode-for-12-bit-4-2-0-P012-P01.patch
@@ -1,7 +1,7 @@
-From 2be07d4d3e21930f994b5e770121ea7909ddaa10 Mon Sep 17 00:00:00 2001
+From 944f0fed491ad0d6b262ac2dd4c67b308903b655 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 09:37:28 -0400
-Subject: [PATCH 17/24] VAAPI/GLES: hardware decode for 12-bit 4:2:0 (P012,
+Subject: [PATCH 17/25] VAAPI/GLES: hardware decode for 12-bit 4:2:0 (P012,
  P016)
 
 Cover HEVC Main12 and VP9 Profile 2 at 12-bit, previously advertised by

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0018-VAAPI-GLES-hardware-decode-for-packed-4-2-2-Y210-Y21.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0018-VAAPI-GLES-hardware-decode-for-packed-4-2-2-Y210-Y21.patch
@@ -1,7 +1,7 @@
-From aad23c657a2139095c8e6417dc8060f0a9bf09cf Mon Sep 17 00:00:00 2001
+From 72eb155e51ba155bead137188c2308f69165be81 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 10:01:54 -0400
-Subject: [PATCH 18/24] VAAPI/GLES: hardware decode for packed 4:2:2 (Y210,
+Subject: [PATCH 18/25] VAAPI/GLES: hardware decode for packed 4:2:2 (Y210,
  Y212, Y216)
 
 Cover HEVC Main422_10 and Main422_12 on GBM + GLES by wiring up the

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0019-VAAPI-GLES-hardware-decode-for-packed-4-4-4-AYUV-XYU.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0019-VAAPI-GLES-hardware-decode-for-packed-4-4-4-AYUV-XYU.patch
@@ -1,7 +1,7 @@
-From 620d47eabae7ef26efbef801a6f0daf9dd2ada83 Mon Sep 17 00:00:00 2001
+From 73d99fa376b1ae2d70db8596e2f888ef7104668b Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 10:05:25 -0400
-Subject: [PATCH 19/24] VAAPI/GLES: hardware decode for packed 4:4:4 (AYUV,
+Subject: [PATCH 19/25] VAAPI/GLES: hardware decode for packed 4:4:4 (AYUV,
  XYUV, Y410, Y412, Y416)
 
 Cover HEVC Main444 / Main444_10 / Main444_12 and VP9 Profile 1 / Profile

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0020-VAAPI-GLES-work-around-Mesa-Y2xx-import-via-ABGR1616.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0020-VAAPI-GLES-work-around-Mesa-Y2xx-import-via-ABGR1616.patch
@@ -1,7 +1,7 @@
-From 7438b0225fdf4ff3b6d6011c05198e93df7c399f Mon Sep 17 00:00:00 2001
+From 9e56d6dd9f99192be66ba08802ca38367e096e29 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 10:06:00 -0400
-Subject: [PATCH 20/24] VAAPI/GLES: work around Mesa Y2xx import via
+Subject: [PATCH 20/25] VAAPI/GLES: work around Mesa Y2xx import via
  ABGR16161616 reinterpretation
 
 Mesa imports DRM_FORMAT_Y210 / Y212 / Y216 as a two-plane internal

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0021-VAAPI-bounds-check-VA-driver-object_index-before-ind.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0021-VAAPI-bounds-check-VA-driver-object_index-before-ind.patch
@@ -1,7 +1,7 @@
-From da8856970f2aa1c0ac799e822657952c7474827a Mon Sep 17 00:00:00 2001
+From 0c15d89ac02da594f4a03f53d43324b4e5d78412 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 08:33:40 -0400
-Subject: [PATCH 21/24] VAAPI: bounds-check VA-driver object_index before
+Subject: [PATCH 21/25] VAAPI: bounds-check VA-driver object_index before
  indexing surface.objects
 
 VAAPI's vaExportSurfaceHandle is an external system boundary - the

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0022-VAAPI-release-CVaapiRenderPicture-on-every-Map-error.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0022-VAAPI-release-CVaapiRenderPicture-on-every-Map-error.patch
@@ -1,7 +1,7 @@
-From 29a73d14fc4dbfeef0069560029995cd01a7073b Mon Sep 17 00:00:00 2001
+From 6893c4292c358be3d37ee5d3fc321eddfb604c9e Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 08:38:58 -0400
-Subject: [PATCH 22/24] VAAPI: release CVaapiRenderPicture on every Map() error
+Subject: [PATCH 22/25] VAAPI: release CVaapiRenderPicture on every Map() error
  path
 
 CVaapi2Texture::Map() Acquires the picture reference on entry and only

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0023-VAAPI-drop-libva-1.x-compat-guards-and-Vaapi1-intero.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0023-VAAPI-drop-libva-1.x-compat-guards-and-Vaapi1-intero.patch
@@ -1,7 +1,7 @@
-From 9414afa1653bcb9fef82739a2b24736eb580d6c9 Mon Sep 17 00:00:00 2001
+From cc1b6466d5b5fbbf203b19588059b8554c3c6927 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 8 May 2026 12:59:58 -0400
-Subject: [PATCH 23/24] VAAPI: drop libva 1.x compat guards and Vaapi1 interop
+Subject: [PATCH 23/25] VAAPI: drop libva 1.x compat guards and Vaapi1 interop
  fallback
 
 Drop Vaapi1 support. Remove build-time guards for early Vaapi2

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0024-VAAPI-GLES-hardware-decode-for-H.264-High10-and-AV1-.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0024-VAAPI-GLES-hardware-decode-for-H.264-High10-and-AV1-.patch
@@ -1,7 +1,7 @@
-From 549d01c06ecd490a8e553d3d6acdcc8371af7634 Mon Sep 17 00:00:00 2001
+From 694a6d67a3dc66e8722a177d91a69fee116b53dd Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Sun, 10 May 2026 13:16:37 -0400
-Subject: [PATCH 24/24] VAAPI/GLES: hardware decode for H.264 High10 and AV1
+Subject: [PATCH 24/25] VAAPI/GLES: hardware decode for H.264 High10 and AV1
  Profile 1
 
 H.264 High10 (10-bit 4:2:0): add profile mapping gated on bitDepth

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0025-GBM-skip-HDR-GUI-composite-and-FBO-clear-when-the-GU.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0025-GBM-skip-HDR-GUI-composite-and-FBO-clear-when-the-GU.patch
@@ -1,0 +1,298 @@
+From 857617fc8f6435aa8f18eaf010ee6ceeef034823 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Wed, 27 May 2026 00:37:45 -0400
+Subject: [PATCH 25/25] GBM: skip HDR GUI composite and FBO clear when the GUI
+ layer is empty
+
+During HDR playback the GUI FBO compositing path ran the full-screen composite (sRGB->PQ tone-map) and a full-surface FBO clear every frame, even when the GUI drew nothing over the video. On a weak GPU (e.g. the Raspberry Pi V3D) this kept the GPU busy during playback with no OSD on screen.
+
+Add a per-frame GUI-draw counter, CRenderSystemBase::m_GUIElementCount: reset in BeginRender, incremented at every GUI draw primitive (textures, text, and video overlays/subtitles) on both the GL and GLES paths. CompositeGui reads it and, when the count is zero (the GUI layer produced nothing this frame), skips the composite and marks the FBO clean so the next frame also skips the clear. The counter doubles as a render diagnostic.
+
+Applies to both the GLES and GL GBM winsystems.
+---
+ .../VideoRenderers/OverlayRendererGL.cpp      |  2 ++
+ .../VideoRenderers/OverlayRendererGLES.cpp    |  2 ++
+ xbmc/guilib/GUIFontTTFGL.cpp                  |  1 +
+ xbmc/guilib/GUIFontTTFGLES.cpp                |  1 +
+ xbmc/guilib/GUITextureGL.cpp                  |  2 ++
+ xbmc/guilib/GUITextureGLES.cpp                |  2 ++
+ xbmc/rendering/RenderSystem.cpp               |  2 ++
+ xbmc/rendering/RenderSystem.h                 |  4 ++++
+ xbmc/rendering/gl/RenderSystemGL.cpp          |  2 ++
+ xbmc/rendering/gles/RenderSystemGLES.cpp      |  2 ++
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 18 ++++++++++++++++--
+ xbmc/windowing/gbm/WinSystemGbmGLContext.h    |  1 +
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 19 ++++++++++++++++---
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.h  |  1 +
+ 14 files changed, 54 insertions(+), 5 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+index 944f324828..d9f52977bb 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+@@ -334,6 +334,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
+   glUniform1f(depthLoc, -1.0f);
+ 
+   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   glDisableVertexAttribArray(colLoc);
+@@ -463,6 +464,7 @@ void COverlayTextureGL::Render(SRenderState& state)
+   glUniform1f(depthLoc, -1.0f);
+ 
+   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   glDisableVertexAttribArray(tex0Loc);
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+index bbe1b372d2..33556be1dd 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+@@ -389,6 +389,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
+   glUniform1f(depthLoc, -1.0f);
+ 
+   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   glDisableVertexAttribArray(colLoc);
+@@ -473,6 +474,7 @@ void COverlayTextureGLES::Render(SRenderState& state)
+   tex[2][1] = tex[3][1] = m_v;
+ 
+   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   glDisableVertexAttribArray(tex0Loc);
+diff --git a/xbmc/guilib/GUIFontTTFGL.cpp b/xbmc/guilib/GUIFontTTFGL.cpp
+index 792f8ee45e..b7115b2215 100644
+--- a/xbmc/guilib/GUIFontTTFGL.cpp
++++ b/xbmc/guilib/GUIFontTTFGL.cpp
+@@ -286,6 +286,7 @@ void CGUIFontTTFGL::LastEnd()
+             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
+ 
+         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);
++        CRenderSystemBase::m_GUIElementCount++;
+       }
+     }
+ 
+diff --git a/xbmc/guilib/GUIFontTTFGLES.cpp b/xbmc/guilib/GUIFontTTFGLES.cpp
+index ea57d0dc8f..6554740fc6 100644
+--- a/xbmc/guilib/GUIFontTTFGLES.cpp
++++ b/xbmc/guilib/GUIFontTTFGLES.cpp
+@@ -281,6 +281,7 @@ void CGUIFontTTFGLES::LastEnd()
+             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
+ 
+         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);
++        CRenderSystemBase::m_GUIElementCount++;
+       }
+ 
+       glMatrixModview.Pop();
+diff --git a/xbmc/guilib/GUITextureGL.cpp b/xbmc/guilib/GUITextureGL.cpp
+index 14b6bfb109..72c77c4f8b 100644
+--- a/xbmc/guilib/GUITextureGL.cpp
++++ b/xbmc/guilib/GUITextureGL.cpp
+@@ -153,6 +153,7 @@ void CGUITextureGL::End()
+     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(ushort)*m_idx.size(), m_idx.data(), GL_STATIC_DRAW);
+ 
+     glDrawElements(GL_TRIANGLES, m_packedVertices.size()*6 / 4, GL_UNSIGNED_SHORT, 0);
++    CRenderSystemBase::m_GUIElementCount++;
+ 
+     if (m_diffuse.size())
+       glDisableVertexAttribArray(tex1Loc);
+@@ -371,6 +372,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
+   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
+ 
+   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   if (texture)
+diff --git a/xbmc/guilib/GUITextureGLES.cpp b/xbmc/guilib/GUITextureGLES.cpp
+index 74b0060970..80d658bf0a 100644
+--- a/xbmc/guilib/GUITextureGLES.cpp
++++ b/xbmc/guilib/GUITextureGLES.cpp
+@@ -173,6 +173,7 @@ void CGUITextureGLES::End()
+     glEnableVertexAttribArray(tex0Loc);
+ 
+     glDrawElements(GL_TRIANGLES, m_packedVertices.size()*6 / 4, GL_UNSIGNED_SHORT, m_idx.data());
++    CRenderSystemBase::m_GUIElementCount++;
+ 
+     if (m_diffuse.size())
+       glDisableVertexAttribArray(tex1Loc);
+@@ -355,6 +356,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
+   }
+ 
+   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
++  CRenderSystemBase::m_GUIElementCount++;
+ 
+   glDisableVertexAttribArray(posLoc);
+   if (texture)
+diff --git a/xbmc/rendering/RenderSystem.cpp b/xbmc/rendering/RenderSystem.cpp
+index d87b488f0f..a73f5b522b 100644
+--- a/xbmc/rendering/RenderSystem.cpp
++++ b/xbmc/rendering/RenderSystem.cpp
+@@ -19,6 +19,8 @@
+ 
+ #include <memory>
+ 
++unsigned int CRenderSystemBase::m_GUIElementCount = 0;
++
+ CRenderSystemBase::CRenderSystemBase()
+ {
+   OnAdvancedSettingsLoaded();
+diff --git a/xbmc/rendering/RenderSystem.h b/xbmc/rendering/RenderSystem.h
+index d981b1bb9f..2c1268745d 100644
+--- a/xbmc/rendering/RenderSystem.h
++++ b/xbmc/rendering/RenderSystem.h
+@@ -45,6 +45,10 @@ public:
+   CRenderSystemBase();
+   virtual ~CRenderSystemBase();
+ 
++  // Number of GUI elements (textures, text, overlays) drawn this frame; reset
++  // in BeginRender, bumped at each GUI draw primitive. Render-thread only.
++  static unsigned int m_GUIElementCount;
++
+   virtual bool InitRenderSystem() = 0;
+   virtual bool DestroyRenderSystem() = 0;
+   virtual bool ResetRenderSystem(int width, int height) = 0;
+diff --git a/xbmc/rendering/gl/RenderSystemGL.cpp b/xbmc/rendering/gl/RenderSystemGL.cpp
+index b2a138c096..655e8ef05d 100644
+--- a/xbmc/rendering/gl/RenderSystemGL.cpp
++++ b/xbmc/rendering/gl/RenderSystemGL.cpp
+@@ -262,6 +262,8 @@ bool CRenderSystemGL::BeginRender()
+   if (!m_bRenderCreated)
+     return false;
+ 
++  m_GUIElementCount = 0;
++
+   bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                     !CServiceBroker::GetWinSystem()->IsHdrComposite();
+ 
+diff --git a/xbmc/rendering/gles/RenderSystemGLES.cpp b/xbmc/rendering/gles/RenderSystemGLES.cpp
+index 480d5d76ac..5c3dad1fbf 100644
+--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
++++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
+@@ -176,6 +176,8 @@ bool CRenderSystemGLES::BeginRender()
+   if (!m_bRenderCreated)
+     return false;
+ 
++  m_GUIElementCount = 0;
++
+   const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                           !CServiceBroker::GetWinSystem()->IsHdrComposite();
+   const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index 4b9008dccf..c20c221023 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -270,14 +270,20 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
+ 
+     m_guiFboWidth = width;
+     m_guiFboHeight = height;
++    m_guiFboClean = false; // fresh FBO is undefined, force a clear
+     CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
+   }
+ 
+   if (!m_guiFbo.BeginRender())
+     return false;
+ 
+-  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+-  glClear(GL_COLOR_BUFFER_BIT);
++  // Clear only when the FBO holds stale content; idle frames are already clean.
++  if (!m_guiFboClean)
++  {
++    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++    glClear(GL_COLOR_BUFFER_BIT);
++    m_guiFboClean = true;
++  }
+ 
+   return true;
+ }
+@@ -298,6 +304,14 @@ void CWinSystemGbmGLContext::CompositeGui()
+   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+     return;
+ 
++  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
++  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
++  // there is nothing to composite.
++  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
++  m_guiFboClean = guiEmpty;
++  if (guiEmpty)
++    return;
++
+   glActiveTexture(GL_TEXTURE0);
+   glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.h b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+index 909354808d..59147f4f90 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+@@ -58,6 +58,7 @@ private:
+   CFrameBufferObject m_guiFbo;
+   int m_guiFboWidth{0};
+   int m_guiFboHeight{0};
++  bool m_guiFboClean{false};
+   std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
+ };
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index 3e59ea8e38..82b987d2c3 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -270,15 +270,20 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
+ 
+     m_guiFboWidth = width;
+     m_guiFboHeight = height;
++    m_guiFboClean = false; // fresh FBO is undefined, force a clear
+     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
+   }
+ 
+   if (!m_guiFbo.BeginRender())
+     return false;
+ 
+-  // clear FBO to transparent black
+-  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+-  glClear(GL_COLOR_BUFFER_BIT);
++  // Clear only when the FBO holds stale content; idle frames are already clean.
++  if (!m_guiFboClean)
++  {
++    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
++    glClear(GL_COLOR_BUFFER_BIT);
++    m_guiFboClean = true;
++  }
+ 
+   return true;
+ }
+@@ -304,6 +309,14 @@ void CWinSystemGbmGLESContext::CompositeGui()
+   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+     return;
+ 
++  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
++  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
++  // there is nothing to composite.
++  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
++  m_guiFboClean = guiEmpty;
++  if (guiEmpty)
++    return;
++
+   glActiveTexture(GL_TEXTURE0);
+   glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+index 706eca0d87..b7dd90bbc0 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+@@ -59,6 +59,7 @@ private:
+   CFrameBufferObject m_guiFbo;
+   int m_guiFboWidth{0};
+   int m_guiFboHeight{0};
++  bool m_guiFboClean{false};
+ 
+   std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
+ };
+-- 
+2.43.0
+


### PR DESCRIPTION
Aside from the package bump there is one additional patch (https://github.com/xbmc/xbmc/pull/28373) which should reduce GPU off-screen rendering effort during HDR playback.