### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/rsyslog-depends/liblognorm/package.mk
+++ b/packages/addons/addon-depends/rsyslog-depends/liblognorm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="liblognorm"
-PKG_VERSION="2.0.9"
-PKG_SHA256="5ba04e808f6530592b699e0994fd00fab84c1e323885d9be6dc91f4919f57801"
+PKG_VERSION="2.1.0"
+PKG_SHA256="1f6c63d218a0a182b7758ce177033b604c2df30bbff80ea42b9bc032975e9ca9"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://www.liblognorm.com"
 PKG_URL="https://github.com/rsyslog/liblognorm/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/snapcast-depends/nqptp/package.mk
+++ b/packages/addons/addon-depends/snapcast-depends/nqptp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nqptp"
-PKG_VERSION="1.2.6"
-PKG_SHA256="26f65165c3545a6cee0b9846b47ce52a015fcd8ec153fe16997d36f61c88029e"
+PKG_VERSION="1.2.8"
+PKG_SHA256="3a2882a299c21605f53bb215ce537f9cc7a1e894476f639ab28562c68fd183a9"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://github.com/mikebrady/nqptp"
 PKG_URL="https://github.com/mikebrady/nqptp/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/tmux/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/tmux/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tmux"
-PKG_VERSION="3.6a"
-PKG_SHA256="b6d8d9c76585db8ef5fa00d4931902fa4b8cbe8166f528f44fc403961a3f3759"
+PKG_VERSION="3.6b"
+PKG_SHA256="390759d25fdba016887ec982b808927e637070fd7d03a8021f8ef3102b9ae3c7"
 PKG_LICENSE="ISC"
 PKG_SITE="https://github.com/tmux/tmux/wiki"
 PKG_URL="https://github.com/tmux/tmux/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-wirbelscan"
-PKG_VERSION="2024.09.15"
-PKG_SHA256="22317c5a919834d70aee309248e7fb8b9f458819dee0e5ccdbedee7fdada8913"
+PKG_VERSION="2026.05.15"
+PKG_SHA256="5b0c3a8b52b054621ec9fd2319240359a0d91171820baf3e7ded63202a082809"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://www.gen2vdr.de/wirbel/wirbelscan/index2.html"
 PKG_URL="https://www.gen2vdr.de/wirbel/wirbelscan/vdr-wirbelscan-${PKG_VERSION}.tgz"

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/0001-interface-channel-count.patch
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-wirbelscan/patches/0001-interface-channel-count.patch
@@ -17,9 +17,9 @@ index f2dda24..9ee66c2 100644
  extern cScanner* Scanner;
 +extern TChannels NewChannels;
  
- const char* WIRBELSCAN_VERSION        = "2024.09.15"; /* YYYY.MM.DD */
+ const char* WIRBELSCAN_VERSION        = "2026.05.15"; /* YYYY.MM.DD */
  const char* WIRBELSCAN_DESCRIPTION    = "DVB channel scan for VDR";
-@@ -221,8 +222,8 @@ bool cPluginWirbelscan::Service(const char* id, void* Data) {
+@@ -221,8 +222,8 @@ bool cPluginWirbelscan::Service(const ch
          strcpy(s->transponder, lTransponder.length()? lTransponder.c_str():"none");
          s->progress = s->status == StatusScanning?lProgress:0;
          s->strength = s->status == StatusScanning?lStrength:0;

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="rsyslog"
 PKG_VERSION="8.2604.0"
 PKG_SHA256="2a04b1cd6f0a5e2b60eec231acce3cf9927c4ed02bc5fbbe5dc4c35fcf887b64"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/rsyslog"

--- a/packages/addons/service/snapserver/package.mk
+++ b/packages/addons/service/snapserver/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapserver"
 PKG_VERSION="0.35.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_DEPENDS_TARGET="toolchain nqptp shairport-sync snapcast"

--- a/packages/addons/service/vdr-addon/package.mk
+++ b/packages/addons/service/vdr-addon/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.8.1"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- rsyslog: update addon (1)
  - liblognorm: update to 2.1.0
- system-tools: update addon (2)
  - tmux: update to 3.6b
- vdr-addon: update addon (1)
  - vdr-plugin-wirbelscan: update to 2026.05.15
- snapserver: update addon (1)
  - nqptp: update to 1.2.8