### PR TITLE
Package updates

### DIFF
--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="12.3.1"
-PKG_REV="0"
-PKG_SHA256="2da62b57da70975d0865d4a1ae4ae4cf422e1b7dcc709eba855cf14f5104617e"
+PKG_VERSION="12.3.2"
+PKG_REV="1"
+PKG_SHA256="82798714baf2f3456ed2f311fc803dc120f2bf3b82358e773847d628cdb4b670"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://archive.mariadb.org/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/mariadb/patches/0001-disable-plugin-auth-pam.patch
+++ b/packages/addons/service/mariadb/patches/0001-disable-plugin-auth-pam.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] disable PLUGIN_AUTH_PAM as we aren't able to build it
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmake/build_configurations/mysql_release.cmake b/cmake/build_configurations/mysql_release.cmake
-index 37a6c45..e2a4ba8 100644
+index cdac53d..5f287af 100644
 --- a/cmake/build_configurations/mysql_release.cmake
 +++ b/cmake/build_configurations/mysql_release.cmake
-@@ -147,7 +147,7 @@ ENDIF()
+@@ -152,7 +152,7 @@ ENDIF()
  
  IF(UNIX)
    SET(WITH_EXTRA_CHARSETS all CACHE STRING "")
@@ -21,5 +21,5 @@ index 37a6c45..e2a4ba8 100644
    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
      FIND_PACKAGE(URING)
 -- 
-2.7.4
+2.53.0
 

--- a/packages/addons/service/mariadb/patches/0002--fix-gcc14-build.patch
+++ b/packages/addons/service/mariadb/patches/0002--fix-gcc14-build.patch
@@ -4,6 +4,7 @@ Date: Fri, 17 May 2024 14:49:46 +0000
 Subject: [PATCH]  fix gcc14 build
 
 diff --git a/tests/async_queries.c b/tests/async_queries.c
+index f0b4fab..09f8d31 100644
 --- a/tests/async_queries.c
 +++ b/tests/async_queries.c
 @@ -31,7 +31,9 @@
@@ -15,5 +16,8 @@ diff --git a/tests/async_queries.c b/tests/async_queries.c
 +#include <event2/event_compat.h>
 +#include <event2/event.h>
  
+ 
  #define SL(s) (s), sizeof(s)
- static const char *my_groups[]= { "client", NULL };
+-- 
+2.53.0
+

--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libdrm"
-PKG_VERSION="2.4.133"
-PKG_SHA256="fc68f9d0ba2ea63c9432a299e14fea09fad7a8a66e8039fcd7802ca59f77b4f5"
+PKG_VERSION="2.4.134"
+PKG_SHA256="ac5e74d157830eb8bee44c6a6bf3ad49774ef0dd2a72bdad74a8f20308b52a95"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dri.freedesktop.org"
 PKG_URL="https://dri.freedesktop.org/libdrm/libdrm-${PKG_VERSION}.tar.xz"

--- a/packages/python/devel/pyelftools/package.mk
+++ b/packages/python/devel/pyelftools/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pyelftools"
-PKG_VERSION="0.32"
-PKG_SHA256="82d0399bce74d162fba75b3568ad47bf48ed2c5e028b72026bdc2f678903de7d"
+PKG_VERSION="0.33"
+PKG_SHA256="5507d69b42ac7211e5db57b42f427376b2cf3e3ab9a72b9239f4fc243566869d"
 PKG_LICENSE="Unlicense"
 PKG_SITE="https://github.com/eliben/pyelftools"
 PKG_URL="https://github.com/eliben/pyelftools/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="7c070aeba9bbf12073646995a03f36c346bb5f541d0078ba6d9dc2a7adaaf6af"
+    PKG_SHA256="09ea03e74aa94e07db7bc00bd2ec1ad86d90a7348c89fde3909a8922543b949f"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="885afb663cc683ee7c2b7864df6703481e015a85c7e741b695aaeac722bc4747"
+    PKG_SHA256="f8c1f9ef6d2315341396a2745d475fb1d0cfe1928c4b543ac0f17e9e8057aaa6"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="e74edd2cf7d0f1f1383b4f00eb90c843750bc489e2ccf7214e6476678a907425"
+    PKG_SHA256="dee75c3c8f9f600ad75bc0c93249e767d3047845a4dd668327ce43ab039ba266"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/cbindgen/package.mk
+++ b/packages/rust/cbindgen/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cbindgen"
-PKG_VERSION="0.29.2"
-PKG_SHA256="c7d4d610482390c70e471a5682de714967e187ed2f92f2237c317a484a8c7e3a"
+PKG_VERSION="0.29.3"
+PKG_SHA256="f3589ce10fd6a61b32d1ac1a1043112838e44b401432f4db9838c2a9ec4322f8"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://github.com/mozilla/bindgen"
 PKG_URL="https://github.com/mozilla/cbindgen/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="3a21b271b1ff973b94d69b25e7a39992f9fbcae1ab6d9475844a23e6ad3908ac"
+    PKG_SHA256="538e85452709687797d990579a491ff9b02f8bffba4a5d54cfa945e28868053e"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="fda8408ea17881c6529e27e58672d6c628f786cad557fac92856077e7a610239"
+    PKG_SHA256="8921e7ce73fdaf42e277def64f87c37e22ed5b8059db63dc77a38f8143792138"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="047ea7098803d3500fa1072e9cee5392697e21525559e4458128a2bf874aa382"
+    PKG_SHA256="c09c7c646248f14f473f5f7a029af15ee57c3a9f9bc93dfa72d9621938586b82"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.95.0"
-PKG_SHA256="ea9b82a83e46967537c3569ce9d6fa16811c043a96e651376c349e70241ca515"
+PKG_VERSION="1.96.0"
+PKG_SHA256="e90a9eb153b2948afac840dbe9d77b64e376706f2864387ee7717f7450043b44"
 PKG_LICENSE="MIT OR Apache-2.0"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"

--- a/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
+++ b/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
@@ -126,7 +126,7 @@ check with:
 *            arch: Arch::Arm,
 *            options: TargetOptions {
 *   +            // ── Upstream arm-unknown-linux-gnueabihf defaults ─────────────
-*                abi: Abi::EabiHf,
+*                cfg_abi: CfgAbi::EabiHf,
 *                llvm_floatabi: Some(FloatAbi::Hard),
 *                features: "+strict-align,+v6,+vfp2".into(),
 *   @@ -24,3 +25,14 @@
@@ -196,10 +196,10 @@ check with:
  create mode 100644 compiler/rustc_target/src/spec/targets/x86_64_libreelec_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 768e43146a0..a68c532cd75 100644
+index 0601f9d7c2c..0b6a16ce77c 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1454,6 +1454,10 @@ fn $module() {
+@@ -1443,6 +1443,10 @@ macro_rules! supported_targets {
  }
  
  supported_targets! {
@@ -277,7 +277,7 @@ index 00000000000..2a4af4d1c67
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs
 @@ -0,0 +1,39 @@
-+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
++use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 +
 +pub(crate) fn target() -> Target {
 +    Target {
@@ -293,7 +293,7 @@ index 00000000000..2a4af4d1c67
 +        arch: Arch::Arm,
 +        options: TargetOptions {
 +            // ── Upstream arm-unknown-linux-gnueabihf defaults ─────────────
-+            abi: Abi::EabiHf,
++            cfg_abi: CfgAbi::EabiHf,
 +            llvm_floatabi: Some(FloatAbi::Hard),
 +            // features: "+strict-align,+v6,+vfp2".into(),
 +            max_atomic_width: Some(64),
@@ -322,7 +322,7 @@ index 00000000000..2a4af4d1c67
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/armv7ve_libreelec_linux_gnueabihf.rs
 @@ -0,0 +1,39 @@
-+use crate::spec::{Abi, Arch, FloatAbi, Target, TargetMetadata, TargetOptions, base};
++use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions, base};
 +
 +pub(crate) fn target() -> Target {
 +    Target {
@@ -338,7 +338,7 @@ index 00000000000..2a4af4d1c67
 +        arch: Arch::Arm,
 +        options: TargetOptions {
 +            // ── Upstream arm-unknown-linux-gnueabihf defaults ─────────────
-+            abi: Abi::EabiHf,
++            cfg_abi: CfgAbi::EabiHf,
 +            llvm_floatabi: Some(FloatAbi::Hard),
 +            // features: "+strict-align,+v6,+vfp2".into(),
 +            max_atomic_width: Some(64),

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="0fe3689eeaed603e5ef24572d11597d3edadaefd2cb181674ad621260f2501d2"
+    PKG_SHA256="76b1a6e8dd1636e364d4bbba685485ff44eee5ff6434add089bab4c703c7e19d"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="4cf73cefec9ac6725bb43493d62893aeff75e6856af668b82002516433c11984"
+    PKG_SHA256="59c5a66930aa51c151b23558a3127bbdf2eb62c22937541b33cf64c1c9f63aee"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="8426a3d170a5879f5682f5fbdd024a1779b3951e7baba685af2d6dc32a6dfc15"
+    PKG_SHA256="7d7fa1d0cfb0fab71a956bb78f41107202c17f30ab56c45288e869a37fd9633d"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dtc"
-PKG_VERSION="1.8.0"
-PKG_SHA256="b298e24ce4824bd2e2af60cf6a3d2815e555b3e44c431eadad0b52798c83a833"
+PKG_VERSION="1.8.1"
+PKG_SHA256="23526015a6f1550e0541a53fe7acea1b5a11e3697cdf3a3bdc076abc38f6045d"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://git.kernel.org/pub/scm/utils/dtc/dtc.git/"
 PKG_URL="https://www.kernel.org/pub/software/utils/dtc/dtc-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- libdrm: update to 2.4.134
- rust: update to 1.96.0
  - rust-std-snapshot: update to 1.96.0
  - rustc-snapshot: update to 1.96.0
  - cargo-snapshot: update to 1.96.0
- mariadb: update to 12.3.2 and addon (1)
- cbindgen: update to 0.29.3
- pyelftools: update to 0.33
- dtc: update to 1.8.1
