### PR TITLE
exfatprogs: add util-linux dependency

### DIFF
--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="85c133e8802cbc1191bff2477a67b376192dfb9f94bb254c05dbae79fd958f2e"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/exfatprogs/exfatprogs"
 PKG_URL="https://github.com/exfatprogs/exfatprogs/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain util-linux"
 PKG_LONGDESC="userspace utilities that contain all of the standard utilities for creating and fixing and debugging exfat filesystems."
 PKG_TOOLCHAIN="autotools"
 


### PR DESCRIPTION
This fixes the build error:

checking for blkid... no
configure: error: Package requirements (blkid) were not met:

No package 'blkid' found