### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/sshfs/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/sshfs/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sshfs"
-PKG_VERSION="3.7.5"
-PKG_SHA256="0e45db63c2d00919db3174134fa234c6e0682d6fe573c46312d1d53d1d61a8bb"
+PKG_VERSION="3.7.6"
+PKG_SHA256="6a1bcb31450a077e9cb1b7ff158c71de34db697c3c0da6cb362502131e495893"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/libfuse/sshfs"
 PKG_URL="https://github.com/libfuse/sshfs/releases/download/sshfs-${PKG_VERSION}/sshfs-${PKG_VERSION}.tar.xz"

--- a/packages/addons/tools/network-tools/package.mk
+++ b/packages/addons/tools/network-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="network-tools"
 PKG_VERSION="1.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.22.2"
-PKG_SHA256="eea48e4841f83fbe51d029337ffd2d14512d0203015dad40b90213d872958af3"
+PKG_VERSION="1.23.0"
+PKG_SHA256="4c9182b18897617182eed12ab5eb9f9d855b3aa3a736d6bdb31abc034ec7d393"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="22.0.2-Piers"
 PKG_SHA256="09a5e35fd2eee28cdf530f439e29e7cf1f4d0eee72f501e3e4f059c66cec7acc"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libxkbcommon"
-PKG_VERSION="1.13.1"
-PKG_SHA256="aeb951964c2f7ecc08174cb5517962d157595e9e3f38fc4a130b91dc2f9fec18"
+PKG_VERSION="1.13.2"
+PKG_SHA256="acc4d5f7c3cbba5f9f8d08d8bdbeede84ecede46792f47929aa9321873385528"
 PKG_LICENSE="MIT AND MIT-open-group AND HPND AND HPND-sell-variant"
 PKG_SITE="https://xkbcommon.org"
 PKG_URL="https://github.com/xkbcommon/libxkbcommon/archive/refs/tags/xkbcommon-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- libxkbcommon: update to 1.13.2
- imagedecoder.heif: update libheif to 1.23.0 and addon (5)
  - libheif: update to 1.23.0
- network-tools: update addon (1)
  - sshfs: update to 3.7.6