### PR TITLE
add initial project coding standards document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Please follow this process; it's the best way to get your work included in the p
    git checkout -b <topic-branch-name>
    ```
 
-- Commit your changes in logical chunks. or your pull request is unlikely
+- Commit your changes in logical chunks, or your pull request is unlikely
    be merged into the main project. Use git's
    [interactive rebase](https://docs.github.com/en/github/getting-started-with-github/about-git-rebase) feature to tidy up your commits before making them public.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 LibreELEC is a 'Just enough OS' Linux distribution for the award-winning [Kodi](https://kodi.tv) software on popular mediacentre hardware. Further information on the project can be found on the [LibreELEC website](https://libreelec.tv).
 
+**Documentation**
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to report issues and submit pull requests
+- [STANDARDS.md](STANDARDS.md) — coding standards for build scripts and package files
+- [packages/README.md](packages/README.md) — detailed guide to `package.mk` structure and variables
+
 **Issues & Support**
 
 Please ask questions in the [LibreELEC forum: Help & Support](https://forum.libreelec.tv/forum-3.html) or ask a member of project staff in the #libreelec IRC channel on Libera.Chat. Please report bugs via [GitHub Issues](https://github.com/LibreELEC/LibreELEC.tv/issues).

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,38 @@
+## Project Coding Standards
+
+### Build system scripts and config:
+
+* Executable build scripts use `#!/bin/bash`. Sourced config fragments (`config/functions`, `config/options`, `config/arch.*` etc.) have no shebang as they are not executed directly
+* Avoid backtick command substitution (subshells). Use `$()` instead
+* String comparison: use `=` not `==`
+* Numeric comparison: use `-eq` not `=` etc.
+* For simple tests, `[ expr1 -o expr2 ]`/`[ expr1 -a expr2 ]` is preferred over the extended form `[[ expr1 || expr2 ]]`/`[[ expr1 && expr2 ]]`. Use `[[ ]]` when regex (`=~`) or glob/pattern matching is needed — these require `[[ ]]`. When short-circuit evaluation is required but `[[ ]]` should be avoided, use command grouping: `[ test1 ] && { [ test2 ] && [ test3 ]; }`. See [test constructs](https://www.tldp.org/LDP/abs/html/testconstructs.html)
+* Shell variables should use braces ie. use `${FOO}` not `$FOO`
+* Use double-quotes (") around variables (or sequences that include variables) when possible to avoid issues with special characters, eg. `cd "$PKG_DIR/scripts"`, although paths should no longer include spaces after #3351. See [quoting variables](https://www.tldp.org/LDP/abs/html/quotingvar.html)
+* Use `. config/blah` to source a file, don't use `source config/blah`
+* To be efficient, avoid forking child processes (`sed`, `cut`, etc.) when a shell built-in can be used instead
+* Avoid long lines (> 90 columns) unless it aids maintainability/processing (eg. `LINUX_DEPENDS`, `PKG_DEPENDS_TARGET` etc.)
+* Use `set -e` or `set -euo pipefail` in scripts that should abort on error
+* Use [ShellCheck](https://www.shellcheck.net/) to check scripts for common mistakes
+
+### Scripts that run on the device:
+
+* Use `#!/bin/sh` — the runtime shell is busybox sh/ash; bash is not available
+* Write to the current POSIX standard; bash extensions cannot be used:
+  * No `[[ ]]` extended tests — use `[ ]`
+  * No arrays, no `source`, no `=~` regex, no process substitution
+  * No `$'...'` escape syntax
+* Use [ShellCheck](https://www.shellcheck.net/) with `--shell=sh` to check scripts for common mistakes
+
+### Within `package.mk`:
+
+* See [packages/README.md](packages/README.md) for more detailed package structure information
+* When using git revisions, the full 40-char revision is to be used
+* Prefix package specific variables with `PKG_` as they are automatically unset before `package.mk` is sourced
+* Use `PKG_VAR+=" value"` to append to a variable, not `PKG_VAR="${PKG_VAR} value"`
+* When creating a directory, related lines are indented:
+```
+  cd ${INSTALL}/blah
+    cp -P foo ${INSTALL}/blah
+```
+* The use of `foo && bar` is allowed, but care should be taken so that package functions do not unintentionally exit with a non-zero exit code in which case `foo && bar || true` may be required, or alternatively use the multi-line `if foo; then bar; fi` pattern in place of `foo && bar`

--- a/packages/README.md
+++ b/packages/README.md
@@ -277,7 +277,7 @@ Use `tools/pkgcheck` to verify packages. It detects the following issues:
 
 Issue | Level | Meaning |
 | :--- | :----: | ---- |
-| late&nbsp;binding&nbsp;violation | FAIL | Late binding variables referenced outside of a function - see [late binding](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/readme.md#late-binding-variable-assignment) |
+| late&nbsp;binding&nbsp;violation | FAIL | Late binding variables referenced outside of a function - see [late binding](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/README.md#late-binding-variable-assignment) |
 | duplicate&nbsp;function&nbsp;def | FAIL | Function defined multiple times, only last definition will be used |
 | bad&nbsp;func&nbsp;-&nbsp;missing&nbsp;brace | FAIL | Opening brace (`{`) for function definition should be on same line as the function def, ie. `pre_configure_target() {` |
 | intertwined&nbsp;vars&nbsp;&&nbsp;funcs | WARN | Variable assignments and logic is intertwined with functions - this is cosmetic, but variables and logic should be specified before all functions |
@@ -311,11 +311,11 @@ Issue | Level | Meaning |
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb-connector-c"
-PKG_VERSION="3.0.2"
-PKG_SHA256="f44f436fc35e081db3a56516de9e3bb11ae96838e75d58910be28ddd2bc56d88"
-PKG_LICENSE="LGPL"
+PKG_VERSION="3.4.9"
+PKG_SHA256="2c70b74393d589df0bde9b3e17cb7b571d30a45aaf006eda7a273120fb660f3a"
+PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://mariadb.org/"
-PKG_URL="https://github.com/MariaDB/mariadb-connector-c/archive/v$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/mariadb-corporation/mariadb-connector-c/archive/v${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib openssl"
 PKG_LONGDESC="mariadb-connector: library to connect to mariadb/mysql database server"
 PKG_BUILD_FLAGS="-gold"
@@ -328,6 +328,6 @@ PKG_CMAKE_OPTS_TARGET="-DWITH_EXTERNAL_ZLIB=ON \
 
 post_makeinstall_target() {
   # drop all unneeded
-  rm -rf $INSTALL/usr
+  rm -rf ${INSTALL}/usr
 }
 ```

--- a/packages/packages.mk.addon_template
+++ b/packages/packages.mk.addon_template
@@ -34,5 +34,5 @@ addon() {
   # copy needed files from other packages (which are not in the image)
 }
 
-# see https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/readme.md for more
+# see https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/README.md for more
 # take a look to other packages, for inspiration

--- a/packages/packages.mk.template
+++ b/packages/packages.mk.template
@@ -22,5 +22,5 @@ PKG_LONGDESC="[long description of the package, often taken from the package/pro
 #  do something, or drop it
 #}
 
-# see https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/readme.md for more
+# see https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/README.md for more
 # take a look to other packages, for inspiration


### PR DESCRIPTION
- Replaces #3055

Add STANDARDS.md from @MilhouseVH original PR, with some minor typographic corrections, and update to current Repository practices.

The changes from the original PR are:
- Shebang rule: clarify that sourced config fragments (config/functions,
  config/options, config/arch.* etc.) have no shebang as they are not
  executed directly; the rule applies to executable scripts only
- Backtick rule: clarify "command substitution (subshells)" to distinguish
  from backticks used as text
- Test rule: expand [[ ]] guidance — [[ ]] is required (not merely
  tolerated) for regex (=~) and glob/pattern matching
- Remove the indent-under-comment example: the indented pattern is
  not used in practice
- Add set -e / set -euo pipefail: document the established pattern
  used in scripts that should abort on error
- Add PKG_VAR+=" value" append operator: document the preferred form
  enforced by tools/fixlecode.py
- Update examples using the braced $VAR

## Audit results against standard (future cleanup opportunities)

### Backtick command substitution
— config/functions has 5 subshell backticks:
  - :1552 requires_addonname=`echo $i | cut -f1 -d ":"`
  - :1553 requires_addonversion=`echo $i | cut -f2 -d ":"`
  - :1666 if [ -z "`grep "$1:" ${INSTALL}/etc/group`" ]
  - :1681 for target in `grep '^WantedBy' ...`
  - :1688 for target in `grep '^Alias' ...`
  
### == in [ ] string comparisons — rule says =:
- config/functions:239,24
- scripts/check_kernel_config:14,19,32,37
- tools/adjust_kernel_config:6,27
- tools/repo-tool:187,190

### source instead of . — rule says . :
- config/functions:826
- tools/distro-tool:36,749,832,889
- packages/addons/addon-depends/docker/moby/package.mk:39

### Unbraced $VAR
— config/functions requires updates (~296 instances)

### [[ ]] without justification
— config/options:2 uses [[ "${EUID}" -eq 0 ]] with no regex or glob — plain [ ] is appropriate
