### PR TITLE
ffmpeg: append TARGET_CPU_FLAGS to --cpu configure argument

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -137,7 +137,7 @@ fi
 
 configure_target() {
   ./configure --prefix="/usr" \
-              --cpu="${TARGET_CPU}" \
+              --cpu="${TARGET_CPU}${TARGET_CPU_FLAGS}" \
               --arch="${TARGET_ARCH}" \
               --enable-cross-compile \
               --cross-prefix="${TARGET_PREFIX}" \


### PR DESCRIPTION
Pass TARGET_CPU_FLAGS alongside TARGET_CPU when calling ffmpeg's --cpu configure option (e.g. cortex-a53+crc+crypto) to avoid a GCC conflict between -mcpu and -march flags.

Previously, --cpu was set to TARGET_CPU alone (e.g. cortex-a53), while TARGET_CPU_FLAGS (e.g. +crc+crypto) were being applied separately via -march, causing GCC to warn:

  cc1: warning: switch '-mcpu=cortex-a53' conflicts with
  '-march=armv8-a+crc+crypto' switch and resulted in options
  '+crc+crypto' being added

Suggested-by: Jonas Karlman <jonas@kwiboo.se>
Fixes: #9384