### PR TITLE
dbussy: update to githash bd4a5c3

### DIFF
--- a/packages/python/system/dbussy/package.mk
+++ b/packages/python/system/dbussy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dbussy"
-PKG_VERSION="691a8a8a1914416b7ea1545fb931d74f2e381f09"
-PKG_SHA256="857104ef2fd1978323d7c87b32c753d2d178b79adbd13f52cea23511f5195ded"
+PKG_VERSION="bd4a5c3ddd2a59df2c10d84cfa7902102b68f050"
+PKG_SHA256="4541064e19277784d0098d9010967488efb1e007bfa309ea140cefb724713317"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://gitlab.com/ldo/dbussy"
 PKG_URL="https://gitlab.com/ldo/dbussy/-/archive/${PKG_VERSION}/dbussy-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://gitlab.com/ldo/dbussy/-/compare/691a8a8a1914416b7ea1545fb931d74f2e381f09...bd4a5c3ddd2a59df2c10d84cfa7902102b68f050