### PR TITLE
systemd: remove deprecated sleep.conf option

### DIFF
--- a/packages/sysutils/systemd/config/sleep.conf.d/sleep.conf.sample
+++ b/packages/sysutils/systemd/config/sleep.conf.d/sleep.conf.sample
@@ -1,3 +1,2 @@
 [Sleep]
-SuspendMode=false
 HibernateMode=false

--- a/projects/Rockchip/filesystem/usr/lib/systemd/sleep.conf.d/sleep.conf
+++ b/projects/Rockchip/filesystem/usr/lib/systemd/sleep.conf.d/sleep.conf
@@ -1,3 +1,2 @@
 [Sleep]
-SuspendMode=false
 HibernateMode=false


### PR DESCRIPTION
This change prevents the following message(s) in the systemd journal: systemd-logind: /usr/lib/systemd/sleep.conf.d/sleep.conf:2: Support for option SuspendMode= has been removed and it is ignored

Removal is mentioned in systemd v255 release notes: https://github.com/systemd/systemd/releases/tag/v255