### PR TITLE
Generic: gputemp: use nvidia-smi only if an Nvidia card is present

### DIFF
--- a/projects/Generic/filesystem/usr/bin/cputemp
+++ b/projects/Generic/filesystem/usr/bin/cputemp
@@ -8,7 +8,7 @@ TEMP=0
 
 if [ $(basename "$0") = "gputemp" -o "$1" = "gpu" ]; then
 
-  if [ -x /usr/bin/nvidia-smi ]; then
+  if [ -d /proc/driver/nvidia -a -x /usr/bin/nvidia-smi ]; then
     TEMP="$(/usr/bin/nvidia-smi -q -x | grep '<gpu_temp>' | awk '{ print $1 }' | sed 's,<gpu_temp>,,g')"
   fi
 


### PR DESCRIPTION
Running nvidia-smi on a non-nvidia system causes a long delay as nvidia-smi will try to load the nvidia kernel driver if it's not present.