### PR TITLE
cage: prevent LE git info leaking into version string

### DIFF
--- a/packages/addons/addon-depends/externalhelper-depends/cage/package.mk
+++ b/packages/addons/addon-depends/externalhelper-depends/cage/package.mk
@@ -13,3 +13,7 @@ PKG_LONGDESC="A Wayland kiosk "
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_MESON_OPTS_TARGET="-Dman-pages=disabled"
+
+pre_configure_target() {
+  export GIT_CEILING_DIRECTORIES="${ROOT}"
+}

--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="4"
+PKG_REV="5"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""


### PR DESCRIPTION
This avoids leaking the LE build env info into the version string

eg:
```
hpmini:~ # cage -v
Cage version 0.3.0-7090d27706 (branch 'le13-test')
```
instead of the expected
```
hpmini:~ # cage -v
Cage version 0.3.0
```