### PR TITLE
rpath: fix sysroot path leaks in packages

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -53,5 +53,6 @@ makeinstall_target() {
 }
 
 post_makeinstall_target() {
+  patchelf --remove-rpath ${INSTALL}/usr/bin/gdb
   rm -rf ${INSTALL}/usr/share/gdb/python
 }

--- a/packages/network/ipset/package.mk
+++ b/packages/network/ipset/package.mk
@@ -12,3 +12,7 @@ PKG_LONGDESC="IP sets are a framework inside the Linux kernel, which can be admi
 PKG_IS_KERNEL_PKG="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--with-kbuild=$(kernel_path)"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/network/libnfs/package.mk
+++ b/packages/network/libnfs/package.mk
@@ -18,3 +18,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-examples \
 pre_configure_target() {
   export CFLAGS="${CFLAGS} -D_FILE_OFFSET_BITS=64"
 }
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/network/libnftnl/package.mk
+++ b/packages/network/libnftnl/package.mk
@@ -10,3 +10,7 @@ PKG_SITE="https://netfilter.org/projects/libnftnl"
 PKG_URL="https://netfilter.org/projects/libnftnl/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="autotools:host gcc:host libmnl"
 PKG_LONGDESC="A userspace library providing a low-level netlink programming interface (API) to the in-kernel nf_tables subsystem."
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/network/nfs-utils/package.mk
+++ b/packages/network/nfs-utils/package.mk
@@ -22,6 +22,10 @@ pre_configure_target() {
   rm -rf .${TARGET_NAME}
 }
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 makeinstall_target() {
   mkdir -p "${INSTALL}/usr/sbin/"
     cp -PR utils/mount/mount.nfs "${INSTALL}/usr/sbin/"

--- a/packages/network/nftables/package.mk
+++ b/packages/network/nftables/package.mk
@@ -12,3 +12,7 @@ PKG_LONGDESC="A userspace library providing a low-level netlink programming inte
 PKG_TOOLCHAIN="autotools"
 
 PKG_CONFIGURE_OPTS_TARGET="--without-cli --with-mini-gmp"
+
+post_configure_target() {
+  libtool_remove_rpath libtool
+}

--- a/packages/sysutils/exfatprogs/package.mk
+++ b/packages/sysutils/exfatprogs/package.mk
@@ -11,6 +11,10 @@ PKG_DEPENDS_TARGET="toolchain util-linux"
 PKG_LONGDESC="userspace utilities that contain all of the standard utilities for creating and fixing and debugging exfat filesystems."
 PKG_TOOLCHAIN="autotools"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/share
 }

--- a/packages/sysutils/ntfsprogs-plus/package.mk
+++ b/packages/sysutils/ntfsprogs-plus/package.mk
@@ -11,6 +11,10 @@ PKG_DEPENDS_TARGET="toolchain libgcrypt"
 PKG_LONGDESC="NTFS filesystem userspace utilities"
 PKG_TOOLCHAIN="autotools"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm ${INSTALL}/usr/lib/libntfs.so
   mv ${INSTALL}/lib/libntfs.so* ${INSTALL}/usr/lib/

--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -17,6 +17,10 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
                            --disable-curl \
                            --enable-https"
 
+post_configure_target() {
+  libtool_remove_rpath libtool
+}
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/bin
 }


### PR DESCRIPTION
- more fixes for #5294 and #7602, these have crept in over time.

- gdb: strip sysroot rpath using patchelf in post_makeinstall_target
- libnfs: remove sysroot rpath from installed binaries and library
- libmicrohttpd: remove sysroot rpath from installed library
- ntfsprogs-plus: remove sysroot rpath from installed binaries
- exfatprogs: remove sysroot rpath from installed binaries
- nfs-utils: remove sysroot rpath from installed binaries
- ipset: remove sysroot rpath from installed library
- libnftnl: remove sysroot rpath from installed library
- nftables: remove sysroot rpath from installed binaries and libraries