### PR TITLE
Revert "pluggy: update to 1.6.0"

### DIFF
--- a/packages/python/devel/pluggy/package.mk
+++ b/packages/python/devel/pluggy/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pluggy"
-PKG_VERSION="1.6.0"
-PKG_SHA256="d35ec78be56dae9fd736e1378a2c3c176fd2aefd9daefc209abeab569c2732ee"
+PKG_VERSION="fc40456932ec7fb258b0c48ef3789b7cd7747647"
+PKG_SHA256="614a8426baa09a837cfa15bd5d842a4951e55c4f5b28d63fe87d3fe6677633a9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/pytest-dev/pluggy"
 PKG_URL="https://github.com/pytest-dev/pluggy/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- Reverts LibreELEC/LibreELEC.tv#11418

Builds failing with 
```
[001/306] [DONE] build   configtools:host
[002/306] [DONE] install crust:target
[003/306] [DONE] install wireless-regdb:target
[004/306] [DONE] install alsa-topology-conf:target
[005/306] [DONE] install entropy:target
[006/306] [DONE] install ir-bpf-decoders:target
[007/306] [DONE] install texturecache.py:target
[008/306] [DONE] install mesa-reusable:target
[009/306] [DONE] install brcmfmac_sdio-firmware:target
[010/306] [DONE] install alsa-ucm-conf:target
[011/306] [DONE] build   make:host
[012/306] [DONE] build   xxHash:host
[013/306] [DONE] build   pkg-config:host
[014/306] [DONE] install kernel-firmware:target
[015/306] [DONE] build   cmake:host
[016/306] [DONE] build   libfmt:host
[017/306] [DONE] build   zstd:host
[018/306] [DONE] build   ccache:host
[019/306] [DONE] build   sonic:host
[020/306] [DONE] build   libcap:host
[021/306] [DONE] build   intltool:host
[022/306] [DONE] build   autoconf-archive:host
[023/306] [DONE] build   bzip2:host
[024/306] [DONE] build   zlib:host
[025/306] [DONE] build   giflib:host
[026/306] [DONE] build   pigz:host
[027/306] [DONE] build   linux:host
[028/306] [DONE] build   mpdecimal:host
[029/306] [DONE] build   7-zip:host
[030/306] [DONE] build   asn1c:host
[031/306] [DONE] build   libpng:host
[032/306] [DONE] build   nspr:host
[033/306] [DONE] build   sed:host
[034/306] [DONE] build   swig:host
[035/306] [DONE] build   m4:host
[036/306] [DONE] build   ncurses:host
[037/306] [DONE] build   openssl:host
[038/306] [DONE] build   gmp:host
[039/306] [DONE] build   mpfr:host
[040/306] [DONE] build   mpc:host
[041/306] [DONE] build   bison:host
[042/306] [DONE] build   gettext:host
[043/306] [DONE] build   autoconf:host
[044/306] [DONE] build   automake:host
[045/306] [DONE] build   libtool:host
[046/306] [DONE] build   autotools:host
[047/306] [DONE] build   dosfstools:host
[048/306] [DONE] build   patchelf:host
[049/306] [DONE] build   mtools:host
[050/306] [DONE] build   fakeroot:host
[051/306] [DONE] build   libffi:host
[052/306] [DONE] build   flex:host
[053/306] [DONE] build   elfutils:host
[054/306] [DONE] build   e2fsprogs:host
[055/306] [DONE] build   populatefs:host
[056/306] [DONE] build   nss:host
[057/306] [DONE] build   util-linux:host
[058/306] [DONE] build   parted:host
[059/306] [DONE] build   Python3:host
[060/306] [DONE] build   flit:host
[061/306] [DONE] build   pyinstaller:host
[062/306] [DONE] build   pyproject-hooks:host
[063/306] [DONE] build   pypackaging:host
[064/306] [DONE] build   pybuild:host
[065/306] [DONE] build   setuptools:host
[066/306] [DONE] build   python-pathspec:host
[067/306] [DONE] build   calver:host
[068/306] [DONE] build   pluggy:host
[069/306] [DONE] build   pyyaml:host
[070/306] [DONE] build   pyelftools:host
[071/306] [DONE] build   MarkupSafe:host
[072/306] [DONE] build   setuptools-scm:host
[073/306] [DONE] build   trove-classifiers:host
[074/306] [DONE] build   Mako:host
[075/306] [DONE] build   Jinja2:host
[076/306] [FAIL] build   hatchling:host
<<< hatchling:host seq 80 <<<
UNPACK      hatchling
BUILD      hatchling (host)
    TOOLCHAIN      python
Executing (host): python3 -m build -n -w -x 
* Building wheel...
Traceback (most recent call last):
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/toolchain/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/toolchain/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/toolchain/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        wheel_directory, config_settings, metadata_directory
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/build/hatchling-1.17.0/backend/src/hatchling/build.py", line 55, in build_wheel
    from hatchling.builders.wheel import WheelBuilder
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/build/hatchling-1.17.0/backend/src/hatchling/builders/wheel.py", line 17, in <module>
    from hatchling.builders.plugin.interface import BuilderInterface
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/build/hatchling-1.17.0/backend/src/hatchling/builders/plugin/interface.py", line 11, in <module>
    from hatchling.plugin.manager import PluginManagerBound
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/build/hatchling-1.17.0/backend/src/hatchling/plugin/__init__.py", line 1, in <module>
    import pluggy
  File "/build/build.LibreELEC-A64.aarch64-13.0-devel/toolchain/lib/python3.14/site-packages/pluggy/__init__.py", line 28, in <module>
    from ._version import version as __version__
ModuleNotFoundError: No module named 'pluggy._version'

ERROR Backend subprocess exited when trying to invoke build_wheel
FAILURE: scripts/build hatchling:host during make_host (default)
*********** FAILED COMMAND ***********
DONT_BUILD_LEGACY_PYC=1 python3 -m build -n -w -x ${PKG_PYTHON_OPTS_HOST}
**************************************
FAILURE: scripts/build hatchling:host has failed!
```