### PR TITLE
pluggy: add missing setuptools-scm dependency

### DIFF
--- a/packages/python/devel/pluggy/package.mk
+++ b/packages/python/devel/pluggy/package.mk
@@ -7,7 +7,7 @@ PKG_SHA256="d35ec78be56dae9fd736e1378a2c3c176fd2aefd9daefc209abeab569c2732ee"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/pytest-dev/pluggy"
 PKG_URL="https://github.com/pytest-dev/pluggy/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_HOST="Python3:host setuptools:host"
+PKG_DEPENDS_HOST="Python3:host setuptools:host setuptools-scm:host"
 PKG_LONGDESC="A minimalist production ready plugin system"
 PKG_TOOLCHAIN="python"
 


### PR DESCRIPTION
This fixes clean build of hatchling. Tested with

PROJECT=Generic DEVICE=Generic ARCH=x86_64 scripts/build_mt hatchling:host PROJECT=Generic DEVICE=Generic ARCH=x86_64 make