### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="e5cf80d9e0b6630bb2e97decf664ad5f0c732b296b7c47030044c3a7287bbddb"
+PKG_SHA256="7608d82f33ce0ebbbed5bf8f6997319375c30a46d325496f3e8974c9a0c8ce6b"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="79eb04c7d8e1d73247cb7fe011eecc645063e0f0"
+export PKG_GIT_COMMIT="d1c06ef6b41d88d76866aea43c246cd7c63d04fa"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.5.2"
-PKG_SHA256="1235ed325d324c76f52e52beaa1dac85c92a073bf2f9fcc5bb9f67e35a668028"
+PKG_VERSION="29.5.3"
+PKG_SHA256="460e3c95fbf86414e88e7cb58551df061c206592bc66680fec75c5cdd551e3bd"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_TOOLCHAIN="manual"
 PKG_NO_REFRESH_PATCHES="tools/moby/gen-patches.sh"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="568f755ebeb1ac9c6a8febbda6cd371ea0a9630b"
+export PKG_GIT_COMMIT="285b47192d4b2f183aba5dd360a92cd52d723004"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://www.docker.com/"

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="sqlite"
-PKG_VERSION="3.53.1"
+PKG_VERSION="3.53.2"
 PKG_VERSION_SQLITE="${PKG_VERSION/./}00"
-PKG_SHA256="83e6b2020a034e9a7ad4a72feea59e1ad52f162e09cbd26735a3ffb98359fc4f"
+PKG_SHA256="588ad51949419a56ebe81fe56193d510c559eb94c9a57748387860b5d3069316"
 PKG_LICENSE="blessing"
 PKG_SITE="https://www.sqlite.org/"
 PKG_URL="https://www.sqlite.org/2026/${PKG_NAME}-autoconf-${PKG_VERSION_SQLITE/./0}.tar.gz"

--- a/packages/databases/sqlite/patches/0001-always-use-memory-for-tempfiles.patch
+++ b/packages/databases/sqlite/patches/0001-always-use-memory-for-tempfiles.patch
@@ -11,9 +11,10 @@ Signed-off-by: Stefan Saraev <stefan@saraev.ca>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/sqlite3.c b/sqlite3.c
+index 0765877..46f0467 100644
 --- a/sqlite3.c
 +++ b/sqlite3.c
-@@ -45789,7 +45789,7 @@ static void unixRemapfile(
+@@ -45809,7 +45809,7 @@ static void unixRemapfile(
      pNew = osMremap(pOrig, nReuse, nNew, MREMAP_MAYMOVE);
      zErr = "mremap";
  #else
@@ -22,7 +23,7 @@ diff --git a/sqlite3.c b/sqlite3.c
      if( pNew!=MAP_FAILED ){
        if( pNew!=pReq ){
          osMunmap(pNew, nNew - nReuse);
-@@ -45808,7 +45808,7 @@ static void unixRemapfile(
+@@ -45828,7 +45828,7 @@ static void unixRemapfile(
  
    /* If pNew is still NULL, try to create an entirely new mapping. */
    if( pNew==0 ){
@@ -31,3 +32,6 @@ diff --git a/sqlite3.c b/sqlite3.c
    }
  
    if( pNew==MAP_FAILED ){
+-- 
+2.53.0
+

--- a/packages/graphics/libde265/package.mk
+++ b/packages/graphics/libde265/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libde265"
-PKG_VERSION="1.1.0"
-PKG_SHA256="afc19dd28e2fc523de5952bba5224ee1d28e286c72436d2843df126cca1181fd"
+PKG_VERSION="1.1.1"
+PKG_SHA256="fd48a927e94ed74fc7ce8829d222b9d8599fcbfe8b6448ba66705babc56ab219"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="http://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libde265/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="22.0.2-Piers"
 PKG_SHA256="09a5e35fd2eee28cdf530f439e29e7cf1f4d0eee72f501e3e4f059c66cec7acc"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="41d0d40e1fb62d4a5cf23df30a4174509ed61e16"
-PKG_SHA256="4f839a98826ba0419535a4b64a4702b89b65f6d03e6f603e9b10e5a817b56a1c"
+PKG_VERSION="c166688baffcdcd78638d7b1f1cb7e8edfae8445"
+PKG_SHA256="6a4a1b45fe635975cb22f700b0f8983f122d4ba56ab74f20add468dc74e496d9"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"

--- a/packages/tools/bcmstat/package.mk
+++ b/packages/tools/bcmstat/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcmstat"
-PKG_VERSION="7880c777d6a2f631a9d017a371911c79b874744f"
-PKG_SHA256="7b0230e87299f40f6f52aeedff9c2a1761bab1d99cb9c958aa5aa476641b9ce8"
+PKG_VERSION="32d067b86fad8214f8b9a87a16241a89974dfb6a"
+PKG_SHA256="8c40097e12aeabd3d57f20a3e8d2a1402ed338867bfa0a9e1a83fc225886c880"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/popcornmix/bcmstat"
 PKG_URL="https://github.com/popcornmix/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libinput"
-PKG_VERSION="1.31.2"
-PKG_SHA256="1daebac6cb5b8946139c9669a7e5c0e4c8f17320de232a6b9bf470f37dc569e4"
+PKG_VERSION="1.31.3"
+PKG_SHA256="01414457befc3d1c68a328ebe01eacec8e7077a4ff08e181f5659daf9f50930e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.freedesktop.org/wiki/Software/libinput/"
 PKG_URL="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.bz2"

--- a/tools/update-functions/bcmstat
+++ b/tools/update-functions/bcmstat
@@ -1,0 +1,8 @@
+function get_pkg_ver() {
+  local github_repos=popcornmix/bcmstat
+
+  local upstream_default_branch=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}" | jq -r '.default_branch')
+  local upstream_latest_commit=$(curl -m 5 -sL "https://api.github.com/repos/${github_repos}/git/refs/heads/${upstream_default_branch}" | jq -r '.object.url')
+
+  pkgver=$(echo ${upstream_latest_commit} | sed 's#.*/##')
+}

--- a/tools/update-functions/extra_commit_body
+++ b/tools/update-functions/extra_commit_body
@@ -1,6 +1,10 @@
 function extra_commit_body() {
   # get the github_repo of the package if it is a github URL
-  github_repos=$(grep PKG_URL ${pkgmk} | grep -oP '(?<=https:\/\/github.com\/)?[0-9A-Za-z._-]+\/[0-9A-Za-z._-]+(?=/archive|/tags|/releases)')
+  github_repos=$(
+    source "${pkgmk}"
+    echo "${PKG_URL}" \
+      | grep -oP '(?<=https:\/\/github.com\/)?[0-9A-Za-z._-]+\/[0-9A-Za-z._-]+(?=/archive|/tags|/releases)'
+  )
   if [ ! -z "${github_repos}" ]; then
     [[ ${#fullhash} -eq 40 || ${#prevpkgver} -eq 40 ]] && \
       commit_msg+="\n\nLog:\n- https://github.com/${github_repos}/compare/${prevpkgver}...${fullhash}"

--- a/tools/update-functions/libde265
+++ b/tools/update-functions/libde265
@@ -1,0 +1,7 @@
+function custom_post_commit() {
+  echo "Starting revision update of dependant addons"
+  # do not change the version, just increment the addon
+  export commit_msg="imagedecoder.heif: update libde265 to ${pkgver}"
+  export commit_body="\n\n- libde265: ${pkgver}"
+  ${progname} imagedecoder.heif $(get_pkg_version imagedecoder.heif)
+}


### PR DESCRIPTION
- imagedecoder.heif: update libde265 to 1.1.1 and addon (6)
  - libde265: update to 1.1.1
- tools/update-functions: add additional special cases
- bcmstat: update to githash 32d067b
- bcm2835-utils: update to githash c166688
- sqlite: update to 3.53.2
- libinput: update to 1.31.3
- docker: update to 29.5.3 and addon (5)
  - cli: update to 29.5.3
  - moby: update to 29.5.3