### PR TITLE
Package updates

### DIFF
--- a/create_tar.sh
+++ b/create_tar.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2011 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
+
 git archive --format=tar --prefix=LibreELEC-source-$1/ tags/$1 | bzip2 > LibreELEC-source-$1.tar.bz2

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="oscam"
-PKG_VERSION="11961"
-PKG_SHA256="5ccb30e7378bb33c08b41c11b297d7c28a5c4542e9ebbc88b8669fbc9d43737d"
-PKG_REV="4"
+PKG_VERSION="11964"
+PKG_SHA256="2b2c7ca8ab30a7080d718a90ec4d1296d3f6e5acd7cd1a9c5addb7e16f662959"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-only"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/tools/bcm2835-utils/package.mk
+++ b/packages/tools/bcm2835-utils/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-utils"
-PKG_VERSION="c166688baffcdcd78638d7b1f1cb7e8edfae8445"
-PKG_SHA256="6a4a1b45fe635975cb22f700b0f8983f122d4ba56ab74f20add468dc74e496d9"
+PKG_VERSION="8903f297141461854ad421bdf90846ad030bdcc7"
+PKG_SHA256="c4376cd4bc86a4faf3714b4b6590019ab3cacce964f8fa02093ff33e862e1f4a"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://github.com/raspberrypi/utils"


### PR DESCRIPTION
- oscam: update to 11964 and addon (5)
- bcm2835-utils: update to githash 8903f29
- create_tar.sh: add SPDX and copyright headers