### PR TITLE
jsoncpp: resolve crash in visualization.shadertoy and bump PKG_REV for other packages

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.argustv"
 PKG_VERSION="22.3.4-Piers"
 PKG_SHA256="77d47279733bd70b6a1ccfce5fda7c63a879e1fd7cfbd3b4255c408b2cd3a9e5"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.argustv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.filmon"
 PKG_VERSION="22.2.4-Piers"
 PKG_SHA256="0ea79e5c14e01f5dd4e301fb8a7aa40793044eec1b7a1ec1915d311c3a925753"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.filmon"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.hdhomerun"
 PKG_VERSION="22.2.5-Piers"
 PKG_SHA256="71530079e0cd51a30151fa3e2d2ae6f9fc5eeae64dc23fcbea9055d50f572f1d"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.hdhomerun"

--- a/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.octonet/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.octonet"
 PKG_VERSION="22.2.0-Piers"
 PKG_SHA256="ccd00a4d1f6683ba6d418bd75c1e8c2b50b7ae794abb1625548fea36aebdcc31"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/DigitalDevices/pvr.octonet"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.pctv"
 PKG_VERSION="22.2.4-Piers"
 PKG_SHA256="69d340abc6e9e9829e6a182eb43151d6c91a7abb5ca965bd090422a011c96c68"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.pctv"

--- a/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.sledovanitv.cz/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="pvr.sledovanitv.cz"
 PKG_VERSION="22.6.1-Piers"
 PKG_SHA256="a1e3474be90932dcded66a2043db53e91c0fc19c4573598dba2d1478c2d51758"
-PKG_REV="3"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/palinek/pvr.sledovanitv.cz"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="pvr.stalker"
 PKG_VERSION="22.2.5-Piers"
 PKG_SHA256="c9604b3526ec39cc564ead07d57adbe9bcb04d8874d50978e125de6f7bfaa42b"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.stalker"

--- a/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/visualization.shadertoy/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="visualization.shadertoy"
 PKG_VERSION="22.1.0-Piers"
 PKG_SHA256="4d839d02a2e2529610ab33f3f9946a581809832575ebee136a42b1e4f57f3798"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/visualization.shadertoy"

--- a/packages/textproc/jsoncpp/patches/0001-fix-crashes.patch
+++ b/packages/textproc/jsoncpp/patches/0001-fix-crashes.patch
@@ -1,0 +1,185 @@
+From f7bc5a38571a0ad23edecb55bdbc948649ce594e Mon Sep 17 00:00:00 2001
+From: Jordan Bayles <jophba@chromium.org>
+Date: Tue, 7 Apr 2026 21:58:40 -0700
+Subject: [PATCH 2/8] Fix C++11 ABI breakage when compiled with C++17 (#1668)
+
+When JSONCPP_HAS_STRING_VIEW was defined, the library dropped the
+`const char*` and `const String&` overloads for `operator[]`, `get`,
+`removeMember`, and `isMember`, breaking ABI compatibility for projects
+consuming the library with C++11.
+
+This change unconditionally declares and defines the legacy overloads
+so they are always exported, restoring compatibility.
+---
+ include/json/value.h        | 15 +++++----------
+ src/lib_json/json_value.cpp | 15 +++++----------
+ 2 files changed, 10 insertions(+), 20 deletions(-)
+
+diff --git a/include/json/value.h b/include/json/value.h
+index f32f45609..1369f9207 100644
+--- a/include/json/value.h
++++ b/include/json/value.h
+@@ -501,7 +501,7 @@ class JSON_API Value {
+   /// that name.
+   /// \param key may contain embedded nulls.
+   const Value& operator[](std::string_view key) const;
+-#else
++#endif
+   /// Access an object value by name, create a null member if it does not exist.
+   /// \note Because of our implementation, keys are limited to 2^30 -1 chars.
+   /// Exceeding that will cause an exception.
+@@ -516,7 +516,6 @@ class JSON_API Value {
+   /// that name.
+   /// \param key may contain embedded nulls.
+   const Value& operator[](const String& key) const;
+-#endif
+   /** \brief Access an object value by name, create a null member if it does not
+    * exist.
+    *
+@@ -534,7 +533,7 @@ class JSON_API Value {
+   /// Return the member named key if it exist, defaultValue otherwise.
+   /// \note deep copy
+   Value get(std::string_view key, const Value& defaultValue) const;
+-#else
++#endif
+   /// Return the member named key if it exist, defaultValue otherwise.
+   /// \note deep copy
+   Value get(const char* key, const Value& defaultValue) const;
+@@ -542,7 +541,6 @@ class JSON_API Value {
+   /// \note deep copy
+   /// \param key may contain embedded nulls.
+   Value get(const String& key, const Value& defaultValue) const;
+-#endif
+   /// Return the member named key if it exist, defaultValue otherwise.
+   /// \note deep copy
+   /// \note key may contain embedded nulls.
+@@ -589,12 +587,11 @@ class JSON_API Value {
+   /// \post type() is unchanged
+ #if JSONCPP_HAS_STRING_VIEW
+   void removeMember(std::string_view key);
+-#else
++#endif
+   void removeMember(const char* key);
+   /// Same as removeMember(const char*)
+   /// \param key may contain embedded nulls.
+   void removeMember(const String& key);
+-#endif
+   /** \brief Remove the named map member.
+    *
+    *  Update 'removed' iff removed.
+@@ -603,12 +600,11 @@ class JSON_API Value {
+    */
+ #if JSONCPP_HAS_STRING_VIEW
+   bool removeMember(std::string_view key, Value* removed);
+-#else
++#endif
+   bool removeMember(String const& key, Value* removed);
+   /// Same as removeMember(const char* begin, const char* end, Value* removed),
+   /// but 'key' is null-terminated.
+   bool removeMember(const char* key, Value* removed);
+-#endif
+   /// Same as removeMember(String const& key, Value* removed)
+   bool removeMember(const char* begin, const char* end, Value* removed);
+   /** \brief Remove the indexed array element.
+@@ -623,14 +619,13 @@ class JSON_API Value {
+   /// Return true if the object has a member named key.
+   /// \param key may contain embedded nulls.
+   bool isMember(std::string_view key) const;
+-#else
++#endif
+   /// Return true if the object has a member named key.
+   /// \note 'key' must be null-terminated.
+   bool isMember(const char* key) const;
+   /// Return true if the object has a member named key.
+   /// \param key may contain embedded nulls.
+   bool isMember(const String& key) const;
+-#endif
+   /// Same as isMember(String const& key)const
+   bool isMember(const char* begin, const char* end) const;
+ 
+diff --git a/src/lib_json/json_value.cpp b/src/lib_json/json_value.cpp
+index 74f77896f..953d58eae 100644
+--- a/src/lib_json/json_value.cpp
++++ b/src/lib_json/json_value.cpp
+@@ -1200,7 +1200,7 @@ const Value& Value::operator[](std::string_view key) const {
+ Value& Value::operator[](std::string_view key) {
+   return resolveReference(key.data(), key.data() + key.length());
+ }
+-#else
++#endif
+ const Value& Value::operator[](const char* key) const {
+   Value const* found = find(key, key + strlen(key));
+   if (!found)
+@@ -1221,7 +1221,6 @@ Value& Value::operator[](const char* key) {
+ Value& Value::operator[](const String& key) {
+   return resolveReference(key.data(), key.data() + key.length());
+ }
+-#endif
+ 
+ Value& Value::operator[](const StaticString& key) {
+   return resolveReference(key.c_str());
+@@ -1265,14 +1264,13 @@ Value Value::get(char const* begin, char const* end,
+ Value Value::get(std::string_view key, const Value& defaultValue) const {
+   return get(key.data(), key.data() + key.length(), defaultValue);
+ }
+-#else
++#endif
+ Value Value::get(char const* key, Value const& defaultValue) const {
+   return get(key, key + strlen(key), defaultValue);
+ }
+ Value Value::get(String const& key, Value const& defaultValue) const {
+   return get(key.data(), key.data() + key.length(), defaultValue);
+ }
+-#endif
+ 
+ bool Value::removeMember(const char* begin, const char* end, Value* removed) {
+   if (type() != objectValue) {
+@@ -1292,14 +1290,13 @@ bool Value::removeMember(const char* begin, const char* end, Value* removed) {
+ bool Value::removeMember(std::string_view key, Value* removed) {
+   return removeMember(key.data(), key.data() + key.length(), removed);
+ }
+-#else
++#endif
+ bool Value::removeMember(const char* key, Value* removed) {
+   return removeMember(key, key + strlen(key), removed);
+ }
+ bool Value::removeMember(String const& key, Value* removed) {
+   return removeMember(key.data(), key.data() + key.length(), removed);
+ }
+-#endif
+ 
+ #ifdef JSONCPP_HAS_STRING_VIEW
+ void Value::removeMember(std::string_view key) {
+@@ -1312,7 +1309,7 @@ void Value::removeMember(std::string_view key) {
+                      CZString::noDuplication);
+   value_.map_->erase(actualKey);
+ }
+-#else
++#endif
+ void Value::removeMember(const char* key) {
+   JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
+                       "in Json::Value::removeMember(): requires objectValue");
+@@ -1323,7 +1320,6 @@ void Value::removeMember(const char* key) {
+   value_.map_->erase(actualKey);
+ }
+ void Value::removeMember(const String& key) { removeMember(key.c_str()); }
+-#endif
+ 
+ bool Value::removeIndex(ArrayIndex index, Value* removed) {
+   if (type() != arrayValue) {
+@@ -1357,14 +1353,13 @@ bool Value::isMember(char const* begin, char const* end) const {
+ bool Value::isMember(std::string_view key) const {
+   return isMember(key.data(), key.data() + key.length());
+ }
+-#else
++#endif
+ bool Value::isMember(char const* key) const {
+   return isMember(key, key + strlen(key));
+ }
+ bool Value::isMember(String const& key) const {
+   return isMember(key.data(), key.data() + key.length());
+ }
+-#endif
+ 
+ Value::Members Value::getMemberNames() const {
+   JSON_ASSERT_MESSAGE(


### PR DESCRIPTION
This resolves a hard crash when loading `visualization.shadertoy` on current LE13 nightlies (see https://github.com/xbmc/visualization.shadertoy/issues/133). As a precaution I've also bumped `PKG_REV` for the other binary add-ons that depend on the `jsoncpp` package.