### PR TITLE
snapclient: whitespace support in "Host ID" field

### DIFF
--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapclient"
 PKG_VERSION="0.35.0"
-PKG_REV="0"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -26,16 +26,13 @@ case "$DISTRO_ARCH" in
     ;;
 esac
 
-[ -n "$sc_h" ] && sc_H="--hostID '$sc_h'"
-[ -n "$sc_s" ] && sc_S="--soundcard '$sc_s'"
-[ -n "$sc_addr" ] && HOST="--host '$sc_addr'"
+ARGS=""
+[ -n "$sc_addr" ] && ARGS="$ARGS --host $sc_addr"
+[ -n "$sc_h" ] && ARGS="$ARGS --hostID '$sc_h'"
+[ -n "$sc_l" ] && ARGS="$ARGS --latency $sc_l"
+[ -n "$sc_p" ] && ARGS="$ARGS --port $sc_p"
+[ -n "$sc_s" ] && ARGS="$ARGS --soundcard $sc_s"
 
 HOME="$ADDON_HOME" \
 nice -n "$sc_n" \
-snapclient \
-  $sc_H \
-  --latency "$sc_l" \
-  $HOST \
-  --port "$sc_p" \
-  $sc_S \
-  > /dev/null
+/bin/sh -c "snapclient $ARGS > /dev/null"


### PR DESCRIPTION
Fixes issue #10746 and pull request #11221 (see my comment).

Running snapclient with `/bin/sh -c "snapclient $ARGS"` prevents the double-quoting of arguments and allows whitespaces in the "Host ID" field.
