### PR TITLE
kodi: update to 06872809 and reardonia patches and use sensible defaults

### DIFF
--- a/packages/mediacenter/kodi/config/appliance-gbm-generic.xml
+++ b/packages/mediacenter/kodi/config/appliance-gbm-generic.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <settings version="1">
   <section id="player">
+    <category id="videoplayer">
+      <group id="3">
+        <setting id="videoplayer.useprimedecoder">
+          <default>false</default>
+        </setting>
+        <setting id="videoplayer.useprimedecoderforhw">
+          <default>false</default>
+        </setting>
+        <setting id="videoplayer.useprimerenderer">
+          <default>1</default>
+        </setting>
+      </group>
+    </category>
     <category id="input">
       <group id="4">
         <setting id="input.libinputkeyboardlayout">

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="3640aaaed83ba411a7b3e3fc16700ef0f3d8dee4"
-PKG_SHA256="41a61fde367429f6a3fff7f93286832f463ffdb0bc4fd75b86ad5721d7e84de0"
+PKG_VERSION="0687280921b4405e36c55e6445d03743a1f73921"
+PKG_SHA256="8e444f8cd4adfd13ca3af510eb628c1d39cf59c94ff9f428cf9b620dc474825e"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-GBM-skip-HDR-GUI-composite-and-FBO-clear-when-the-GU.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0001-GBM-skip-HDR-GUI-composite-and-FBO-clear-when-the-GU.patch
@@ -1,7 +1,7 @@
-From 748622d7d371caf4c1bfb7048da6be2ff409b769 Mon Sep 17 00:00:00 2001
+From 40138f72fbd822068e0e481d8c744bf0c6036b13 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Wed, 27 May 2026 00:37:45 -0400
-Subject: [PATCH 1/5] GBM: skip HDR GUI composite and FBO clear when the GUI
+Subject: [PATCH 1/7] GBM: skip HDR GUI composite and FBO clear when the GUI
  layer is empty
 
 During HDR playback the GUI FBO compositing path ran the full-screen
@@ -27,14 +27,14 @@ Applies to both the GLES and GL GBM winsystems.
  xbmc/guilib/GUITextureGL.cpp                  |  2 ++
  xbmc/guilib/GUITextureGLES.cpp                |  2 ++
  xbmc/rendering/RenderSystem.cpp               |  2 ++
- xbmc/rendering/RenderSystem.h                 |  4 ++++
+ xbmc/rendering/RenderSystem.h                 |  4 +++
  xbmc/rendering/gl/RenderSystemGL.cpp          |  2 ++
  xbmc/rendering/gles/RenderSystemGLES.cpp      |  2 ++
- xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 18 ++++++++++++++++--
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  | 26 +++++++++++++++++--
  xbmc/windowing/gbm/WinSystemGbmGLContext.h    |  1 +
- .../windowing/gbm/WinSystemGbmGLESContext.cpp | 19 ++++++++++++++++---
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp | 19 +++++++++++---
  xbmc/windowing/gbm/WinSystemGbmGLESContext.h  |  1 +
- 14 files changed, 54 insertions(+), 5 deletions(-)
+ 14 files changed, 62 insertions(+), 5 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
 index 944f324828..d9f52977bb 100644
@@ -195,11 +195,21 @@ index d34c313129..6036c2251e 100644
                            !CServiceBroker::GetWinSystem()->IsHdrComposite();
    const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();
 diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index 4b9008dccf..c20c221023 100644
+index 4b9008dccf..eaf7f25457 100644
 --- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
 +++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -270,14 +270,20 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
+@@ -268,16 +268,30 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
+       return false;
+     }
  
++    if (GetEnabledFrontToBackRendering() && !m_guiFbo.AttachDepthBuffer(width, height))
++    {
++      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to attach depth buffer to GUI FBO {}x{}",
++                width, height);
++      m_guiFbo.Cleanup();
++      return false;
++    }
++
      m_guiFboWidth = width;
      m_guiFboHeight = height;
 +    m_guiFboClean = false; // fresh FBO is undefined, force a clear
@@ -221,7 +231,7 @@ index 4b9008dccf..c20c221023 100644
  
    return true;
  }
-@@ -298,6 +304,14 @@ void CWinSystemGbmGLContext::CompositeGui()
+@@ -298,6 +312,14 @@ void CWinSystemGbmGLContext::CompositeGui()
    if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
      return;
  

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-GBM-skip-GUI-re-render-in-D2P-when-nothing-dirties-S.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0002-GBM-skip-GUI-re-render-in-D2P-when-nothing-dirties-S.patch
@@ -1,7 +1,7 @@
-From 331ee582e6259d723cda73defe2bbe145d541def Mon Sep 17 00:00:00 2001
+From b12e74464a0cb1b98adb8cd9461bae904b0326ba Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Thu, 28 May 2026 22:38:21 -0400
-Subject: [PATCH 2/5] GBM: skip GUI re-render in D2P when nothing dirties (SDR
+Subject: [PATCH 2/7] GBM: skip GUI re-render in D2P when nothing dirties (SDR
  and HDR)
 
 Today Kodi re-walks CGUIWindowManager and re-renders the GUI on every
@@ -121,7 +121,7 @@ index 3abc92a7e5..7025273635 100644
    virtual void CompositeGui() {}
  
 diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index c20c221023..2f476ac5db 100644
+index eaf7f25457..14f2feb338 100644
 --- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
 +++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
 @@ -242,11 +242,13 @@ bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
@@ -139,7 +139,7 @@ index c20c221023..2f476ac5db 100644
    int width = m_nWidth;
    int height = m_nHeight;
  
-@@ -274,6 +276,11 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
+@@ -282,6 +284,11 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
      CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
    }
  
@@ -151,7 +151,7 @@ index c20c221023..2f476ac5db 100644
    if (!m_guiFbo.BeginRender())
      return false;
  
-@@ -290,7 +297,8 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
+@@ -298,7 +305,8 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
  
  void CWinSystemGbmGLContext::EndGuiComposite()
  {

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-GBM-cache-PQ-back-buffer-across-D2P-dirty-driven-ski.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0003-GBM-cache-PQ-back-buffer-across-D2P-dirty-driven-ski.patch
@@ -1,7 +1,7 @@
-From de11ddc5ccb1be7b83dcd1bf220502f09d7f0e3a Mon Sep 17 00:00:00 2001
+From c8bbf6bb1cfa2682bcbf904985aec911b199cd27 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 29 May 2026 17:43:40 -0400
-Subject: [PATCH 3/5] GBM: cache PQ back buffer across D2P dirty-driven skip
+Subject: [PATCH 3/7] GBM: cache PQ back buffer across D2P dirty-driven skip
  frames
 
 On the D2P direct-to-plane path, the GUI plane back buffer holds the
@@ -34,10 +34,10 @@ gated on IsRenderingVideoLayer() == true.
  2 files changed, 77 insertions(+), 14 deletions(-)
 
 diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-index 2f476ac5db..904109dc1f 100644
+index 14f2feb338..d7b83a6462 100644
 --- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
 +++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
-@@ -277,7 +277,14 @@ bool CWinSystemGbmGLContext::BeginGuiComposite(bool guiWillRender)
+@@ -285,7 +285,14 @@ bool CWinSystemGbmGLContext::BeginGuiComposite(bool guiWillRender)
    }
  
    // When GUI render is being skipped, leave the FBO bind/clear out: nothing
@@ -53,7 +53,7 @@ index 2f476ac5db..904109dc1f 100644
    if (!guiWillRender)
      return true;
  
-@@ -300,6 +307,14 @@ void CWinSystemGbmGLContext::EndGuiComposite()
+@@ -308,6 +315,14 @@ void CWinSystemGbmGLContext::EndGuiComposite()
    if (m_guiWillRender)
      m_guiFbo.EndRender();
  
@@ -68,7 +68,7 @@ index 2f476ac5db..904109dc1f 100644
    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
    glClear(GL_COLOR_BUFFER_BIT);
  }
-@@ -312,12 +327,26 @@ void CWinSystemGbmGLContext::CompositeGui()
+@@ -320,12 +335,26 @@ void CWinSystemGbmGLContext::CompositeGui()
    if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
      return;
  

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-Overlays-hook-MarkDirty-so-subtitles-drive-the-dirty.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0004-Overlays-hook-MarkDirty-so-subtitles-drive-the-dirty.patch
@@ -1,7 +1,7 @@
-From 1fa850f1b3e8183ce00e829c306a9bd1f9689e6c Mon Sep 17 00:00:00 2001
+From d13341a17b50f60cc702b044ddf30a0e524c4d28 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Fri, 29 May 2026 23:56:21 -0400
-Subject: [PATCH 4/5] Overlays: hook MarkDirty so subtitles drive the
+Subject: [PATCH 4/7] Overlays: hook MarkDirty so subtitles drive the
  dirty-driven Render skip
 
 CRenderManager overlays (subtitles, debug OSD) do not participate in

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-Overlays-per-frame-visibility-signal-libass-correctn.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0005-Overlays-per-frame-visibility-signal-libass-correctn.patch
@@ -1,7 +1,7 @@
-From ae91f18f2123eaa3539da5138d97a46de459aedf Mon Sep 17 00:00:00 2001
+From 37916d33fa882d51e14f665f753e6a50cd17e001 Mon Sep 17 00:00:00 2001
 From: reardonia <2925104+reardonia@users.noreply.github.com>
 Date: Thu, 4 Jun 2026 22:52:20 -0400
-Subject: [PATCH 5/5] Overlays: per-frame visibility signal, libass
+Subject: [PATCH 5/7] Overlays: per-frame visibility signal, libass
  correctness, re-enable D2P detach
 
 Replaces the always-on-once-libass-loaded HasOverlay signal with a per-frame
@@ -41,29 +41,32 @@ verify skip rate during draft testing; to be removed before merge.
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 ---
- xbmc/application/Application.cpp              |  38 ++
+ xbmc/application/Application.cpp              |  36 ++
  xbmc/application/ApplicationPlayer.cpp        |   9 +
  xbmc/application/ApplicationPlayer.h          |   1 +
  xbmc/cores/IPlayer.h                          |   6 +
- .../DVDCodecs/Overlay/DVDOverlayLibass.h      |   7 +
+ .../DVDCodecs/Overlay/DVDOverlayLibass.h      |  14 +-
  xbmc/cores/VideoPlayer/VideoPlayer.cpp        |   5 +
  xbmc/cores/VideoPlayer/VideoPlayer.h          |   1 +
- .../VideoRenderers/DebugRenderer.cpp          |  22 +-
- .../VideoRenderers/OverlayRenderer.cpp        | 349 +++++++++++-------
+ .../VideoRenderers/DebugRenderer.cpp          | 121 +++++-
+ .../VideoRenderers/OverlayRenderer.cpp        | 348 +++++++++++-------
  .../VideoRenderers/OverlayRenderer.h          |  62 +++-
- .../VideoRenderers/RenderManager.cpp          |  14 +-
+ .../VideoRenderers/RenderManager.cpp          |  16 +-
  .../VideoRenderers/RenderManager.h            |  14 +-
  xbmc/guilib/GUIVideoControl.cpp               |   4 +-
  xbmc/pictures/GUIWindowSlideShow.cpp          |   5 +-
+ xbmc/rendering/RenderSystem.h                 |   2 +
  xbmc/video/windows/GUIWindowFullScreen.cpp    |   6 +-
+ xbmc/windowing/gbm/WinSystemGbmGLContext.cpp  |   2 +-
+ .../windowing/gbm/WinSystemGbmGLESContext.cpp |   2 +-
  xbmc/windowing/gbm/drm/DRMAtomic.cpp          |  21 +-
- 16 files changed, 396 insertions(+), 168 deletions(-)
+ 19 files changed, 503 insertions(+), 172 deletions(-)
 
 diff --git a/xbmc/application/Application.cpp b/xbmc/application/Application.cpp
-index e9077e1c01..09e06cec10 100644
+index e9077e1c01..3b3ec708e5 100644
 --- a/xbmc/application/Application.cpp
 +++ b/xbmc/application/Application.cpp
-@@ -905,6 +905,44 @@ void CApplication::Render()
+@@ -905,6 +905,42 @@ void CApplication::Render()
                                                         appPlayer->IsRenderingVideoLayer());
  
    CTimeUtils::UpdateFrameTime(hasRendered);
@@ -86,8 +89,7 @@ index e9077e1c01..09e06cec10 100644
 +    else
 +    {
 +      ++s_video;
-+      const bool ctrlsOn =
-+          CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls();
++      const bool ctrlsOn = CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls();
 +      const bool subsOn = appPlayer->HasVisibleOverlay();
 +      if (ctrlsOn)
 +        ++s_ctrls;
@@ -100,8 +102,7 @@ index e9077e1c01..09e06cec10 100644
 +          ++s_skipGui;
 +      }
 +      if (s_video % 240 == 0)
-+        CLog::Log(LOGDEBUG,
-+                  "TEMP: [framecount] video={} ctrls={} subs={} skip-gui={} skip-any={}",
++        CLog::Log(LOGDEBUG, "TEMP: [framecount] video={} ctrls={} subs={} skip-gui={} skip-any={}",
 +                  s_video, s_ctrls, s_subs, s_skipGui, s_skipAny);
 +    }
 +  }
@@ -158,18 +159,32 @@ index 197ee9a614..07a5f7115a 100644
    virtual void GetRects(CRect& source, CRect& dest, CRect& view) const
    {
 diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
-index daffb2fe6e..dc67983fed 100644
+index daffb2fe6e..17dff9fdf2 100644
 --- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
 +++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
-@@ -32,6 +32,13 @@ public:
+@@ -22,7 +22,12 @@ public:
+   {
+   }
+ 
+-  CDVDOverlayLibass(const CDVDOverlayLibass& src) : CDVDOverlay(src), m_libass(src.m_libass) {}
++  CDVDOverlayLibass(const CDVDOverlayLibass& src)
++    : CDVDOverlay(src),
++      m_pendingChange(src.m_pendingChange),
++      m_libass(src.m_libass)
++  {
++  }
+ 
+   ~CDVDOverlayLibass() override = default;
+ 
+@@ -32,6 +37,13 @@ public:
    */
    std::shared_ptr<CDVDSubtitlesLibass> GetLibassHandler() const { return m_libass; }
  
-+  // libass change-since-last-walk-consumed. OR-accumulated by
-+  // OVERLAY::CRenderer::PrepareOverlays from libass detect_change output;
-+  // consumed and cleared by ConvertLibass when a fresh COverlay is created.
-+  // Lives on the persistent overlay so it survives the per-frame SElement
-+  // recycling driven by RenderManager AddOverlay/Release.
++  // libass change-since-last-walk-consumed flag. Set non-zero by
++  // OVERLAY::CRenderer::PrepareOverlays when libass detect_change reports
++  // non-zero; consumed and cleared by ConvertLibass when a fresh COverlay
++  // is created. Lives on the persistent overlay so it survives the
++  // per-frame SElement recycling driven by RenderManager AddOverlay/Release.
 +  int m_pendingChange{0};
 +
  private:
@@ -204,18 +219,54 @@ index 6f7494fdc8..99ec442088 100644
    bool Supports(EINTERLACEMETHOD method) const override;
    EINTERLACEMETHOD GetDeinterlacingMethodDefault() const override;
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
-index 160a9d31be..b86b818703 100644
+index 160a9d31be..4182adcdcf 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
-@@ -138,8 +138,26 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
+@@ -8,11 +8,13 @@
+ 
+ #include "DebugRenderer.h"
+ 
++#include "ServiceBroker.h"
+ #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
+ #include "cores/VideoPlayer/Interface/TimingConstants.h"
+ #include "settings/SubtitlesSettings.h"
+ #include "utils/log.h"
+ #include "windowing/GraphicContext.h"
++#include "windowing/WinSystem.h"
+ 
+ using namespace OVERLAY;
+ 
+@@ -44,6 +46,11 @@ void CDebugRenderer::Initialize()
+   // We create only a single overlay with a fixed PTS for each rendered frame
+   m_overlay = m_adapter->CreateOverlay();
+   m_overlayRenderer.AddOverlay(m_overlay, 1000000., 0);
++
++  // Kick the dirty-driven walk skip so the toggle takes effect this frame;
++  // without this the walk stays idle and the debug overlay never starts
++  // rendering until something else dirties the GUI.
++  OVERLAY::MarkDirty();
+ }
+ 
+ void CDebugRenderer::Dispose()
+@@ -51,6 +58,7 @@ void CDebugRenderer::Dispose()
+   m_isInitialized = false;
+   m_overlayRenderer.Flush();
+   m_overlay.reset();
++  OVERLAY::MarkDirty();
+   if (m_adapter)
+   {
+     delete m_adapter;
+@@ -138,8 +146,117 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
        if (updateStyle)
          CreateSubtitlesStyle();
  
 -      std::shared_ptr<COverlay> o =
 -          ConvertLibass(*ovAss, it->pts, updateStyle, m_debugOverlayStyle);
-+      // Debug OSD draws on its own pass and does not go through PrepareOverlays,
-+      // so it populates the SElement's cached libass output inline before
-+      // handing it to ConvertLibass.
++      // Debug OSD is a standalone path: text content changes every frame
++      // and DebugRenderer::Render MarkDirty's per frame anyway, so it does
++      // not participate in the PrepareOverlays / SElement caching scheme.
++      // The rOpts setup below mirrors what master's CRenderer::ConvertLibass
++      // did inline.
 +      KODI::SUBTITLES::STYLE::renderOpts rOpts;
 +      rOpts.sourceWidth = m_rs.Width();
 +      rOpts.sourceHeight = m_rs.Height();
@@ -224,20 +275,109 @@ index 160a9d31be..b86b818703 100644
 +      rOpts.frameWidth = m_rv.Width();
 +      rOpts.frameHeight = m_rv.Height();
 +
-+      it->renderedFrameWidth = rOpts.frameWidth;
-+      it->renderedFrameHeight = rOpts.frameHeight;
-+      int currentChange = 0;
-+      it->renderedImages = ovAss->GetLibassHandler()->RenderImage(
-+          it->pts, rOpts, updateStyle, m_debugOverlayStyle, &currentChange);
-+      if (currentChange > 0)
-+        ovAss->m_pendingChange = currentChange;
++      // Render subtitle of half-sbs and half-ou video in full screen, not in half screen
++      if (m_stereomode == "left_right" || m_stereomode == "right_left")
++      {
++        // only half-sbs video, sbs video don't need to change source size
++        if (rOpts.sourceWidth / rOpts.sourceHeight < 1.2f)
++          rOpts.sourceWidth = m_rs.Width() * 2;
++      }
++      else if (m_stereomode == "top_bottom" || m_stereomode == "bottom_top")
++      {
++        // only half-ou video, ou video don't need to change source size
++        if (rOpts.sourceWidth / rOpts.sourceHeight > 2.5f)
++          rOpts.sourceHeight = m_rs.Height() * 2;
++      }
 +
-+      std::shared_ptr<COverlay> o = ConvertLibass(*it);
++      // Set position of subtitles based on video calibration settings
++      RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
++      // Keep track of subtitle position value change,
++      // can be changed by GUI Calibration or by window mode/resolution change or
++      // by user manual change (e.g. keyboard shortcut)
++      if (m_subtitlePosResInfo != resInfo.iSubtitles)
++      {
++        if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
++        {
++          // m_subtitlePosition has been changed
++          // and has been requested to save the value to resInfo
++          resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
++          CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
++              CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
++          m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
++        }
++        else
++          ResetSubtitlePosition();
++      }
++
++      rOpts.m_par = resInfo.fPixelRatio;
++
++      // rOpts.position and margins (set to style) can invalidate the text
++      // positions to subtitles type that make use of margins to position text on
++      // the screen (e.g. ASS/WebVTT) then we allow to set them when position
++      // override setting is enabled only
++      if (ovAss->IsForcedMargins())
++      {
++        rOpts.marginsMode = KODI::SUBTITLES::STYLE::MarginsMode::DISABLED;
++      }
++      else if (m_subtitleAlign == KODI::SUBTITLES::Align::MANUAL)
++      {
++        // When vertical margins are used Libass apply a displacement in percentage
++        // of the height available to line position, this displacement causes
++        // problems with subtitle calibration bar on Video Calibration window,
++        // so when you moving the subtitle bar of the GUI the text will no longer
++        // match the bar, this calculation compensates for the displacement.
++        // Note also that the displacement compensation will cause a different
++        // default position of the text, different from the other alignment positions
++        double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
++
++        int assPlayResY = ovAss->GetLibassHandler()->GetPlayResY();
++        double assVertMargin = static_cast<double>(m_debugOverlayStyle->marginVertical) *
++                               (static_cast<double>(assPlayResY) / 720);
++        double vertMarginScaled =
++            assVertMargin / assPlayResY * static_cast<double>(rOpts.frameHeight);
++
++        double pos = posPx / (static_cast<double>(rOpts.frameHeight) - vertMarginScaled);
++        rOpts.position = 100 - pos * 100;
++      }
++      else if (m_subtitleAlign == KODI::SUBTITLES::Align::BOTTOM_OUTSIDE)
++      {
++        // To keep consistent the position of text as other alignment positions
++        // we avoid apply the displacement compensation
++        double posPx = static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin -
++                                           resInfo.Overscan.top);
++        rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
++      }
++      else if (m_subtitleAlign == KODI::SUBTITLES::Align::BOTTOM_INSIDE ||
++               m_subtitleAlign == KODI::SUBTITLES::Align::TOP_INSIDE)
++      {
++        rOpts.marginsMode = KODI::SUBTITLES::STYLE::MarginsMode::INSIDE_VIDEO;
++      }
++
++      // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
++      // This setting influence style->alignment property
++      if (ovAss->IsTextAlignEnabled())
++      {
++        if (m_subtitleHorizontalAlign == KODI::SUBTITLES::HorizontalAlign::LEFT)
++          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::LEFT;
++        else if (m_subtitleHorizontalAlign == KODI::SUBTITLES::HorizontalAlign::RIGHT)
++          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::RIGHT;
++        else
++          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::CENTER;
++      }
++
++      int changes = 0;
++      ASS_Image* images = ovAss->GetLibassHandler()->RenderImage(it->pts, rOpts, updateStyle,
++                                                                 m_debugOverlayStyle, &changes);
++
++      if (!images)
++        continue;
++
++      std::shared_ptr<COverlay> o = COverlay::Create(images, rOpts.frameWidth, rOpts.frameHeight);
  
        if (o)
          OVERLAY::CRenderer::Render(o.get());
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
-index 07768393f6..613d1a56c1 100644
+index 07768393f6..b00e9b61d8 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
 @@ -71,16 +71,6 @@ void CRenderer::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index
@@ -310,7 +450,7 @@ index 07768393f6..613d1a56c1 100644
  }
  
  void CRenderer::SetVideoRect(CRect &source, CRect &dest, CRect &view)
-@@ -419,125 +421,205 @@ void CRenderer::CreateSubtitlesStyle()
+@@ -419,125 +421,204 @@ void CRenderer::CreateSubtitlesStyle()
    m_overlayStyle->lineSpacing = settings->GetLineSpacing();
  }
  
@@ -319,7 +459,7 @@ index 07768393f6..613d1a56c1 100644
 -    double pts,
 -    bool updateStyle,
 -    const std::shared_ptr<struct SUBTITLES::STYLE::style>& overlayStyle)
-+bool CRenderer::PrepareOverlays(int idx)
++void CRenderer::PrepareOverlays(int idx)
  {
 -  SUBTITLES::STYLE::renderOpts rOpts;
 -
@@ -348,7 +488,7 @@ index 07768393f6..613d1a56c1 100644
 -  }
 +  std::unique_lock lock(m_section);
 +  if (idx < 0 || idx >= NUM_BUFFERS)
-+    return false;
++    return;
  
 -  // Set position of subtitles based on video calibration settings
 -  RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
@@ -541,8 +681,8 @@ index 07768393f6..613d1a56c1 100644
 +    {
 +      // To keep consistent the position of text as other alignment positions
 +      // we avoid apply the displacement compensation
-+      double posPx = static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin -
-+                                         resInfo.Overscan.top);
++      double posPx =
++          static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin - resInfo.Overscan.top);
 +      rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
 +    }
 +    else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_INSIDE ||
@@ -569,8 +709,8 @@ index 07768393f6..613d1a56c1 100644
 +    // Pull the libass output for this PTS. Cached on the SElement until
 +    // ConvertLibass consumes it later in this frame's GUI walk.
 +    int currentChange = 0;
-+    e.renderedImages = ovAss.GetLibassHandler()->RenderImage(
-+        e.pts, rOpts, updateStyle, m_overlayStyle, &currentChange);
++    e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
++                                                             m_overlayStyle, &currentChange);
 +    // OR-accumulate libass's per-call change onto the persistent overlay,
 +    // not onto SElement: m_buffers[idx] is rebuilt per frame by AddOverlay/
 +    // Release on the render queue, so SElement state cannot survive the
@@ -600,7 +740,6 @@ index 07768393f6..613d1a56c1 100644
 +
 +  if (hasChanges)
 +    MarkDirty();
-+  return hasChanges;
 +}
  
 +std::shared_ptr<COverlay> CRenderer::ConvertLibass(SElement& e)
@@ -619,7 +758,7 @@ index 07768393f6..613d1a56c1 100644
      {
        std::map<unsigned int, std::shared_ptr<COverlay>>::iterator it =
            m_textureCache.find(o.m_textureid);
-@@ -546,16 +628,22 @@ std::shared_ptr<COverlay> CRenderer::ConvertLibass(
+@@ -546,16 +627,22 @@ std::shared_ptr<COverlay> CRenderer::ConvertLibass(
      }
    }
  
@@ -630,7 +769,7 @@ index 07768393f6..613d1a56c1 100644
    m_textureCache[m_textureid] = overlay;
    o.m_textureid = m_textureid;
    m_textureid++;
-+  o.m_pendingChange = 0;  // consume
++  o.m_pendingChange = 0; // consume
    return overlay;
  }
  
@@ -644,7 +783,7 @@ index 07768393f6..613d1a56c1 100644
    std::shared_ptr<COverlay> r = NULL;
  
    if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
-@@ -563,15 +651,10 @@ std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
+@@ -563,15 +650,10 @@ std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
      CDVDOverlayLibass& ovAss = static_cast<CDVDOverlayLibass&>(o);
      if (!ovAss.GetLibassHandler())
        return nullptr;
@@ -664,7 +803,7 @@ index 07768393f6..613d1a56c1 100644
      if (!r)
        return nullptr;
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
-index 03f299d372..0075479a30 100644
+index 03f299d372..dcddee49fc 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
 @@ -109,6 +109,16 @@ namespace OVERLAY {
@@ -673,13 +812,13 @@ index 03f299d372..0075479a30 100644
  
 +    /*!
 +     * \brief Pre-walk hook: render libass output for the present slot.
-+     *  Called once per frame on the render thread before the GUI walk-skip
++     *  Called once per frame on the GUI/main thread before the GUI walk-skip
 +     *  decision. Caches the ASS_Image* and detect_change flag on each
 +     *  SElement so ConvertLibass can consume them during the walk without
-+     *  re-entering libass. Returns true when libass reports a visible or
-+     *  changed subtitle so the caller can MarkDirty.
++     *  re-entering libass. Calls MarkDirty internally when libass reports
++     *  a visible or changed subtitle.
 +     */
-+    bool PrepareOverlays(int idx);
++    void PrepareOverlays(int idx);
 +
      /*!
       * \brief Release resources
@@ -767,7 +906,7 @@ index 03f299d372..0075479a30 100644
    };
  }
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
-index f918f153a0..8dc6492e98 100644
+index f918f153a0..96168ed3ec 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
 @@ -231,7 +231,7 @@ bool CRenderManager::Configure()
@@ -810,12 +949,14 @@ index f918f153a0..8dc6492e98 100644
      }
    }
  
-@@ -812,7 +818,7 @@ bool CRenderManager::IsGuiLayer()
+@@ -811,8 +817,8 @@ bool CRenderManager::IsGuiLayer()
+     if (!m_pRenderer)
        return false;
  
-     if ((m_pRenderer->IsGuiLayer() && IsPresenting()) ||
+-    if ((m_pRenderer->IsGuiLayer() && IsPresenting()) ||
 -        m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
-+        m_renderedDebugOverlay || m_overlays.HasVisibleOverlay(m_presentsource))
++    if ((m_pRenderer->IsGuiLayer() && IsPresenting()) || m_renderedDebugOverlay ||
++        m_overlays.HasVisibleOverlay(m_presentsource))
        return true;
  
      if (m_renderDebug && m_debugTimer.IsTimePast())
@@ -882,6 +1023,19 @@ index 359f729704..e2e1c735d7 100644
    {
      MarkDirtyRegion();
    }
+diff --git a/xbmc/rendering/RenderSystem.h b/xbmc/rendering/RenderSystem.h
+index 2c1268745d..5b8f2326e0 100644
+--- a/xbmc/rendering/RenderSystem.h
++++ b/xbmc/rendering/RenderSystem.h
+@@ -49,6 +49,8 @@ public:
+   // in BeginRender, bumped at each GUI draw primitive. Render-thread only.
+   static unsigned int m_GUIElementCount;
+ 
++  unsigned int GetGUIElementCount() const { return m_GUIElementCount; }
++
+   virtual bool InitRenderSystem() = 0;
+   virtual bool DestroyRenderSystem() = 0;
+   virtual bool ResetRenderSystem(int width, int height) = 0;
 diff --git a/xbmc/video/windows/GUIWindowFullScreen.cpp b/xbmc/video/windows/GUIWindowFullScreen.cpp
 index 22a03e32dd..476215d2cc 100644
 --- a/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -899,6 +1053,32 @@ index 22a03e32dd..476215d2cc 100644
      MarkDirtyRegion();
  
    m_controlStats->Reset();
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+index d7b83a6462..5c0b75eca0 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+@@ -339,7 +339,7 @@ void CWinSystemGbmGLContext::CompositeGui()
+   // FBO is in the same state as the previous frame and the flag stays as-is.
+   if (m_guiWillRender)
+   {
+-    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
++    const bool guiEmpty = (GetGUIElementCount() == 0);
+     m_guiFboClean = guiEmpty;
+     if (guiEmpty)
+       return;
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+index 4f14ed76e2..74c991bcd8 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+@@ -340,7 +340,7 @@ void CWinSystemGbmGLESContext::CompositeGui()
+   //   D2P:          "FBO is empty/clean AND back buffer cache is invalid"
+   if (m_guiWillRender)
+   {
+-    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
++    const bool guiEmpty = (GetGUIElementCount() == 0);
+     m_guiFboClean = guiEmpty;
+     if (guiEmpty)
+       return;
 diff --git a/xbmc/windowing/gbm/drm/DRMAtomic.cpp b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
 index cebb8666fd..6a0dc0e37f 100644
 --- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-Overlays-WinSystemGbm-tighten-review-feedback-commen.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0006-Overlays-WinSystemGbm-tighten-review-feedback-commen.patch
@@ -1,0 +1,373 @@
+From 5397d311ad6cc700d3204da2320ab5327b2a4178 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Sun, 7 Jun 2026 23:04:50 -0400
+Subject: [PATCH 6/7] Overlays/WinSystemGbm: tighten review-feedback comments
+
+Reword and shrink docstrings/comments across the dirty-skip optimization
+to use accurate render-pass vs Process-walk terminology and drop the
+deprecated "presence"/"session" jargon. Renames hasChanges to doMarkDirty
+in OVERLAY::CRenderer::PrepareOverlays and merges a redundant if block.
+PrepareOverlays return type changed to void.
+---
+ .../VideoRenderers/DebugRenderer.cpp          | 10 +--
+ .../VideoRenderers/OverlayRenderer.cpp        | 66 ++++++++-----------
+ .../VideoRenderers/OverlayRenderer.h          | 41 +++++-------
+ .../VideoRenderers/RenderManager.cpp          |  8 +--
+ .../VideoRenderers/RenderManager.h            |  8 +--
+ xbmc/guilib/GUIWindowManager.h                |  6 +-
+ xbmc/pictures/GUIWindowSlideShow.cpp          |  7 +-
+ xbmc/video/windows/GUIWindowFullScreen.cpp    |  9 +--
+ xbmc/windowing/gbm/WinSystemGbmGLContext.h    |  3 +-
+ xbmc/windowing/gbm/WinSystemGbmGLESContext.h  |  3 +-
+ 10 files changed, 74 insertions(+), 87 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+index 4182adcdcf..42ca61f5d9 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+@@ -146,11 +146,11 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
+       if (updateStyle)
+         CreateSubtitlesStyle();
+ 
+-      // Debug OSD is a standalone path: text content changes every frame
+-      // and DebugRenderer::Render MarkDirty's per frame anyway, so it does
+-      // not participate in the PrepareOverlays / SElement caching scheme.
+-      // The rOpts setup below mirrors what master's CRenderer::ConvertLibass
+-      // did inline.
++      // Copied from OVERLAY::CRenderer::ConvertLibass. PR #28373 changed
++      // that function to read its libass output from a per-frame SElement
++      // populated by AddOverlay/Release. The debug overlay is added once
++      // at Initialize and never produces an SElement, so it cannot share
++      // the implementation.
+       KODI::SUBTITLES::STYLE::renderOpts rOpts;
+       rOpts.sourceWidth = m_rs.Width();
+       rOpts.sourceHeight = m_rs.Height();
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+index b00e9b61d8..8e8d1803c9 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+@@ -266,15 +266,16 @@ bool CRenderer::HasVisibleOverlay(int idx) const
+       continue;
+ 
+     const CDVDOverlay& o = *e.overlay_dvd;
+-    // Image-based (PGS/DVB) and DVD SPU: ProcessOverlays PTS-filters before
+-    // AddOverlay, so presence is the per-frame visibility test.
++    // PGS/DVB and DVD SPU: ProcessOverlays inserts these into m_buffers
++    // only at PTS values where the bitmap is on screen, so finding one
++    // here means it is visible.
+     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+       return true;
+ 
+-    // libass (TEXT/SSA): the container survives the whole session via
+-    // iPTSStopTime=DVD_NOPTS_VALUE, so presence alone is meaningless. The
+-    // accurate per-frame signal is whether ass_render_frame returned any
+-    // images for the current PTS, cached by PrepareOverlays.
++    // libass (TEXT/SSA): the container stays in m_buffers for the whole
++    // video (iPTSStopTime=DVD_NOPTS_VALUE). Visibility means
++    // ass_render_frame returned images for the current PTS, cached by
++    // PrepareOverlays in e.renderedImages.
+     if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
+     {
+       if (e.renderedImages != nullptr)
+@@ -427,7 +428,7 @@ void CRenderer::PrepareOverlays(int idx)
+   if (idx < 0 || idx >= NUM_BUFFERS)
+     return;
+ 
+-  bool hasChanges = false;
++  bool doMarkDirty = false;
+   bool hasImageSpu = false;
+   for (auto& e : m_buffers[idx])
+   {
+@@ -441,18 +442,16 @@ void CRenderer::PrepareOverlays(int idx)
+ 
+     CDVDOverlay& o = *e.overlay_dvd;
+ 
+-    // Image-based subtitles (PGS, DVB) and DVD SPU: presence of the entry
+-    // in the present buffer slot is the visibility test. ProcessOverlays
+-    // PTS-filters before AddOverlay, so any entry here covers "now".
+-    // For change detection: m_textureid == 0 means the overlay has never
+-    // been rendered (new arrival). Catches new bitmaps for PGS/DVB and
+-    // every-frame-different animated PGS. The presence-flip check after
+-    // the loop catches the disappearance case.
++    // PGS/DVB and DVD SPU: only added to m_buffers at their visible PTS,
++    // so finding one means it is on screen now. m_textureid == 0 is the
++    // "new arrival" signal (also true every frame for animated PGS where
++    // each frame is a fresh CDVDOverlay). Disappearance is caught after
++    // the loop by the hasImageSpu vs m_prevHadImageSpu check.
+     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+     {
+       hasImageSpu = true;
+       if (o.m_textureid == 0)
+-        hasChanges = true;
++        doMarkDirty = true;
+       continue;
+     }
+ 
+@@ -471,11 +470,12 @@ void CRenderer::PrepareOverlays(int idx)
+       CreateSubtitlesStyle();
+     }
+ 
++    // rOpts setup moved from CRenderer::ConvertLibass; duplicated in CDebugRenderer::CRenderer::Render.
+     SUBTITLES::STYLE::renderOpts rOpts;
+ 
+-    // libass render in a target area which named as frame. the frame size may bigger than video size,
+-    // and including margins between video to frame edge. libass allow to render subtitles into the margins.
+-    // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.
++    // Three rects: source (subtitle canvas), video (playing size), frame
++    // (render target; may exceed video to include letterbox bars so libass
++    // can place subtitles in them).
+     rOpts.sourceWidth = m_rs.Width();
+     rOpts.sourceHeight = m_rs.Height();
+     rOpts.videoWidth = m_rd.Width();
+@@ -581,30 +581,22 @@ void CRenderer::PrepareOverlays(int idx)
+     int currentChange = 0;
+     e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
+                                                              m_overlayStyle, &currentChange);
+-    // OR-accumulate libass's per-call change onto the persistent overlay,
+-    // not onto SElement: m_buffers[idx] is rebuilt per frame by AddOverlay/
+-    // Release on the render queue, so SElement state cannot survive the
+-    // transition-to-walk gap. The CDVDOverlayLibass shared_ptr survives.
+     if (currentChange > 0)
++    {
++      // Persist on the overlay so a skipped GUI render does not drop the change.
+       ovAss.m_pendingChange = currentChange;
+-
+-    // MarkDirty only on this-frame change (not the accumulated value).
+-    if (currentChange > 0)
+-      hasChanges = true;
++      doMarkDirty = true;
++    }
+   }
+ 
+-  // Image/SPU disappearance: image-based subtitles (PGS/DVB/SPU) have no
+-  // libass-style per-frame change signal. The m_textureid==0 check inside
+-  // the loop catches arrival of a new bitmap. This catches the symmetric
+-  // case: the buffer slot just went empty (last frame had image/SPU, this
+-  // frame does not). Without this, when a PGS subtitle ends the walk does
+-  // not fire, the cached bitmap stays on the GUI plane, and the screen
+-  // never blanks between consecutive PGS subtitles.
++  // PGS/DVB/SPU disappearance: arrival is caught by m_textureid==0 in
++  // the loop above. Without this, a PGS subtitle ending leaves its
++  // cached bitmap on the GUI plane until something else dirties.
+   if (hasImageSpu != m_prevHadImageSpu)
+-    hasChanges = true;
++    doMarkDirty = true;
+   m_prevHadImageSpu = hasImageSpu;
+ 
+-  if (hasChanges)
++  if (doMarkDirty)
+     MarkDirty();
+ }
+ 
+@@ -651,8 +643,8 @@ std::shared_ptr<COverlay> CRenderer::Convert(SElement& e)
+     if (!ovAss.GetLibassHandler())
+       return nullptr;
+ 
+-    // ASS_Image* and detect_change were populated this frame by
+-    // PrepareOverlays. ConvertLibass does not re-enter libass.
++    // Build the COverlay from libass output PrepareOverlays cached on e
++    // earlier this frame; avoids re-entering libass during render.
+     r = ConvertLibass(e);
+ 
+     if (!r)
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+index dcddee49fc..2268b122c0 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+@@ -41,10 +41,11 @@ namespace OVERLAY {
+   };
+ 
+   /*!
+-   * \brief Mark the GUI dirty so the GUI walk fires next frame.
+-   *  Used by overlay-related code paths (subtitles, debug OSD) to keep
+-   *  the GUI walk running while overlays are visible; overlays are not
+-   *  CGUIControls and do not participate in the dirty system automatically.
++   * \brief Mark the entire GUI dirty so the next render pass runs
++   *  (not skipped). Overlays (subtitles, debug OSD) are not CGUIControls
++   *  and do not set m_controlDirtyState automatically; callers invoke
++   *  this at overlay state transitions and on per-frame updates where
++   *  needed (debug OSD).
+    */
+   void MarkDirty();
+ 
+@@ -134,20 +135,15 @@ namespace OVERLAY {
+     void Release(int idx);
+ 
+     /*!
+-     * \brief True if any overlay in buffer slot \a idx is actually visible
+-     *  on this frame.
++     * \brief True if any overlay in m_buffers[idx] is visible this frame.
+      *
+-     *  For libass overlays (TEXT/SSA), the persistent CDVDOverlayText /
+-     *  CDVDOverlaySSA container has iPTSStopTime = DVD_NOPTS_VALUE and so
+-     *  survives ProcessOverlays' PTS filter for the entire playback session
+-     *  even between events. Presence in m_buffers[idx] is therefore not a
+-     *  visibility test for libass. Visibility is read from the per-frame
+-     *  e.renderedImages cache populated by PrepareOverlays via
+-     *  ass_render_frame (non-null when an event covers the current PTS).
++     *  PGS/DVB and DVD SPU: ProcessOverlays only inserts at the visible PTS,
++     *  so any entry in m_buffers means visible.
+      *
+-     *  For image (PGS/DVB/IMAGE) and SPU overlays, ProcessOverlays already
+-     *  PTS-filters before AddOverlay, so presence in m_buffers[idx] is the
+-     *  per-frame visibility test.
++     *  libass (TEXT/SSA): the container is added once with no stop PTS and
++     *  stays in m_buffers for the whole video. Visibility means
++     *  ass_render_frame returned images for the current PTS, cached on
++     *  e.renderedImages by PrepareOverlays.
+      *
+      *  Must be called after PrepareOverlays has run this frame; before that
+      *  e.renderedImages reflects the previous frame's state.
+@@ -180,9 +176,9 @@ namespace OVERLAY {
+       SElement() : overlay_dvd(NULL) { pts = 0.0; }
+       double pts;
+       std::shared_ptr<CDVDOverlay> overlay_dvd;
+-      // Output of libass cached by PrepareOverlays and consumed by
+-      // ConvertLibass when the GUI walk runs. libass owns renderedImages;
+-      // the pointer is valid only until the next ass_render_frame call.
++      // libass output cached by PrepareOverlays; read by ConvertLibass during
++      // render. libass owns the pointer; valid only until the next
++      // ass_render_frame call.
+       ASS_Image* renderedImages{nullptr};
+       float renderedFrameWidth{0.0f};
+       float renderedFrameHeight{0.0f};
+@@ -232,10 +228,9 @@ namespace OVERLAY {
+ 
+     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
+     std::atomic<bool> m_isSettingsChanged{false};
+-    // Track whether last frame had any image/SPU overlay, for transition
+-    // detection in PrepareOverlays. Image/SPU overlays have no per-frame
+-    // change signal like libass' assDetectChange, so we compare per-frame
+-    // presence to drive MarkDirty on arrival and disappearance.
++    // Whether last frame had any image/SPU overlay. Used by PrepareOverlays
++    // to detect arrival/disappearance transitions (image/SPU have no
++    // per-frame change signal of their own, unlike libass detect_change).
+     bool m_prevHadImageSpu{false};
+   };
+ }
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+index 96168ed3ec..683ff9ca86 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+@@ -352,11 +352,9 @@ void CRenderManager::FrameMove()
+ 
+   m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->HasVideoPlane() || firstFrame);
+ 
+-  // Pre-walk libass probe: render the libass output for the present slot
+-  // once on the render thread, before the GUI walk-skip check runs next
+-  // frame. PrepareOverlays MarkDirty's internally when libass reports
+-  // something visible or changed. Replaces the cross-thread MarkDirty
+-  // formerly issued from CRenderer::AddOverlay on the video thread.
++  // Run libass for the current PTS and cache the output for ConvertLibass
++  // to use during the render pass. PrepareOverlays MarkDirty's on libass
++  // changes and on PGS/DVB/SPU arrival/disappearance.
+   m_overlays.PrepareOverlays(m_presentsource);
+ 
+   ManageCaptures();
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+index 7ce352cbc6..31a96c3716 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+@@ -102,11 +102,9 @@ public:
+   void ShowVideo(bool enable);
+ 
+   /*!
+-   * \brief True if any subtitle/overlay is actually visible on the current
+-   *  presented frame. Per-frame accurate, unlike the coarse HasOverlay path
+-   *  which returns true for the whole playback session whenever a libass
+-   *  track is loaded (due to the persistent NOPTS container). See
+-   *  OVERLAY::CRenderer::HasVisibleOverlay for the full rationale.
++   * \brief True if any subtitle/overlay is visible on the current presented
++   *  frame. Per-frame accurate. See OVERLAY::CRenderer::HasVisibleOverlay
++   *  for the libass vs PGS/DVB/SPU details.
+    *
+    *  Must be called after CRenderManager::FrameMove has run this frame
+    *  (which calls PrepareOverlays). Reads cached state; cheap.
+diff --git a/xbmc/guilib/GUIWindowManager.h b/xbmc/guilib/GUIWindowManager.h
+index d25c8f1b1b..ac15a2e666 100644
+--- a/xbmc/guilib/GUIWindowManager.h
++++ b/xbmc/guilib/GUIWindowManager.h
+@@ -100,9 +100,9 @@ public:
+   void MarkDirty(const CRect& rect);
+ 
+   /*! \brief True if Process() collected any dirty regions this frame.
+-   Callable after Process() to decide whether Render() needs to run; used by
+-   the dirty-driven skip on paths with a persistent framebuffer (DRM plane,
+-   GUI compositing FBO).
++   *   Callable after Process() to decide whether the render pass needs
++   *   to run; used by the dirty-driven skip in CApplication::FrameMove
++   *   (currently gated to D2P plane and HDR GUI compositing FBO contexts).
+    */
+   bool HasDirtyRegions() const { return !m_dirtyregions.empty(); }
+ 
+diff --git a/xbmc/pictures/GUIWindowSlideShow.cpp b/xbmc/pictures/GUIWindowSlideShow.cpp
+index e2e1c735d7..3e4facdfb7 100644
+--- a/xbmc/pictures/GUIWindowSlideShow.cpp
++++ b/xbmc/pictures/GUIWindowSlideShow.cpp
+@@ -695,9 +695,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
+     CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPicturesInfoProvider().SetCurrentSlide(m_slides.at(m_iCurrentSlide).get());
+ 
+   RenderPause();
+-  // Force MarkDirty when video is drawn through the GUI walk (single-plane
+-  // path: the walk drives video frame display). On D2P the video plane self-
+-  // updates independently of the walk, so no per-frame MarkDirty is needed.
++  // Single-plane mode (video drawn into the GUI back buffer during the
++  // render pass): MarkDirty every frame to keep the render pass running.
++  // D2P (video has its own hardware plane): video updates independently
++  // of the render pass.
+   if (IsVideo(*m_slides.at(m_iCurrentSlide)) && appPlayer && !appPlayer->IsRenderingVideoLayer())
+   {
+     MarkDirtyRegion();
+diff --git a/xbmc/video/windows/GUIWindowFullScreen.cpp b/xbmc/video/windows/GUIWindowFullScreen.cpp
+index 476215d2cc..de2768d25b 100644
+--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
++++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
+@@ -376,10 +376,11 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
+ {
+   const auto& components = CServiceBroker::GetAppComponents();
+   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+-  // Only fire for single-plane renderers where video draws via the GUI walk
+-  // (VAAPI, LinuxRendererGLES, DRMPRIMEGLES). For D2P, video lives on its
+-  // own hardware plane; subtitle dirty is handled by OVERLAY::PrepareOverlays
+-  // on actual change.
++  // IsRenderingVideoLayer: true on D2P (video has its own DRM plane);
++  // false in single-plane mode (video drawn through the render pass).
++  // Single-plane: MarkDirtyRegion every frame so the render pass keeps
++  // running and draws the next video frame. D2P video plane updates
++  // independently.
+   if (!appPlayer->IsRenderingVideoLayer())
+     MarkDirtyRegion();
+ 
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLContext.h b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+index d9e484e0f4..1c68c58212 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+@@ -58,8 +58,9 @@ private:
+   CFrameBufferObject m_guiFbo;
+   int m_guiFboWidth{0};
+   int m_guiFboHeight{0};
++  // True when the GUI FBO is empty (no draws this frame); CompositeGui skips composite when true.
+   bool m_guiFboClean{false};
+-  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
++  // Whether the GUI render pass will run this frame; set by BeginGuiComposite.
+   bool m_guiWillRender{true};
+   std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
+ };
+diff --git a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+index 08971e4671..7c6a04f28f 100644
+--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
++++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+@@ -59,8 +59,9 @@ private:
+   CFrameBufferObject m_guiFbo;
+   int m_guiFboWidth{0};
+   int m_guiFboHeight{0};
++  // True when the GUI FBO is empty (no draws this frame); CompositeGui skips composite when true.
+   bool m_guiFboClean{false};
+-  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
++  // Whether the GUI render pass will run this frame; set by BeginGuiComposite.
+   bool m_guiWillRender{true};
+ 
+   std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
+-- 
+2.43.0
+

--- a/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-fix-gtest-segfault.patch
+++ b/packages/mediacenter/kodi/patches/reardonia/reardonia-0007-fix-gtest-segfault.patch
@@ -1,0 +1,29 @@
+From eae2e3f805ad8313a60eb22162afff7b114d4178 Mon Sep 17 00:00:00 2001
+From: reardonia <2925104+reardonia@users.noreply.github.com>
+Date: Mon, 8 Jun 2026 11:27:38 -0400
+Subject: [PATCH 7/7] fix gtest segfault
+
+CDebugRenderer::Dispose called OVERLAY::MarkDirty unconditionally, which
+deref'd a null CGUIComponent.m_windowManager in the test environment.
+Early-return when not initialized.
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+index 42ca61f5d9..4a2903c53b 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+@@ -55,6 +55,9 @@ void CDebugRenderer::Initialize()
+ 
+ void CDebugRenderer::Dispose()
+ {
++  if (!m_isInitialized)
++    return;
++
+   m_isInitialized = false;
+   m_overlayRenderer.Flush();
+   m_overlay.reset();
+-- 
+2.43.0
+


### PR DESCRIPTION
This bumps Kodi to current HEAD and bumps the patchset for https://github.com/xbmc/xbmc/pull/28373. Also, as the prime renderer method is ignored when VAAPI is enabled except for some DMA buffer allocation bits; set default configuration via appliance.xml to ensure Generic/GBM defaults to using EGL with DRMPRIME disabled to keep things cleaner.