### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/ccid/package.mk
+++ b/packages/addons/addon-depends/ccid/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ccid"
-PKG_VERSION="1.8.0"
-PKG_SHA256="531dc29e7c1b9e22e1918f0767b625d52ce8a98f266eb2144c5cf5dbd29c0f67"
+PKG_VERSION="1.8.1"
+PKG_SHA256="1de8a1a6e25e18cc7462f29dc50353d66cc59e413760bdfca37ce6fc6ca1dbf1"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://ccid.apdu.fr"
 PKG_URL="https://ccid.apdu.fr/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/pcsc-lite/package.mk
+++ b/packages/addons/addon-depends/pcsc-lite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcsc-lite"
-PKG_VERSION="2.5.0"
-PKG_SHA256="59b3c4b5be4ab228698edeb5b3ef46ad54ea217e7dd0891372770bb92b55db92"
+PKG_VERSION="2.5.1"
+PKG_SHA256="bfcfe38a20afc49849c6bf55325e38f449fc4b26d3923fdc32b969ae41a8741b"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://pcsclite.apdu.fr"
 PKG_URL="https://pcsclite.apdu.fr/files/pcsc-lite-${PKG_VERSION}.tar.xz"

--- a/packages/addons/service/oscam/package.mk
+++ b/packages/addons/service/oscam/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="oscam"
 PKG_VERSION="11965"
 PKG_SHA256="30a3999a6fda716da467fbde63c14dc0e3e0235d8ffdcec35adfc58eee1ae02e"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-only"
 PKG_SITE="https://git.streamboard.tv/common/oscam/-/wikis"

--- a/packages/addons/service/pcscd/package.mk
+++ b/packages/addons/service/pcscd/package.mk
@@ -5,7 +5,7 @@
 
 PKG_NAME="pcscd"
 PKG_VERSION="1.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/service/proftpd/package.mk
+++ b/packages/addons/service/proftpd/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="proftpd"
-PKG_VERSION="1.3.9"
-PKG_SHA256="4a5f13b666226813b4da0ade34535d325e204ab16cf8008c7353b1b5a972f74b"
-PKG_REV="0"
+PKG_VERSION="1.3.9b"
+PKG_SHA256="a4dd1820aa70abeac7be234d03a806c3ba1cc86566cf6069d2a14566fc5eb5af"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.proftpd.org/"


### PR DESCRIPTION
- oscam: update pcsc-lite to 2.5.1 and addon (7 
- pcscd: update ccid to 1.8.1 and addon (2)
  - ccid: update to 1.8.1
  - pcsc-lite: update to 2.5.1
- proftpd: update to 1.3.9b and addon (1)