### PR TITLE
 qt5,rpi_ws281x,hyperion,hyperhdr: fix Qt5 cross-compilation build

### DIFF
--- a/packages/addons/addon-depends/qt5/package.mk
+++ b/packages/addons/addon-depends/qt5/package.mk
@@ -12,8 +12,7 @@ PKG_LONGDESC="A cross-platform application and UI framework."
 PKG_BUILD_FLAGS="-sysroot"
 
 PKG_CONFIGURE_OPTS_TARGET="-prefix /usr
-                           -sysroot "${SYSROOT_PREFIX}"
-                           -hostprefix "${TOOLCHAIN}"
+                           -hostprefix /usr/host
                            -device linux-libreelec-g++
                            -opensource -confirm-license
                            -release
@@ -139,4 +138,8 @@ EOF
 
   unset CC CXX LD RANLIB AR AS CPPFLAGS CFLAGS LDFLAGS CXXFLAGS
   ./configure ${PKG_CONFIGURE_OPTS_TARGET}
+}
+
+makeinstall_target() {
+  make install INSTALL_ROOT="${INSTALL}"
 }

--- a/packages/addons/addon-depends/qt5/package.mk
+++ b/packages/addons/addon-depends/qt5/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="qt5"
-PKG_VERSION="5.15.18"
-PKG_SHA256="cea1fbabf02455f3f0e8eaa839f5d6f45cdb56b62c8a83af5c1d00ac05f912ea"
+PKG_VERSION="5.15.19"
+PKG_SHA256="173c2326dae138bbb0d98921e9d911e55c00163d93a6db29f294b5e19ff306ae"
 PKG_LICENSE="LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only"
 PKG_SITE="https://qt-project.org"
 PKG_URL="https://download.qt.io/archive/qt/${PKG_VERSION%.*}/${PKG_VERSION}/single/qt-everywhere-opensource-src-${PKG_VERSION}.tar.xz"

--- a/packages/addons/addon-depends/rpi_ws281x/patches/0001-rename-version-to-VERSION-to-avoid-shadowing-cxx20.patch
+++ b/packages/addons/addon-depends/rpi_ws281x/patches/0001-rename-version-to-VERSION-to-avoid-shadowing-cxx20.patch
@@ -1,0 +1,85 @@
+From ac77fbe9b43c7d5656b521735cc9ab3d3ccc8325 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 11 Jun 2026 20:48:08 +1000
+Subject: [PATCH] CMakeLists: rename version to VERSION to avoid shadowing
+ C++20 <version>
+
+Problem
+-------
+The file named `version` in the repository root contains the plain-text
+project version string ("1.1.0") and is read by CMakeLists.txt at
+configure time:
+
+    file(READ version PROJECT_VERSION)
+
+When rpi_ws281x is used as a CMake subdirectory of a C++20 project, the
+subdirectory's source path is typically added to the compiler include
+search path so that the library headers (ws2811.h, rpihw.h, etc.) can be
+found with angle-bracket includes.  On any compiler that implements C++20,
+the `<version>` feature-test header is part of the standard library.  When
+a translation unit (directly, or through a transitively included header)
+does:
+
+    #include <version>
+
+the preprocessor searches the include path in order.  If the rpi_ws281x
+source directory appears on that path before the toolchain's system include
+directory, the compiler opens the plain-text `version` file instead of the
+C++20 standard library header.  Attempting to parse "1.1.0" as C++ source
+is a hard error:
+
+    error: stray '.' in program
+
+Fix
+---
+Rename `version` to `VERSION`.  On Linux (and all other case-sensitive
+filesystems) `VERSION` and `version` are distinct names; the compiler
+looking for `<version>` will no longer find the version data file.
+
+Update the single `file(READ ...)` call in CMakeLists.txt accordingly.
+No other file in this repository references the plain name `version` as a
+path: `version.h.in` and `version.py` are separate files with different
+names and are unaffected.
+
+Impact
+------
+Behaviour is identical for all existing build methods (CMake, SCons).  The
+only observable change is the filename on disk; the content and the
+PROJECT_VERSION variable it populates are unchanged.
+---
+ CMakeLists.txt     | 4 ++--
+ version => VERSION | 0
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+ rename version => VERSION (100%)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba5dd90..19bb717 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.0.0)
+ 
+-# read and parse version file
+-file(READ version PROJECT_VERSION)
++# read and parse VERSION file
++file(READ VERSION PROJECT_VERSION)
+ string(STRIP ${PROJECT_VERSION} PROJECT_VERSION)
+ string(REGEX REPLACE "([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" VERSION_MAJOR ${PROJECT_VERSION})
+ string(REGEX REPLACE "[0-9]+\\.([0-9]+)\\.[0-9]+" "\\1" VERSION_MINOR ${PROJECT_VERSION})
+diff --git a/VERSION b/VERSION
+new file mode 100644
+index 0000000..9084fa2
+--- /dev/null
++++ b/VERSION
+@@ -0,0 +1 @@
++1.1.0
+diff --git a/version b/version
+deleted file mode 100644
+index 9084fa2..0000000
+--- a/version
++++ /dev/null
+@@ -1 +0,0 @@
+-1.1.0
+-- 
+2.53.0
+

--- a/packages/addons/service/hyperhdr/package.mk
+++ b/packages/addons/service/hyperhdr/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="hyperhdr"
 PKG_VERSION="21.0.0.0"
 PKG_SHA256="fde381b8ae701c93b57b23cfa95c56dcbbecee7e5e7b2cce5d8b5f97ed86a676"
-PKG_REV="1"
+PKG_REV="2"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/awawa-dev/HyperHDR"
 PKG_URL="https://github.com/awawa-dev/HyperHDR/archive/v${PKG_VERSION}.tar.gz"
@@ -49,6 +49,11 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON \
                        -Wno-dev"
 
 pre_configure_target() {
+  cat > "${PKG_BUILD}/toolchain-qt5.cmake" <<EOF
+include("${CMAKE_CONF}")
+list(APPEND CMAKE_FIND_ROOT_PATH "$(get_install_dir qt5)/usr")
+EOF
+  PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_TOOLCHAIN_FILE=${PKG_BUILD}/toolchain-qt5.cmake"
   pkg_flatbuffers_version=$(get_pkg_version flatbuffers)
   tar --strip-components=1 -xf "${SOURCES}/flatbuffers/flatbuffers-${pkg_flatbuffers_version}.tar.gz" -C "${PKG_BUILD}/external/flatbuffers"
   cp -a $(get_build_dir rpi_ws281x)/* ${PKG_BUILD}/external/rpi_ws281x

--- a/packages/addons/service/hyperion/package.mk
+++ b/packages/addons/service/hyperion/package.mk
@@ -5,7 +5,7 @@ PKG_NAME="hyperion"
 PKG_VERSION="fb413cd7e8825ffc26925013f57ac93a774f12bc"
 PKG_SHA256="fafa4eeddacb15a8fd96b0e69fac400faa735c6e1ccd78673c9d96b0ac84d7a3"
 PKG_VERSION_DATE="2019-08-19"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/hyperion-project/hyperion"
@@ -53,6 +53,12 @@ pre_build_target() {
 
 pre_configure_target() {
   echo "" >../cmake/FindGitVersion.cmake
+
+  cat > "${PKG_BUILD}/toolchain-qt5.cmake" <<EOF
+include("${CMAKE_CONF}")
+list(APPEND CMAKE_FIND_ROOT_PATH "$(get_install_dir qt5)/usr")
+EOF
+  PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_TOOLCHAIN_FILE=${PKG_BUILD}/toolchain-qt5.cmake"
 }
 
 addon() {


### PR DESCRIPTION
## Summary

- Fixes #9310
- qt5 was installing into the live sysroot.
- This PR also fixes the downstream cmake find and a C++20 header shadowing issue that surfaces once qt5 installs correctly.

### qt5

Two configure problems:

**1. `-sysroot "${SYSROOT_PREFIX}"` caused `make install` to write to the live sysroot.**  Qt's build system uses `INSTALL_ROOT` as its staging variable (not `DESTDIR`); with `-sysroot` set, the default install bypassed staging entirely.  Fix: remove `-sysroot` from configure and pass `INSTALL_ROOT="${INSTALL}"` to `make install`.

**2. `-hostprefix "${TOOLCHAIN}"` baked the toolchain directory path into the generated cmake config files (`Qt5CoreConfigExtras.cmake`).**  Paths to `moc`, `mkspecs` etc. were stored relative to the toolchain, making them unresolvable from the staging area.  Using `-hostprefix /usr/host` (a subdirectory of `-prefix /usr`) keeps all cmake config paths self-contained within the staging area: Qt uses `QT_HOST_DATA_RELATIVE` to reference host items as `host/...` relative to the install prefix. Host tools land in `usr/host/bin/`, target libraries in `usr/lib/`, cleanly separated.

### rpi_ws281x

The source tree ships a plain-text `version` file in its root.  When the directory is added to the compiler include path (as both hyperion and hyperhdr do), `#include <version>` - used by Qt5's `qstdlibdetection.h` - finds this file instead of the C++20 standard library header, producing `error: stray '.' in program`.
- Patch submitted upstream: https://github.com/jgarff/rpi_ws281x/pull/570

### hyperion / hyperhdr

Qt5 installs outside the sysroot (was suppose to given `PKG_BUILD_FLAGS="-sysroot"`).  LibreELEC's cmake toolchain sets `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY`, so cmake cannot find Qt5's config files without an explicit path hint.

Generate a thin wrapper toolchain file in `pre_configure_target()` that `include()`s the real LibreELEC toolchain then appends Qt5's staging prefix to `CMAKE_FIND_ROOT_PATH`.  Passing `-DCMAKE_TOOLCHAIN_FILE=` via `PKG_CMAKE_OPTS_TARGET` overrides the default (last occurrence wins in cmake's command-line processing).

## Test plan

- [X] Clean build on aarch64 — hyperion/hyperhdr
- [X] Clean build on arm — hyperion/hyperhdr
- [X] Clean build on x86_64 — hyperion/hyperhdr