### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.ffmpegdirect/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.ffmpegdirect"
-PKG_VERSION="22.2.5-Piers"
-PKG_SHA256="6ba3f18958943aaa0cd15ba7fab51a85d3738192cd1dc1f5a442446cc3fa63c1"
+PKG_VERSION="22.2.6-Piers"
+PKG_SHA256="2c0464dbfc115a41a753e7ce92afb2f4db4fc9eabac6302e666942d1c7cb285d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -3,9 +3,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="22.5.2-Piers"
-PKG_SHA256="679a0061227d157ad3ab40e7e0f48b64e31924af74862910728eee149af3473b"
-PKG_REV="2"
+PKG_VERSION="22.6.0-Piers"
+PKG_SHA256="822cb55537c85bbec7f5509f981398cfa1af8a153623f3524f2aba8a54a2c902"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/kodi-pvr/pvr.nextpvr"


### PR DESCRIPTION
- inputstream.ffmpegdirect: update 22.2.5-Piers to 22.2.6-Piers
- pvr.nextpvr: update 22.5.2-Piers to 22.6.0-Piers