### PR TITLE
x265: use PKG_X265_SONAME and automate updates

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -4,6 +4,8 @@
 PKG_NAME="x265"
 PKG_VERSION="4.2"
 PKG_SHA256="04978f795943e49fcea76eb5ede9c1bd0fe9b6c073518897be6fc43b44f60850"
+# When changing PKG_VERSION remember to sync PKG_X265_SONAME with X265_BUILD in source/CMakeLists.txt
+PKG_X265_SONAME="216"
 PKG_ARCH="aarch64 x86_64"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://www.videolan.org/developers/x265.html"

--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -30,7 +30,7 @@ post_install_addon() {
   cp -P $(get_build_dir libhdhomerun)/hdhomerun_config ${INSTALL}/lbin
   cp -P $(get_install_dir comskip)/usr/bin/comskip ${INSTALL}/lbin
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.215 ${INSTALL}/lib.private
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) ${INSTALL}/lib.private
     patchelf --add-rpath '${ORIGIN}/../lib.private' ${INSTALL}/lbin/comskip
   fi
 }

--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -126,7 +126,7 @@ addon() {
 
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
     mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.215 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -P $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
     patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -27,7 +27,7 @@ addon() {
 
   # libs
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.215 \
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) \
            ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
 }

--- a/tools/update-functions/x265
+++ b/tools/update-functions/x265
@@ -1,0 +1,28 @@
+function custom_post_script() {
+  local _tarball _x265h x265_build
+  _tarball="${SOURCES}/${pkgname}/${pkgname}-${pkgver}.tar.bz2"
+  _x265cmake=$(tar -tjf "${_tarball}" 2>/dev/null | grep '/source/CMakeLists\.txt$')
+  [ -z "${_x265cmake}" ] && { echo "x265: source/CMakeLists.txt not found in ${_tarball}"; return 1; }
+  x265_build=$(tar -xOf "${_tarball}" "${_x265cmake}" 2>/dev/null | awk '/^set\(X265_BUILD /{sub(/\)/, ""); print $2}')
+  [ -z "${x265_build}" ] && { echo "x265: failed to read X265_BUILD from source"; return 1; }
+  sed -e "s|^PKG_X265_SONAME=.*|PKG_X265_SONAME=\"${x265_build}\"|" -i "${pkgmk}"
+  echo "x265: X265_BUILD=${x265_build} (PKG_X265_SONAME updated)"
+}
+
+function custom_post_commit() {
+  local addon tvh_pkgmk tvh_rev
+
+  for addon in ffmpeg-tools nextpvr; do
+    export commit_msg="${addon}: update x265 to ${pkgver}"
+    export commit_body=""
+    ${progname} ${addon} $(get_pkg_version ${addon})
+  done
+
+  # tvheadend43 has get_pkg_ver so update-pkg rejects a version argument
+  # and would fetch the latest upstream if called without one; bump PKG_REV directly
+  tvh_pkgmk="$(get_pkg_directory tvheadend43)/package.mk"
+  tvh_rev=$(awk -F'"' '/^PKG_REV=/{print $2}' "${tvh_pkgmk}")
+  tvh_rev=$((tvh_rev + 1))
+  sed -e "s|^PKG_REV=.*|PKG_REV=\"${tvh_rev}\"|" -i "${tvh_pkgmk}"
+  git commit -m "tvheadend43: update x265 to ${pkgver} and addon (${tvh_rev})" "${tvh_pkgmk}"
+}


### PR DESCRIPTION
Add PKG_X265_SONAME to x265/package.mk (tracks X265_BUILD soname integer) and use it in ffmpeg-tools, tvheadend43 and nextpvr instead of hardcoding the library version number.

Add tools/update-functions/x265 to extract X265_BUILD from the downloaded source tarball on each version bump and update PKG_X265_SONAME in the same commit and increment the addon revisions of all dependents.

- fixes #11469 