### PR TITLE
x265: simplify package and use wildcard to copy shared library

### DIFF
--- a/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
+++ b/packages/addons/addon-depends/ffmpegx-depends/x265/package.mk
@@ -4,8 +4,6 @@
 PKG_NAME="x265"
 PKG_VERSION="4.2"
 PKG_SHA256="04978f795943e49fcea76eb5ede9c1bd0fe9b6c073518897be6fc43b44f60850"
-# When changing PKG_VERSION remember to sync PKG_X265_SONAME with X265_BUILD in source/CMakeLists.txt
-PKG_X265_SONAME="216"
 PKG_ARCH="aarch64 x86_64"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://www.videolan.org/developers/x265.html"

--- a/packages/addons/service/nextpvr/package.mk
+++ b/packages/addons/service/nextpvr/package.mk
@@ -30,7 +30,7 @@ post_install_addon() {
   cp -P $(get_build_dir libhdhomerun)/hdhomerun_config ${INSTALL}/lbin
   cp -P $(get_install_dir comskip)/usr/bin/comskip ${INSTALL}/lbin
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) ${INSTALL}/lib.private
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.* ${INSTALL}/lib.private
     patchelf --add-rpath '${ORIGIN}/../lib.private' ${INSTALL}/lbin/comskip
   fi
 }

--- a/packages/addons/service/tvheadend43/package.mk
+++ b/packages/addons/service/tvheadend43/package.mk
@@ -126,7 +126,7 @@ addon() {
 
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
     mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
-    cp -P $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
     patchelf --add-rpath '${ORIGIN}/../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/{comskip,tvheadend}
   fi
 

--- a/packages/addons/tools/ffmpeg-tools/package.mk
+++ b/packages/addons/tools/ffmpeg-tools/package.mk
@@ -27,7 +27,7 @@ addon() {
 
   # libs
   if [ "${TARGET_ARCH}" = "aarch64" ] || [ "${TARGET_ARCH}" = "x86_64" ]; then
-    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.$(get_pkg_variable x265 PKG_X265_SONAME) \
+    cp -PL $(get_install_dir x265)/usr/lib/libx265.so.* \
            ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   fi
 }

--- a/tools/update-functions/x265
+++ b/tools/update-functions/x265
@@ -1,14 +1,3 @@
-function custom_post_script() {
-  local _tarball _x265h x265_build
-  _tarball="${SOURCES}/${pkgname}/${pkgname}-${pkgver}.tar.bz2"
-  _x265cmake=$(tar -tjf "${_tarball}" 2>/dev/null | grep '/source/CMakeLists\.txt$')
-  [ -z "${_x265cmake}" ] && { echo "x265: source/CMakeLists.txt not found in ${_tarball}"; return 1; }
-  x265_build=$(tar -xOf "${_tarball}" "${_x265cmake}" 2>/dev/null | awk '/^set\(X265_BUILD /{sub(/\)/, ""); print $2}')
-  [ -z "${x265_build}" ] && { echo "x265: failed to read X265_BUILD from source"; return 1; }
-  sed -e "s|^PKG_X265_SONAME=.*|PKG_X265_SONAME=\"${x265_build}\"|" -i "${pkgmk}"
-  echo "x265: X265_BUILD=${x265_build} (PKG_X265_SONAME updated)"
-}
-
 function custom_post_commit() {
   local addon tvh_pkgmk tvh_rev
 


### PR DESCRIPTION
no need to complicate with extra variable
maybe option is also to build x265 as static library

improves #11475 