### PR TITLE
simplify HID remote handling in kodi and hwdb entries

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="kodi"
-PKG_VERSION="a1ef051fdd286c5b2c49922b6e4197dceb49a02b"
-PKG_SHA256="60a12c789546d8a009bec2ebd262d716146025615e6529f8e4ca00ddc91b3e6c"
+PKG_VERSION="8215fb4515c7c40e85e8c1929697a4cf05419f5b"
+PKG_SHA256="870423389f55f2c2db025539fcbced965addda736e2f23d03c9ff7805dbba197"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi/patches/1016-keymaps-map-KEY_SELECT-to-Select-action.patch
+++ b/packages/mediacenter/kodi/patches/1016-keymaps-map-KEY_SELECT-to-Select-action.patch
@@ -1,0 +1,37 @@
+From 7114b18e8fc8e1d6b8081f1999279c2602eab3f1 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Tue, 16 Jun 2026 23:07:11 +0200
+Subject: [PATCH] keymaps: map KEY_SELECT to Select action
+
+The OK button on lots of HID remotes generates KEY_SELECT, which
+gets mapped by kodi to the launch_media_select keyname.
+
+The historical default mapping of that key to open the music
+window is quite arbitrary, map it to the often used select action
+instead.
+
+Also add a longpress mapping to open the context menu, to match
+default KEY_ENTER and KEY_OK actions.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ system/keymaps/keyboard.xml | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/system/keymaps/keyboard.xml b/system/keymaps/keyboard.xml
+index 8c901f024867..776c0bb440f4 100644
+--- a/system/keymaps/keyboard.xml
++++ b/system/keymaps/keyboard.xml
+@@ -139,7 +139,8 @@
+       <rewind>Rewind</rewind>
+       <record/>
+       <launch_mail></launch_mail>
+-      <launch_media_select>ActivateWindow(Music)</launch_media_select>
++      <launch_media_select>Select</launch_media_select>
++      <launch_media_select mod="longpress">ContextMenu</launch_media_select>
+       <launch_app1_pc_icon>ActivateWindow(Programs)</launch_app1_pc_icon>
+       <launch_app2_pc_icon>ActivateWindow(Programs)</launch_app2_pc_icon>
+       <launch_file_browser/>
+-- 
+2.47.3
+

--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -1,27 +1,12 @@
-# ali express g60s pro plus remote
-evdev:input:b0003v1915p1001e0201*
- KEYBOARD_KEY_c0041=enter
-
-# alfawise z1 remote
-evdev:input:b0005v2B54p1603e*
- KEYBOARD_KEY_c0041=enter
-
 # auvipal g9f remote
 evdev:input:b0005v045Ep0041*
- KEYBOARD_KEY_c0041=enter
  KEYBOARD_KEY_70071=l
  KEYBOARD_KEY_70070=g
  KEYBOARD_KEY_7006f=x
  KEYBOARD_KEY_7006e=i
 
-# bt250 remote
-evdev:input:b0005v1D5ApC080e0000*
- KEYBOARD_KEY_c0041=enter
-
 # buzztv bt-300/bt-400 smart remote
 evdev:input:b0005v0957p1001*
- KEYBOARD_KEY_c0041=enter
- KEYBOARD_KEY_c0040=c
  KEYBOARD_KEY_70040=z
  KEYBOARD_KEY_70041=esc
  KEYBOARD_KEY_70042=t
@@ -29,39 +14,6 @@ evdev:input:b0005v0957p1001*
  KEYBOARD_KEY_70044=o
  KEYBOARD_KEY_70045=volumeup
  KEYBOARD_KEY_70069=volumedown
-
-# foxtel remote
-evdev:input:b0005v06E7p8144*
- KEYBOARD_KEY_c0041=enter
-
-# google tv remote
-evdev:name:*Chromecast Remote*:*
- KEYBOARD_KEY_c0041=enter
-
-# g7bts remote
-evdev:input:b0005v045Ep0041e0300*
- KEYBOARD_KEY_c0041=enter
-
-# g20bts remote
-evdev:input:b0005v2B54p1600e0000*
- KEYBOARD_KEY_c0041=enter
-
-# justboom smart remote
-evdev:input:b0003v2252p0120*
- KEYBOARD_KEY_c0041=enter
- KEYBOARD_KEY_c0040=c
-
-# nvidia shield remotes
-evdev:input:b0005v0955p7213*
- KEYBOARD_KEY_c0041=enter
-
-evdev:input:b0005v0955p7217*
- KEYBOARD_KEY_c0041=enter
-
-# o2.cz khamsin bluetooth remote
-evdev:input:b0005v0217p0000e0110*
- KEYBOARD_KEY_c0041=enter
- KEYBOARD_KEY_c0040=c
 
 # all osmc remotes
 evdev:input:b0003v2252p17*
@@ -98,34 +50,6 @@ evdev:input:b0003v2252p1037*
  KEYBOARD_KEY_c0060=kpleftparen
  KEYBOARD_KEY_10084=kprightparen
 
-# ugoos ur01-ble remote
-evdev:input:b0005v005Dp0001*
- KEYBOARD_KEY_c0041=enter
-
-# UR02 remote
-evdev:input:b0005v0508p1980*
- KEYBOARD_KEY_c0041=enter
-
-# wechip g20 remote
-evdev:input:b0003v4842p0001*
- KEYBOARD_KEY_c0041=enter
-
-# xiaomi remote
-evdev:input:b0005v2717p32B9e4A4C*
- KEYBOARD_KEY_c0041=enter
-
-# xiaomi remote 
-evdev:input:b0005v2717p32B9e4A53* 
- KEYBOARD_KEY_c0041=enter
-
-# yyykq remote
-evdev:input:b0005v0416p0300*
- KEYBOARD_KEY_c0041=enter
-
-# zidoo v10 remote
-evdev:input:b0005v2B54p1600*
- KEYBOARD_KEY_c0041=enter
-
 # zidoo v12 remote
 evdev:input:b0005v5A44p5A44*
  KEYBOARD_KEY_7001e=one #1
@@ -143,7 +67,6 @@ evdev:input:b0005v5A44p5A44*
  KEYBOARD_KEY_70045=m #square key with lines
  KEYBOARD_KEY_7009a=o #tv out
  KEYBOARD_KEY_700b7=power #tv out green
- KEYBOARD_KEY_c0041=enter
  KEYBOARD_KEY_c006d=c #zoom
  KEYBOARD_KEY_c00bc=repeat
  KEYBOARD_KEY_c01bd=i #info
@@ -151,7 +74,3 @@ evdev:input:b0005v5A44p5A44*
  KEYBOARD_KEY_c00e2=volume_mute
  KEYBOARD_KEY_c00e9=period #vol-up
  KEYBOARD_KEY_c00ea=comma #vol-down
-
-# ZTERCR21 remote
-evdev:input:b0005v0508p0110*
- KEYBOARD_KEY_c0041=enter


### PR DESCRIPTION
Kodi PR https://github.com/xbmc/xbmc/pull/27932 added support for KEY_MENU / XF86MenuKB in the libinput handler which means we no longer need to remap that keycode on HID remotes to KEY_C via a hwdb entry.

Further investigation revealed that over the years we piled up a total of 22 (!) remappings of KEY_SELECT to KEY_ENTER for various remotes.

The historical default mapping of KEY_SELECT/XF86Select in kodi to launch the music window is quite arbitrary, few IR remotes geneate that code and most of them use it for a different function (like Hauppauge remotes where the "Home" button generates KEY_SELECT).

So simply add a patch for kodi's default keyboard handling to use the "Select" action for KEY_SELECT, this allows us to drop a lot of our downstream hwdb entries.

Runtime tested on a RPi5 with the JustBoom Smart Remote, OK button (including longpress) and the Menu button work like before.