### PR TITLE
libgpiod: update to 2.3 and meson

### DIFF
--- a/packages/addons/addon-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/libgpiod/package.mk
@@ -2,23 +2,35 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libgpiod"
-PKG_VERSION="2.2.5"
-PKG_SHA256="3a093cabe19bd5077f9f1bf31c8d4743cba3276718fca007f8eb6392a3bce575"
+PKG_VERSION="2.3"
+PKG_SHA256="3f7deffb86a4d0add7e4e4b58f21d50d2473f40a37dffddecc09895c3842dccd"
 PKG_LICENSE="GPL-2.0-or-later AND LGPL-2.1-or-later"
 PKG_SITE="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/"
 PKG_URL="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain Python3 setuptools:host"
 PKG_LONGDESC="Tools for interacting with the linux GPIO character device."
-PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="+pic -sysroot"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-tools --disable-shared"
+PKG_MESON_OPTS_TARGET="-Dtools=enabled \
+                       -Dgpioset-interactive=disabled \
+                       -Dtests=disabled \
+                       -Dexamples=disabled \
+                       -Dbindings-cxx=disabled \
+                       -Dbindings-python=disabled \
+                       -Dbindings-rust=disabled \
+                       -Dbindings-glib=disabled \
+                       -Ddbus=disabled \
+                       -Dintrospection=disabled \
+                       -Dsystemd=disabled \
+                       -Dprofiling=false \
+                       -Ddefault_library=shared"
 
 post_make_target() {
   (
-    LDFLAGS+=" -L${PKG_BUILD}/.${TARGET_NAME}/lib/.libs"
-    CFLAGS+=" -I${PKG_BUILD}/include"
     cd ../bindings/python
+    export CC="${TARGET_CC}"
+    CFLAGS+=" -I${PKG_BUILD}/include"
+    LDFLAGS+=" -L${PKG_BUILD}/.${TARGET_NAME}/lib"
     python_target_env python3 -m build -n -w -x
   )
 }

--- a/packages/addons/service/lcdd/package.mk
+++ b/packages/addons/service/lcdd/package.mk
@@ -5,12 +5,13 @@ PKG_NAME="lcdd"
 PKG_VERSION="71877ee059a238400b5f6b41cee7c43a3df00334"
 PKG_SHA256="e910c7d748b58cc57543dc8845f8b2bcd0592dddd58bd72a55a58e90e6bfd861"
 PKG_VERSION_DATE="0.5dev+2024-12-14"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://lcdproc.org/"
 PKG_URL="https://github.com/lcdproc/lcdproc/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain freetype libftdi1 libgpiod libhid libugpio libusb ncurses serdisplib"
+PKG_DEPENDS_CONFIG="libgpiod"
 PKG_SECTION="service"
 PKG_SHORTDESC="LCDproc: Software to display system information from your Linux/*BSD box on a LCD"
 PKG_LONGDESC="LCDproc (${PKG_VERSION}) is a piece of software that displays real-time system information from your Linux/*BSD box on a LCD. The server supports several serial devices: Matrix Orbital, Crystal Fontz, Bayrad, LB216, LCDM001 (kernelconcepts.de), Wirz-SLI, Cwlinux(.com) and PIC-an-LCD; and some devices connected to the LPT port: HD44780, STV5730, T6963, SED1520 and SED1330. Various clients are available that display things like CPU load, system load, memory usage, uptime, and a lot more."
@@ -43,9 +44,11 @@ addon() {
   cp -PR ${PKG_INSTALL}/etc/LCDd.conf ${ADDON_BUILD}/${PKG_ADDON_ID}/config/
   cp -PR ${PKG_INSTALL}/usr/lib       ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
   patchelf --add-rpath '${ORIGIN}/../../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/lcdproc/glcd.so
+  patchelf --add-rpath '${ORIGIN}/../../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/lcdproc/hd44780.so
   cp -PR ${PKG_INSTALL}/usr/sbin      ${ADDON_BUILD}/${PKG_ADDON_ID}/bin/
 
   mkdir -p ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
+  cp -L $(get_install_dir libgpiod)/usr/lib/libgpiod.so.3 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
   cp -L $(get_install_dir serdisplib)/usr/lib/libserdisp.so.2 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
   sed -e "s|^DriverPath=.*$|DriverPath=/storage/.kodi/addons/service.lcdd/lib/lcdproc/|" \

--- a/packages/addons/service/lcdd/patches/0002-configure-drivers-use-PKG_CHECK_MODULES-for-libgpiod.patch
+++ b/packages/addons/service/lcdd/patches/0002-configure-drivers-use-PKG_CHECK_MODULES-for-libgpiod.patch
@@ -1,0 +1,76 @@
+From 2be236ea64911bfcd07016f3e0bfe0ec53279219 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Wed, 17 Jun 2026 11:05:04 +0000
+Subject: [PATCH] configure, drivers: use PKG_CHECK_MODULES for libgpiod
+ detection
+
+The hd44780-gpiod driver check used AC_CHECK_LIB(gpiod, main, ...),
+a plain link test against the default linker search paths. This is
+blind to PKG_CONFIG_PATH, so on systems where libgpiod is installed
+to a non-default prefix (only discoverable via its .pc file), the
+check fails even though libgpiod is present and usable. It also
+never supplied a header search path, so builds failed with "gpiod.h:
+No such file or directory" even when the link test happened to pass.
+
+Switch to PKG_CHECK_MODULES, wrapped in the same
+ifdef([PKG_CHECK_MODULES], ...) guard already used for libusb-1.0
+detection, so configure still degrades gracefully if pkg.m4 is
+unavailable. Add AC_SUBST for LIBGPIOD_LIBS and LIBGPIOD_CFLAGS, and
+wire them into server/drivers/Makefile.am: append @LIBGPIOD_CFLAGS@
+to hd44780_CFLAGS so gpiod.h is found, and replace the now-unused
+@LIBGPIOD@ with @LIBGPIOD_LIBS@ in hd44780_LDADD so the driver links
+against the correct flags instead of a hardcoded -lgpiod.
+---
+ acinclude.m4               | 13 ++++++-------
+ server/drivers/Makefile.am |  4 ++--
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 0f305444..88400176 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -241,13 +241,12 @@ dnl			else
+ 			],[
+ 				AC_MSG_WARN([Could not find libugpio, not building hd44780-ugpio driver])
+ 			])
+-			AC_CHECK_LIB(gpiod, main,[
+-				HD44780_DRIVERS="$HD44780_DRIVERS hd44780-hd44780-gpiod.o"
+-				LIBGPIOD="-lgpiod"
+-				AC_DEFINE(HAVE_GPIOD, [1], [Define to 1 if you have libgpiod])
+-			],[
+-				AC_MSG_WARN([Could not find libgpiod, not building hd44780-gpiod driver])
+-			])
++			ifdef([PKG_CHECK_MODULES],
++				[PKG_CHECK_MODULES(LIBGPIOD, libgpiod,
++					[HD44780_DRIVERS="$HD44780_DRIVERS hd44780-hd44780-gpiod.o"
++					 AC_DEFINE(HAVE_GPIOD, [1], [Define to 1 if you have libgpiod])],
++					[AC_MSG_WARN([Could not find libgpiod, not building hd44780-gpiod driver])])],
++				[AC_MSG_WARN([pkg-config not (fully) installed; hd44780-gpiod driver may not be built])])
+ 			if test "$ac_cv_port_have_lpt" = yes ; then
+ 				HD44780_DRIVERS="$HD44780_DRIVERS hd44780-hd44780-4bit.o hd44780-hd44780-ext8bit.o hd44780-hd44780-winamp.o hd44780-hd44780-serialLpt.o hd44780-hd44780-lcm162.o"
+ 			fi
+diff --git a/server/drivers/Makefile.am b/server/drivers/Makefile.am
+index b8ef090e..b8cf6101 100644
+--- a/server/drivers/Makefile.am
++++ b/server/drivers/Makefile.am
+@@ -29,7 +29,7 @@ noinst_LIBRARIES = libLCD.a libbignum.a
+ futaba_CFLAGS =      @LIBUSB_CFLAGS@ @LIBUSB_1_0_CFLAGS@ $(AM_CFLAGS)
+ g15_CFLAGS =         @LIBUSB_CFLAGS@ @FT2_CFLAGS@ $(AM_CFLAGS)
+ glcd_CFLAGS =        @FT2_CFLAGS@ @LIBPNG_CFLAGS@ @LIBUSB_CFLAGS@ @LIBX11_CFLAGS@ $(AM_CFLAGS)
+-hd44780_CFLAGS =     @LIBUSB_CFLAGS@ @LIBFTDI_CFLAGS@ $(AM_CFLAGS)
++hd44780_CFLAGS =     @LIBUSB_CFLAGS@ @LIBFTDI_CFLAGS@ @LIBGPIOD_CFLAGS@ $(AM_CFLAGS)
+ i2500vfd_CFLAGS =    @LIBFTDI_CFLAGS@ $(AM_CFLAGS)
+ IOWarrior_CFLAGS =   @LIBUSB_CFLAGS@ $(AM_CFLAGS)
+ lis_CFLAGS =         @LIBFTDI_CFLAGS@ $(AM_CFLAGS)
+@@ -50,7 +50,7 @@ glcd_LDADD =         libLCD.a @GLCD_DRIVERS@ @FT2_LIBS@ @LIBPNG_LIBS@ @LIBSERDIS
+ glcd_DEPENDENCIES =  @GLCD_DRIVERS@ glcd-glcd-render.o libLCD.a
+ glcdlib_LDADD =      @LIBGLCD@
+ glk_LDADD =          libbignum.a
+-hd44780_LDADD =      libLCD.a @HD44780_DRIVERS@ @HD44780_I2C@ @LIBUSB_1_0_LIBS@ @LIBUSB_LIBS@ @LIBFTDI_LIBS@ @LIBUGPIO@ @LIBGPIOD@ libbignum.a
++hd44780_LDADD =      libLCD.a @HD44780_DRIVERS@ @HD44780_I2C@ @LIBUSB_1_0_LIBS@ @LIBUSB_LIBS@ @LIBFTDI_LIBS@ @LIBUGPIO@ @LIBGPIOD_LIBS@ libbignum.a
+ hd44780_DEPENDENCIES = @HD44780_DRIVERS@ @HD44780_I2C@ libLCD.a libbignum.a
+ i2500vfd_LDADD =     @LIBFTDI_LIBS@
+ imon_LDADD =         libLCD.a libbignum.a
+-- 
+2.53.0
+

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"
@@ -139,8 +139,10 @@ addon() {
     cp -P $(get_install_dir oniguruma)/usr/lib/{libonig.so,libonig.so.5,libonig.so.5.*.*} ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private
 
     # libgpiod
-    cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpioget,gpioinfo,gpiomon,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -P $(get_install_dir libgpiod)/usr/bin/{gpiodetect,gpioget,gpioinfo,gpiomon,gpionotify,gpioset} ${ADDON_BUILD}/${PKG_ADDON_ID}/bin
+    cp -L $(get_install_dir libgpiod)/usr/lib/libgpiod.so.3 ${ADDON_BUILD}/${PKG_ADDON_ID}/lib.private/
     cp -PR $(get_build_dir libgpiod)/bindings/python/build/lib.linux*/* ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/
+    patchelf --add-rpath '${ORIGIN}/../../lib.private' ${ADDON_BUILD}/${PKG_ADDON_ID}/lib/gpiod/_ext.*.so
 
     # lm_sensors
     cp -P $(get_install_dir lm_sensors)/usr/bin/sensors ${ADDON_BUILD}/${PKG_ADDON_ID}/bin 2>/dev/null || :


### PR DESCRIPTION
- lcdd: update addon (2)
  - https://github.com/lcdproc/lcdproc/pull/226
  - libgpiod had not been linking
  - libgpiod: update to 2.3 and meson
- system-tools: update addon (7)
  - libgpiod: update to 2.3 and meson