### PR TITLE
libclc: add target build for spirv64-mesa3d- and prepare for imagination

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -63,6 +63,12 @@ get_graphicdrivers() {
     VAAPI_SUPPORT="yes"
   fi
 
+  if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+    GALLIUM_DRIVERS+=" zink"
+    VULKAN_DRIVERS_MESA+=" imagination"
+    V4L2_SUPPORT="yes"
+  fi
+
   if listcontains "${GRAPHIC_DRIVERS}" "iris"; then
     GALLIUM_DRIVERS+=" iris"
     XORG_DRIVERS+=" intel"

--- a/packages/devel/libclc/package.mk
+++ b/packages/devel/libclc/package.mk
@@ -6,6 +6,7 @@ PKG_VERSION="$(get_pkg_version llvm)"
 PKG_LICENSE="NCSA OR MIT"
 PKG_URL=""
 PKG_DEPENDS_HOST="toolchain:host llvm:host"
+PKG_DEPENDS_TARGET="toolchain llvm:host"
 PKG_LONGDESC="Low-Level Virtual Machine (LLVM) is a compiler infrastructure."
 PKG_DEPENDS_UNPACK+=" llvm"
 PKG_PATCH_DIRS+=" $(get_pkg_directory llvm)/patches"
@@ -26,4 +27,15 @@ pre_configure_host() {
   mkdir -p "${PKG_BUILD}/.${HOST_NAME}"
   cd ${PKG_BUILD}/.${HOST_NAME}
   PKG_CMAKE_OPTS_HOST="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD}"
+}
+
+pre_configure_target() {
+  LIBCLC_TARGETS_TO_BUILD="spirv64-mesa3d-"
+
+  mkdir -p "${PKG_BUILD}/.${TARGET_NAME}"
+  cd ${PKG_BUILD}/.${TARGET_NAME}
+  # cross-compile: use HOST LLVM so cmake finds clang, opt, llvm-spirv, not sysroot LLVM whose tools were stripped
+  PKG_CMAKE_OPTS_TARGET="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD} \
+                         -DLLVM_DIR=${TOOLCHAIN}/lib/cmake/llvm \
+                         -DLIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR=${TOOLCHAIN}/bin"
 }

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="bac2bca9121897a2b8162e79636b50ac998fca799c8e6cf914edd85962babdf0"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"
-PKG_DEPENDS_HOST="toolchain:host expat:host libclc:host libdrm:host Mako:host pyyaml:host spirv-tools:host"
+PKG_DEPENDS_HOST="toolchain:host expat:host libclc:host libdrm:host llvm:host Mako:host pyyaml:host spirv-tools:host"
 PKG_DEPENDS_TARGET="toolchain expat libdrm Mako:host pyyaml:host"
 PKG_LONGDESC="Mesa is a 3-D graphics library with an API."
 
@@ -22,7 +22,7 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dgallium-drivers= \
                      -Dplatforms= \
                      -Dglx=disabled \
-                     -Dvulkan-drivers= \
+                     -Dvulkan-drivers=imagination \
                      -Dshared-llvm=disabled \
                      -Dtools=panfrost \
                      -Dvideo-codecs= \
@@ -31,7 +31,8 @@ PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dmesa-clc=enabled \
                      -Dinstall-mesa-clc=true \
                      -Dprecomp-compiler=enabled \
-                     -Dinstall-precomp-compiler=true"
+                     -Dinstall-precomp-compiler=true \
+                     -Dimagination-srv=false"
 
 PKG_MESON_OPTS_TARGET="-Dgallium-drivers=${GALLIUM_DRIVERS// /,} \
                        -Dgallium-extra-hud=false \
@@ -70,7 +71,12 @@ else
   PKG_MESON_OPTS_TARGET+=" -Ddraw-use-llvm=false"
 fi
 
-if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+  PKG_DEPENDS_TARGET+=" spirv-tools"
+  PKG_MESON_OPTS_TARGET+=" -Dimagination-srv=true"
+fi
+
+if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
   if [ "${USE_REUSABLE}" = "yes" ]; then
     PKG_DEPENDS_TARGET+=" mesa-reusable"
   else
@@ -116,7 +122,10 @@ else
 fi
 
 makeinstall_host() {
-  host_files="src/compiler/clc/mesa_clc src/compiler/spirv/vtn_bindgen2 src/panfrost/clc/panfrost_compile"
+  host_files="src/compiler/clc/mesa_clc \
+              src/compiler/spirv/vtn_bindgen2 \
+              src/imagination/pco/uscgen/pco_clc \
+              src/panfrost/clc/panfrost_compile"
 
   if listcontains "${BUILD_REUSABLE}" "(all|mesa:host)"; then
     # Build the reusable mesa:host for both local and to be added to a GitHub release

--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -12,6 +12,7 @@ PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-Tools"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-Tools/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="toolchain:host"
+PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_UNPACK="spirv-headers"
 PKG_LONGDESC="The SPIR-V Tools project provides an API and commands for processing SPIR-V modules."
 

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -42,13 +42,13 @@ PKG_CMAKE_OPTS_COMMON="-DLLVM_INCLUDE_TOOLS=ON \
                        -DLLVM_ENABLE_Z3_SOLVER=OFF \
                        -DCMAKE_SKIP_RPATH=ON"
 
-if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
   PKG_DEPENDS_UNPACK="spirv-headers spirv-llvm-translator"
   PKG_CMAKE_OPTS_COMMON+=" -DLLVM_SPIRV_INCLUDE_TESTS=OFF"
 fi
 
 post_unpack() {
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     mkdir -p "${PKG_BUILD}"/llvm/projects/{SPIRV-Headers,SPIRV-LLVM-Translator}
       tar --strip-components=1 \
         -xf "${SOURCES}/spirv-headers/spirv-headers-$(get_pkg_version spirv-headers).tar.gz" \
@@ -104,7 +104,11 @@ post_make_host() {
                       llvm-profdata llvm-readobj llvm-size llvm-strip \
                       llvm-tblgen opt
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+    ninja ${NINJA_OPTS} clang-tblgen
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     ninja ${NINJA_OPTS} llvm-spirv
   fi
 }
@@ -116,20 +120,41 @@ post_makeinstall_host() {
     cp -a bin/{llvm-profdata,llvm-readobj,llvm-size,llvm-strip} "${TOOLCHAIN}/bin"
     cp -a bin/{llvm-tblgen,opt} "${TOOLCHAIN}/bin"
 
-  if listcontains "${GRAPHIC_DRIVERS}" "(iris|panfrost)"; then
+  if listcontains "${GRAPHIC_DRIVERS}" "imagination"; then
+    cp -a bin/clang-tblgen "${TOOLCHAIN}/bin"
+  fi
+
+  if listcontains "${GRAPHIC_DRIVERS}" "(imagination|iris|panfrost)"; then
     cp -a bin/llvm-spirv "${TOOLCHAIN}/bin"
   fi
 }
 
 pre_configure_target() {
+  case "${TARGET_ARCH}" in
+    "aarch64")
+      LLVM_BUILD_TARGETS=""
+      LLVM_BUILD_CLANG="-DLLVM_ENABLE_PROJECTS=''"
+      ;;
+    "arm")
+      LLVM_BUILD_TARGETS=""
+      LLVM_BUILD_CLANG="-DLLVM_ENABLE_PROJECTS=''"
+      ;;
+    "x86_64")
+      LLVM_BUILD_TARGETS="AMDGPU"
+      # do not build clang (not needed)
+      # llvm:target is only required to build mesa amd on x86_64 targets
+      LLVM_BUILD_CLANG="-DLLVM_ENABLE_PROJECTS=''"
+      ;;
+  esac
+
   mkdir -p ${PKG_BUILD}/.${TARGET_NAME}
   cd ${PKG_BUILD}/.${TARGET_NAME}
   PKG_CMAKE_OPTS_TARGET="${PKG_CMAKE_OPTS_COMMON} \
                          -DCMAKE_BINARY_DIR=${PKG_BUILD}/.${TARGET_NAME} \
                          -DLLVM_NATIVE_BUILD=${PKG_BUILD}/.${TARGET_NAME}/native \
                          -DCMAKE_CROSSCOMPILING=ON \
-                         -DLLVM_ENABLE_PROJECTS='' \
-                         -DLLVM_TARGETS_TO_BUILD=AMDGPU \
+                         ${LLVM_BUILD_CLANG} \
+                         -DLLVM_TARGETS_TO_BUILD=${LLVM_BUILD_TARGETS} \
                          -DLLVM_TARGET_ARCH="${TARGET_ARCH}" \
                          -DLLVM_TABLEGEN=${TOOLCHAIN}/bin/llvm-tblgen"
 }


### PR DESCRIPTION
Make `libclc` available as a target package so `spirv64-mesa3d-.spv`
is installed on-device for the Imagination PowerVR Vulkan driver.

The existing `libclc:host` only produces builtins for the build host.
This adds a target build that cross-compiles `spirv64-mesa3d-` against
HOST LLVM tools (the sysroot LLVM tools are stripped at install time).

Supporting changes to enable the target build:
- **llvm**: build `llvm-spirv` and `clang-tblgen` as host tools
- **config/graphic**: add imagination driver block (zink, imagination Vulkan, V4L2)
- **mesa**: build `pco_clc` in `mesa:host`/`mesa-reusable`; enable imagination target build
- **spirv-tools**: add target build

Notes:
- Link: https://gitlab.freedesktop.org/imagination/mesa/-/commits/dev/bxs
- Replacement for #10067
- For device packaging (libclc will need to be included via ADDITIONAL_PACKAGES) 

