### PR TITLE
libgpiod: force TARGET_xFLAGS when cross-compiling Python bindings

### DIFF
--- a/packages/addons/addon-depends/libgpiod/package.mk
+++ b/packages/addons/addon-depends/libgpiod/package.mk
@@ -29,8 +29,8 @@ post_make_target() {
   (
     cd ../bindings/python
     export CC="${TARGET_CC}"
-    CFLAGS+=" -I${PKG_BUILD}/include"
-    LDFLAGS+=" -L${PKG_BUILD}/.${TARGET_NAME}/lib"
+    CFLAGS="${TARGET_CFLAGS} -I${PKG_BUILD}/include"
+    LDFLAGS="${TARGET_LDFLAGS} -L${PKG_BUILD}/.${TARGET_NAME}/lib"
     python_target_env python3 -m build -n -w -x
   )
 }


### PR DESCRIPTION
Force TARGET_xFLAGS for Python sysconfig in CFLAGS and LDFLAGS; fixes python3 -m build.

Fixes:
- aarch64-libreelec-linux-gnu-gcc: error: unknown value 'native' for '-march'