### PR TITLE
libfmt: update to 12.2.0

### DIFF
--- a/packages/devel/libfmt/package.mk
+++ b/packages/devel/libfmt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libfmt"
-PKG_VERSION="12.1.0"
-PKG_SHA256="ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea"
+PKG_VERSION="12.2.0"
+PKG_SHA256="8b852bb5aa6e7d8564f9e81394055395dd1d1936d38dfd3a17792a02bebd7af0"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/fmtlib/fmt"
 PKG_URL="https://github.com/fmtlib/fmt/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- libfmt: update to 12.2.0
- ~mpd: fix build with libfmt 12.2.0 and use fmt/format.h not fmt/core.h~
  - https://github.com/MusicPlayerDaemon/MPD/pull/2512
  - https://github.com/MusicPlayerDaemon/MPD/commit/88d5b5248d71862815da336cfd1c6f66626bb4d4
  - #11576
  - aa17ed9bd9267c6b87c33518f0966b3bed9cc0df
- kodi: avoid deprecated fstring to string_view conversion with libfmt 12.2.0
  - https://github.com/xbmc/xbmc/pull/28459