### PR TITLE
Addon updates

### DIFF
--- a/packages/addons/addon-depends/cxxtools/patches/0001-cmake-add-install-rules-for-sub-libraries.patch
+++ b/packages/addons/addon-depends/cxxtools/patches/0001-cmake-add-install-rules-for-sub-libraries.patch
@@ -1,0 +1,83 @@
+From 93ffb63b29678b514e1e8c75bb40d339febb161a Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 18 Jun 2026 20:40:49 +1000
+Subject: [PATCH] cmake: add install rules for sub-libraries
+
+The cmake build defines cxxtools-http, cxxtools-json, cxxtools-bin,
+cxxtools-xmlrpc and cxxtools-unit but provides no install() rules for
+them; only the main cxxtools library is installed.  Add LIBRARY and
+ARCHIVE install destinations for each sub-library to match the
+autotools build.
+---
+ src/bin/CMakeLists.txt    | 5 +++++
+ src/http/CMakeLists.txt   | 5 +++++
+ src/json/CMakeLists.txt   | 5 +++++
+ src/unit/CMakeLists.txt   | 5 +++++
+ src/xmlrpc/CMakeLists.txt | 5 +++++
+ 5 files changed, 25 insertions(+)
+
+diff --git a/src/bin/CMakeLists.txt b/src/bin/CMakeLists.txt
+index 0998546c..0c2e98aa 100644
+--- a/src/bin/CMakeLists.txt
++++ b/src/bin/CMakeLists.txt
+@@ -14,3 +14,8 @@ add_library(cxxtools-bin
+ )
+ 
+ target_link_libraries(cxxtools-bin cxxtools)
++
++install(TARGETS cxxtools-bin
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+diff --git a/src/http/CMakeLists.txt b/src/http/CMakeLists.txt
+index 0c77ec06..27b4dc70 100644
+--- a/src/http/CMakeLists.txt
++++ b/src/http/CMakeLists.txt
+@@ -19,3 +19,8 @@ add_library(cxxtools-http
+ )
+ 
+ target_link_libraries(cxxtools-http cxxtools)
++
++install(TARGETS cxxtools-http
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+diff --git a/src/json/CMakeLists.txt b/src/json/CMakeLists.txt
+index 6c588767..045a8393 100644
+--- a/src/json/CMakeLists.txt
++++ b/src/json/CMakeLists.txt
+@@ -14,3 +14,8 @@ add_library(cxxtools-json
+ )
+ 
+ target_link_libraries(cxxtools-json cxxtools cxxtools-http)
++
++install(TARGETS cxxtools-json
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+diff --git a/src/unit/CMakeLists.txt b/src/unit/CMakeLists.txt
+index a1e2fd80..c84b2ca6 100644
+--- a/src/unit/CMakeLists.txt
++++ b/src/unit/CMakeLists.txt
+@@ -11,3 +11,8 @@ add_library(cxxtools-unit
+ )
+ 
+ target_link_libraries(cxxtools-unit cxxtools)
++
++install(TARGETS cxxtools-unit
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
+diff --git a/src/xmlrpc/CMakeLists.txt b/src/xmlrpc/CMakeLists.txt
+index 97c54584..59c6669c 100644
+--- a/src/xmlrpc/CMakeLists.txt
++++ b/src/xmlrpc/CMakeLists.txt
+@@ -10,3 +10,8 @@ add_library(cxxtools-xmlrpc
+ )
+ 
+ target_link_libraries(cxxtools-xmlrpc cxxtools cxxtools cxxtools-http)
++
++install(TARGETS cxxtools-xmlrpc
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)

--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="7608d82f33ce0ebbbed5bf8f6997319375c30a46d325496f3e8974c9a0c8ce6b"
+PKG_SHA256="f95b9594a671a8650eea0c47c267fbe15516a7c5f01fbf777715881497eb58a5"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="d1c06ef6b41d88d76866aea43c246cd7c63d04fa"
+export PKG_GIT_COMMIT="fb59821d450bc76c97e52617f66dde0c6035e332"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.3.1"
-PKG_SHA256="9de4cb8bfb27964a8ffd95e35326b7279ea2e2a6506da16c2533d3f523f12c11"
+PKG_VERSION="2.3.2"
+PKG_SHA256="1a215ae4acb184192668b21f8b8375ceb6e86f8832a97fe6f7ab53ad79bb2cee"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="64b425cf570b3b8dd1d4cc46da7c1fce65c6651a"
+export PKG_GIT_COMMIT="fff62f14765df376e5fc36f5a8f8e795b5670f61"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.5.3"
-PKG_SHA256="460e3c95fbf86414e88e7cb58551df061c206592bc66680fec75c5cdd551e3bd"
+PKG_VERSION="29.6.0"
+PKG_SHA256="7b967550d43fb5e0ab448282164cc16b670d26017fc3b6cd6284ceef36998158"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_TOOLCHAIN="manual"
 PKG_NO_REFRESH_PATCHES="tools/moby/gen-patches.sh"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="285b47192d4b2f183aba5dd360a92cd52d723004"
+export PKG_GIT_COMMIT="70eaf5ef6f274623ddcca8eb634ccf7cba15cbc5"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
+++ b/packages/addons/addon-depends/vdr-plugins/vdr-plugin-restfulapi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="vdr-plugin-restfulapi"
-PKG_VERSION="996884ed17c2aa52c044b1a432ad5fccb64ba796"
-PKG_SHA256="c2c9a2dbf83de4793d0ce86b66e872560e4a83c738dc4d66f4685077b3dfd826"
+PKG_VERSION="f47b99c5fa46449c9c7ffa2c9386a7df0133efad"
+PKG_SHA256="f427cda446d6a4bf58ae274b77966ae338f87820431d868e96c6f2990a47ea1a"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://github.com/yavdr/vdr-plugin-restfulapi"
 PKG_URL="https://github.com/yavdr/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/filebrowser/package.mk
+++ b/packages/addons/service/filebrowser/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="filebrowser"
-PKG_VERSION="2.63.13"
-PKG_REV="5"
+PKG_VERSION="2.63.15"
+PKG_REV="6"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://filebrowser.org"
 PKG_DEPENDS_TARGET="toolchain:host"
@@ -15,15 +15,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="9baf1d903a721f5e74409bb04e883d91fed493bdc724f7baaa7ee663f832fbc7"
+    PKG_SHA256="74dd4e2403235987e4dba26b6e34a6f2c56e9fc98e13d9205c079f9e1c8c42f5"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-arm64-filebrowser.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="4374daaf3291818859725f68bc51f48766b3b35e2df69a997e667e81468c6971"
+    PKG_SHA256="f1af939497e72f2afb2d80312d2136b487084aa3be97ed75c1f5c43e2ad5c1d0"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-armv7-filebrowser.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="1743269f00cf0f23f43e1a2e899beacb54d178092f8af992dc0d304fcf26556e"
+    PKG_SHA256="2e781227d626d8b8ba533b77bdd6cb3a8cf70e014af1a8a3966a13a901a0a951"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-amd64-filebrowser.tar.gz"
     ;;
 esac

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.5.14"
-PKG_SHA256="e91f04cd8cec75d72b8a2aaa7e90b1ba0a5e2094b7a882fc3a29a484a48a87e9"
+PKG_VERSION="0.5.15"
+PKG_SHA256="baa121bc918df5fa0e0e70755bb1c99ffab0ab107225ecf99aa470e2c6ba5e7b"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- vdr-plugin-restfulapi: update to githash f47b99c 
  - (vdr-addon not compiling since last increment - so no need to bump addon.)
  - cxxtools: add cmake install rules for sub-libraries
    - addresses linkage issues with vdr-plugin-restfulapi 
    - https://github.com/maekitalo/cxxtools/pull/48
- filebrowser: update to 2.63.15 and addon (6)
- wireplumber: update to 0.5.15
- docker: update to 29.6.0 and addon (6)
  - cli: update to 29.6.0
  - moby: update to 29.6.0
  - containerd: update to 2.3.2