### PR TITLE
mesa: add mpeg12dec to video-codecs for r600/radeonsi

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -103,7 +103,7 @@ fi
 if [ "${VAAPI_SUPPORT}" = "yes" ] && listcontains "${GRAPHIC_DRIVERS}" "(r600|radeonsi)"; then
   PKG_DEPENDS_TARGET+=" libva"
   PKG_MESON_OPTS_TARGET+=" -Dgallium-va=enabled \
-                           -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc,av1dec,av1enc,vp9dec"
+                           -Dvideo-codecs=mpeg12dec,vc1dec,h264dec,h264enc,h265dec,h265enc,av1dec,av1enc,vp9dec"
 else
   PKG_MESON_OPTS_TARGET+=" -Dgallium-va=disabled"
 fi


### PR DESCRIPTION
As discussed in the LE forums (https://forum.libreelec.tv/thread/30488-x86-64-no-mpeg2-hw-acceleration-with-amd-gpu/), currently, the legacy codec MPEG2 is not enabled to be hw-decoded even though the hardware supports this. 

This commit enables Mesa to support hw decoding of all video codecs supported by the GPU - by explicitly enabling them in the -Dvideo-codecs= config option.



