### PR TITLE
gettext: link target libxml2 from sysroot and disable curses/xattr

### DIFF
--- a/packages/devel/gettext/package.mk
+++ b/packages/devel/gettext/package.mk
@@ -9,7 +9,7 @@ PKG_LICENSE="GPL-3.0-or-later AND LGPL-2.1-or-later"
 PKG_SITE="https://www.gnu.org/s/gettext/"
 PKG_URL="https://ftp.gnu.org/pub/gnu/gettext/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="make:host"
-PKG_DEPENDS_TARGET="autotools:host make:host gcc:host"
+PKG_DEPENDS_TARGET="autotools:host make:host gcc:host libxml2"
 PKG_LONGDESC="A program internationalization library and tools."
 PKG_BUILD_FLAGS="+local-cc"
 
@@ -27,6 +27,9 @@ PKG_CONFIGURE_OPTS_HOST="${PKG_CONFIGURE_OPTS_COMMON} \
                          --without-emacs"
 
 PKG_CONFIGURE_OPTS_TARGET="${PKG_CONFIGURE_OPTS_COMMON} \
+                           --disable-curses \
+                           --disable-xattr \
+                           --with-libxml2-prefix=${SYSROOT_PREFIX}/usr \
                            --with-sysroot=yes"
 
 post_configure_target() {


### PR DESCRIPTION
gl_LIBXML ignores pkg-config and probes the build host's /usr/lib* directly, so a host libxml2 can get linked into the target build. curses and attr leaked from the host the same way.

Update package to add a libxml2 DEPEND and force --with-libxml2-prefix to the sysroot for target builds, and disable curses and xattr.

closes #11163