### PR TITLE
create_addon: skip incompatible addons in the drop list without aborting

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -46,7 +46,7 @@ EOF
 
 # Get list of addon packages
 get_addons() {
-  local paths filter
+  local paths filter optional="${2}"
   local pkgpath exited
   local count=0 validpkg
 
@@ -91,14 +91,14 @@ get_addons() {
     if [ "${validpkg}" = "yes" ]; then
       echo "${PKG_NAME}"
       count=$((count + 1))
-    elif [ -n "${VERIFY_FAIL}" -a -n "${filter}" ]; then
+    elif [ -n "${VERIFY_FAIL}" -a -n "${filter}" -a -z "${optional}" ]; then
       echo "$(print_color CLR_ERROR "${PKG_NAME}"): ${VERIFY_FAIL}" >&2
     fi
   done
 
   unset -f exit
 
-  if [ ${count} -eq 0 -a -n "${filter}" ]; then
+  if [ ${count} -eq 0 -a -n "${filter}" -a -z "${optional}" ]; then
     echo "$(print_color CLR_ERROR "ERROR: no addons matched for filter ${filter}")" >&2
     echo "For more information type: ./scripts/create_addon --help" >&2
     die
@@ -162,7 +162,7 @@ while [ $# -gt 0 ]; do
       usage 1
       ;;
     -*)
-      addons_drop+=" $(get_addons ${1:1})"
+      addons_drop+=" $(get_addons "${1:1}" optional)"
       ;;
     *)
       addons+=" $(get_addons ${1})"


### PR DESCRIPTION
Dropping an addon that is incompatible with the target arch (e.g. -argononecontrol on x86_64) aborted the whole run, because get_addons() calls die when its filter matches no compatible package and the drop path expanded the filter the same way as the build list.

Add an "optional" mode to get_addons that suppresses the die and the incompatible-arch message, and use it when expanding the drop list. The drop list is still expanded to real package names, so group and regex drops such as "all -binary" keep working - storing the raw filter instead would silently leave them in the build set.

- fixes #9917