### PR TITLE
foot: add missing PKG_CONFIG dependencies for addon build

### DIFF
--- a/packages/addons/tools/terminal.foot/package.mk
+++ b/packages/addons/tools/terminal.foot/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="terminal.foot"
 PKG_VERSION="0.0.1"
-PKG_REV="0"
+PKG_REV="1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""

--- a/packages/wayland/util/foot/package.mk
+++ b/packages/wayland/util/foot/package.mk
@@ -12,7 +12,7 @@ PKG_LONGDESC="A fast, lightweight and minimalistic Wayland terminal emulator"
 
 if [ "${DISPLAYSERVER}" != "wl" ]; then
   PKG_BUILD_FLAGS="-sysroot"
-  PKG_DEPENDS_CONFIG="wayland"
+  PKG_DEPENDS_CONFIG="wayland wayland-protocols tllist fcft"
 fi
 
 PKG_MESON_OPTS_TARGET="-Ddocs=disabled \


### PR DESCRIPTION
Without wayland-protocols, tllist and fcft added meson will git-clone them and build local versions