### PR TITLE
service.bluetooth-audio: use full PulseAudio device id

### DIFF
--- a/packages/addons/service/bluetooth-audio/source/default.py
+++ b/packages/addons/service/bluetooth-audio/source/default.py
@@ -40,7 +40,7 @@ class KodiFunctions(object):
       __addon__.setSetting('audiodevice', self.audiodevice)
     else:
       self.audiodevice = __addon__.getSetting('audiodevice')
-    self.pulsedevice = 'PULSE:Default'
+    self.pulsedevice = 'PULSE:Default|Bluetooth Audio (PULSEAUDIO)'
 
     xbmc.log('%s: setting default audio device "%s" on start' % (__addonid__, self.audiodevice), xbmc.LOGINFO)
     self.select_default()


### PR DESCRIPTION
Description

This fixes a Bluetooth audio issue in service.bluetooth-audio.

The add-on currently sets Kodi’s Bluetooth audio output device to:

PULSE:Default

On my LibreELEC 12.2.1 / Raspberry Pi 4 setup this caused Kodi to fall back to or show ALSA in the audio settings screen after Bluetooth auto-connect. When that happened, the PulseAudio Bluetooth sink was still available, but it became suspended and Kodi no longer had an active PulseAudio sink input. MP3 playback could stop or become unstable, especially when entering Kodi’s audio settings page.

Kodi works correctly when the full validated PulseAudio device identifier is used:

PULSE:Default|Bluetooth Audio (PULSEAUDIO)

After applying this change locally, Bluetooth audio works correctly after reboot and auto-connect.

Tested on
LibreELEC 12.2.1
Raspberry Pi 4
Bluetooth speaker: JBL GO 2
PulseAudio: 17.0
Add-on: service.bluetooth-audio v12.2.0.1
Before

The add-on logged:

service.bluetooth-audio: setting default audio device "PULSE:Default" on start

Kodi could then show ALSA as the selected audio output device. Entering the audio settings page could interrupt playback, and PulseAudio showed the Bluetooth sink as suspended with no active Kodi sink input.

After

The add-on logs:

service.bluetooth-audio: setting default audio device "PULSE:Default|Bluetooth Audio (PULSEAUDIO)" on start

After reboot and Bluetooth auto-connect:

Kodi shows PulseAudio correctly in the audio settings screen.
guisettings.xml keeps the correct PulseAudio device.
PulseAudio Bluetooth sink is RUNNING.
Kodi has an active KodiSink sink input.
The ALSA fallback no longer occurs.
Notes

This is a minimal fix for the currently hardcoded PulseAudio device id used by the Bluetooth Audio add-on.