### PR TITLE
ldacBT: update to githash f0c878e

### DIFF
--- a/packages/audio/ldacBT/package.mk
+++ b/packages/audio/ldacBT/package.mk
@@ -2,11 +2,11 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ldacBT"
-PKG_VERSION="2.0.2.3"
-PKG_SHA256="c02998718f9c4620437d7594b4d121b3ab4c5cfeba8d41fa31dd5c71db09edca"
+PKG_VERSION="f0c878e19c384ad2284489d28e6da4ea049aff85"
+PKG_SHA256="d38e9d689fe5c287a7a2317b979c6ec2b44db7d481a2c3971edf4f90be05ec54"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/EHfive/ldacBT"
-PKG_URL="https://github.com/EHfive/ldacBT/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://github.com/EHfive/ldacBT/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_UNPACK="libldac"
 PKG_LONGDESC="LDAC Bluetooth encoder library (build tools)"


### PR DESCRIPTION
Log:
- https://github.com/EHfive/ldacBT/compare/2.0.2.3...f0c878e19c384ad2284489d28e6da4ea049aff85
- Incorporates cmake build patch