### PR TITLE
Drop eventlircd on all images except Generic-legacy

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -8,7 +8,7 @@ PKG_SHA256="caeba9dfa1eda6f5c80058bd59b81904d98c7d95c7c6ff214f8c01ed1093296c"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.kodi.tv"
 PKG_URL="https://github.com/xbmc/xbmc/archive/${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt nlohmann-json sqlite ffmpeg crossguid libdvdnav libfmt lirc libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libxkbcommon"
+PKG_DEPENDS_TARGET="toolchain JsonSchemaBuilder:host TexturePacker:host Python3 zlib systemd lzo pcre2 swig:host libass curl exiv2 fontconfig fribidi tinyxml tinyxml2 libjpeg-turbo freetype libcdio taglib libxml2 libxslt nlohmann-json sqlite ffmpeg crossguid libdvdnav libfmt libfstrcmp flatbuffers:host flatbuffers libudfread spdlog libxkbcommon"
 PKG_DEPENDS_UNPACK="commons-lang3 commons-text groovy"
 PKG_DEPENDS_HOST="toolchain"
 PKG_LONGDESC="A free and open source cross-platform media player."
@@ -232,6 +232,13 @@ configure_package() {
     KODI_ARCH="-DWITH_ARCH=${TARGET_ARCH}"
   fi
 
+  if [ "${REMOTE_SUPPORT}" = "yes" -a "${DISPLAYSERVER}" = "x11" ]; then
+    KODI_LIRCCLIENT="-DENABLE_LIRCCLIENT=ON"
+    PKG_DEPENDS_TARGET+=" lirc"
+  else
+    KODI_LIRCCLIENT="-DENABLE_LIRCCLIENT=OFF"
+  fi
+
   if [ "${PROJECT}" = "Allwinner" -o "${PROJECT}" = "Rockchip" ]; then
     PKG_PATCH_DIRS+=" drmprime-filter"
   fi
@@ -257,7 +264,7 @@ configure_package() {
                          -DENABLE_DBUS=ON \
                          -DENABLE_XSLT=ON \
                          -DENABLE_CCACHE=OFF \
-                         -DENABLE_LIRCCLIENT=ON \
+                         ${KODI_LIRCCLIENT} \
                          -DENABLE_EVENTCLIENTS=ON \
                          -DENABLE_DEBUGFISSION=OFF \
                          -DENABLE_APP_AUTONAME=OFF \

--- a/packages/virtual/remote/package.mk
+++ b/packages/virtual/remote/package.mk
@@ -7,6 +7,10 @@ PKG_VERSION="1"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://www.libreelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain eventlircd libirman v4l-utils evrepeat"
+PKG_DEPENDS_TARGET="toolchain lirc libirman v4l-utils evrepeat"
 PKG_SECTION="virtual"
 PKG_LONGDESC="Meta package for installing various tools needed for remote support"
+
+if [ "${DISPLAYSERVER}" = "x11" ]; then
+  PKG_DEPENDS_TARGET+=" eventlircd"
+fi


### PR DESCRIPTION
With the recent improvements in Kodi's input handling gbm and wayland now have pretty decent support for (IR) remote buttons.

This finally allows us to stop routing remotes through eventlircd which was quite tedious to support and never was perfect either.

The most important benefits for users is that they now can use standard kodi keymapping functions (keyboard.xml or the keymap editor addon) and finally get long-press support, which helps a lot with low-button-count remotes.

OTOH the default button mapping of some of the "special" buttons may now change and users will have to use upstream kodi functionality to map then, and likely a few oddball buttons / keycodes won't be supported in kodi yet.

Adding support for additional keycodes in kodi is fortunately quite easy now and will help Kodi users on other Linux platforms, too.

The only way to find out what's missing is to shake the tree and just do a hard drop of eventlircd, then improve kodi as needed.

While we have some idea which keycodes are used by the rc-core IR remotes (where we have in-kernel keymaps) we have no idea which of these remotes / keycodes are actually used and especially which keycodes are used by the HID (USB/RF, BT, ...) remotes.