### PR TITLE
kodi: add patch to add support for more remote buttons

### DIFF
--- a/packages/mediacenter/kodi/patches/0002-wip-ps3remote-and-other-buttons.patch
+++ b/packages/mediacenter/kodi/patches/0002-wip-ps3remote-and-other-buttons.patch
@@ -1,0 +1,170 @@
+From aebe1c8acfc994a0ea0591883c2043515f79e87f Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 29 Jun 2026 13:16:59 +0200
+Subject: [PATCH 1/4] [input] Map button keys of PS3 BD and other remotes
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ system/keymaps/keyboard.xml           | 5 +++++
+ xbmc/input/keyboard/XBMC_keysym.h     | 5 +++++
+ xbmc/input/keyboard/XBMC_keytable.cpp | 5 +++++
+ xbmc/input/keyboard/XBMC_vkeys.h      | 5 +++++
+ 4 files changed, 20 insertions(+)
+
+diff --git a/system/keymaps/keyboard.xml b/system/keymaps/keyboard.xml
+index 2303b23a48a6..61c24cb4d432 100644
+--- a/system/keymaps/keyboard.xml
++++ b/system/keymaps/keyboard.xml
+@@ -172,6 +172,11 @@
+       <angle/>
+       <goto/>
+       <cable/>
++      <option>ContextMenu</option>
++      <frame_back>analogseekback</frame_back>
++      <frame_forward>analogseekforward</frame_forward>
++      <properties>Info</properties>
++      <mp3>ActivateWindow(Music)</mp3>
+       <dvd>PlayerControl(ShowVideoMenu)</dvd>
+       <tv>ActivateWindow(TVGuide)</tv>
+       <radio>ActivateWindow(RadioChannels)</radio>
+diff --git a/xbmc/input/keyboard/XBMC_keysym.h b/xbmc/input/keyboard/XBMC_keysym.h
+index c7b98816dafd..3593cc50de79 100644
+--- a/xbmc/input/keyboard/XBMC_keysym.h
++++ b/xbmc/input/keyboard/XBMC_keysym.h
+@@ -322,6 +322,11 @@ enum XBMCKey
+   XBMCK_ANGLE = 530,
+   XBMCK_GOTO = 531,
+   XBMCK_CABLE = 532,
++  XBMCK_OPTION = 533,
++  XBMCK_FRAME_BACK = 534,
++  XBMCK_FRAME_FORWARD = 535,
++  XBMCK_PROPERTIES = 536,
++  XBMCK_MP3 = 537,
+ 
+   /*
+    * Extended keypad key symbols for Num Lock state-specific behaviors
+diff --git a/xbmc/input/keyboard/XBMC_keytable.cpp b/xbmc/input/keyboard/XBMC_keytable.cpp
+index d5cc2ee72e80..8dd10adfb72d 100644
+--- a/xbmc/input/keyboard/XBMC_keytable.cpp
++++ b/xbmc/input/keyboard/XBMC_keytable.cpp
+@@ -232,6 +232,11 @@ static const XBMCKEYTABLE XBMCKeyTable[] = {
+     {XBMCK_ANGLE, 0, 0, XBMCVK_ANGLE, "angle"},
+     {XBMCK_GOTO, 0, 0, XBMCVK_GOTO, "goto"},
+     {XBMCK_CABLE, 0, 0, XBMCVK_CABLE, "cable"},
++    {XBMCK_OPTION, 0, 0, XBMCVK_OPTION, "option"},
++    {XBMCK_FRAME_BACK, 0, 0, XBMCVK_FRAME_BACK, "frame_back"},
++    {XBMCK_FRAME_FORWARD, 0, 0, XBMCVK_FRAME_FORWARD, "frame_forward"},
++    {XBMCK_PROPERTIES, 0, 0, XBMCVK_PROPERTIES, "properties"},
++    {XBMCK_MP3, 0, 0, XBMCVK_MP3, "mp3"},
+ 
+     // Function keys
+ 
+diff --git a/xbmc/input/keyboard/XBMC_vkeys.h b/xbmc/input/keyboard/XBMC_vkeys.h
+index 73fb56e3b1e9..c5c4f98b9d24 100644
+--- a/xbmc/input/keyboard/XBMC_vkeys.h
++++ b/xbmc/input/keyboard/XBMC_vkeys.h
+@@ -253,6 +253,11 @@ typedef enum
+   XBMCVK_ANGLE = 0x112,
+   XBMCVK_GOTO = 0x113,
+   XBMCVK_CABLE = 0x114,
++  XBMCVK_OPTION = 0x115,
++  XBMCVK_FRAME_BACK = 0x116,
++  XBMCVK_FRAME_FORWARD = 0x117,
++  XBMCVK_PROPERTIES = 0x118,
++  XBMCVK_MP3 = 0x119,
+ 
+   XBMCVK_LAST = 0x3FF
+ } XBMCVKey;
+-- 
+2.47.3
+
+
+From 7fa05bc4d336d6bd7bc9030f5dd043cf90d4fb9e Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 29 Jun 2026 13:19:00 +0200
+Subject: [PATCH 2/4] [libinput][keyboard] Map button keys of PS3 BD and other
+ remotes
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ xbmc/platform/linux/input/LibInputKeyboard.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/platform/linux/input/LibInputKeyboard.cpp b/xbmc/platform/linux/input/LibInputKeyboard.cpp
+index ec78a931d211..65368e17f0cd 100644
+--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
++++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
+@@ -194,7 +194,11 @@ constexpr auto xkbMap = make_map<xkb_keysym_t, XBMCKey>({
+     {XKB_KEY_XF86Clear, XBMCK_VIDEO_DEFAULT}, // KEY_CLEAR
+     {XKB_KEY_XF86CycleAngle, XBMCK_ANGLE}, // KEY_ANGLE
+     {XKB_KEY_XF86GoTo, XBMCK_GOTO}, // KEY_GOTO
+-    {XKB_KEY_XF86MediaSelectCable, XBMCK_CABLE} // KEY_TV2
++    {XKB_KEY_XF86MediaSelectCable, XBMCK_CABLE}, // KEY_TV2
++    {XKB_KEY_XF86Option, XBMCK_OPTION}, // KEY_OPTION
++    {XKB_KEY_XF86FrameBack, XBMCK_FRAME_BACK}, // KEY_FRAMEBACK
++    {XKB_KEY_XF86FrameForward, XBMCK_FRAME_FORWARD}, // KEY_FRAMEFORWARD
++    {XKB_KEY_SunProps, XBMCK_PROPERTIES} // KEY_PROPS
+ });
+ 
+ constexpr auto logLevelMap = make_map<xkb_log_level, int>({{XKB_LOG_LEVEL_CRITICAL, LOGERROR},
+-- 
+2.47.3
+
+
+From 43bb6e54188b97d36381f6e77d77e2480cdb98f5 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 29 Jun 2026 13:19:26 +0200
+Subject: [PATCH 3/4] [wayland][keyboard] Map button keys of PS3 BD and other
+ remotes
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ xbmc/windowing/wayland/XkbcommonKeymap.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/windowing/wayland/XkbcommonKeymap.cpp b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+index 82ba603d655e..d7f5c17e4a8b 100644
+--- a/xbmc/windowing/wayland/XkbcommonKeymap.cpp
++++ b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+@@ -240,7 +240,11 @@ constexpr auto XkbKeycodeXBMCMappings = make_map<xkb_keycode_t, XBMCKey>({
+     {XKB_KEY_XF86Clear, XBMCK_VIDEO_DEFAULT}, // KEY_CLEAR
+     {XKB_KEY_XF86CycleAngle, XBMCK_ANGLE}, // KEY_ANGLE
+     {XKB_KEY_XF86GoTo, XBMCK_GOTO}, // KEY_GOTO
+-    {XKB_KEY_XF86MediaSelectCable, XBMCK_CABLE} // KEY_TV2
++    {XKB_KEY_XF86MediaSelectCable, XBMCK_CABLE}, // KEY_TV2
++    {XKB_KEY_XF86Option, XBMCK_OPTION}, // KEY_OPTION
++    {XKB_KEY_XF86FrameBack, XBMCK_FRAME_BACK}, // KEY_FRAMEBACK
++    {XKB_KEY_XF86FrameForward, XBMCK_FRAME_FORWARD}, // KEY_FRAMEFORWARD
++    {XKB_KEY_SunProps, XBMCK_PROPERTIES} // KEY_PROPS
+ 
+ #if defined(TARGET_WEBOS)
+     // WebOS remote
+-- 
+2.47.3
+
+
+From 61579860f52117d3ef70fc7a17eb3e1f729636a8 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Mon, 29 Jun 2026 14:31:21 +0200
+Subject: [PATCH 4/4] [linux][keyboard] Add evdev mapping for KEY_MP3
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ xbmc/platform/linux/input/EvdevKeyMapping.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xbmc/platform/linux/input/EvdevKeyMapping.cpp b/xbmc/platform/linux/input/EvdevKeyMapping.cpp
+index 375ec2ece527..0968493f9beb 100644
+--- a/xbmc/platform/linux/input/EvdevKeyMapping.cpp
++++ b/xbmc/platform/linux/input/EvdevKeyMapping.cpp
+@@ -20,6 +20,7 @@ constexpr auto evdevMap = make_map<uint32_t, XBMCKey>({
+     {KEY_SETUP, XBMCK_SETUP},
+     {KEY_LAST, XBMCK_RECALL_LAST},
+     {KEY_LIST, XBMCK_LIST},
++    {KEY_MP3, XBMCK_MP3},
+ 
+     // ambiguously mapped in xkb, map via evdev
+     {KEY_AGAIN, XBMCK_AGAIN},
+-- 
+2.47.3
+


### PR DESCRIPTION
This adds the current state of my WIP remote button kodi branch and adds support for more buttons found on the PS3 BluRay and other remotes.

I'll keep collecting more keycodes during the next few weeks and then PR it to kodi, as a follow-up to https://github.com/xbmc/xbmc/pull/28497