### PR TITLE
snapclient: add configurable "boot delay" and "restart on resume" setting in the addon

### DIFF
--- a/packages/addons/service/snapclient/package.mk
+++ b/packages/addons/service/snapclient/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="snapclient"
 PKG_VERSION="0.35.0"
-PKG_REV="1"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_DEPENDS_TARGET="toolchain alsa-plugins snapcast"

--- a/packages/addons/service/snapclient/source/bin/snapclient.start
+++ b/packages/addons/service/snapclient/source/bin/snapclient.start
@@ -33,6 +33,13 @@ ARGS=""
 [ -n "$sc_p" ] && ARGS="$ARGS --port $sc_p"
 [ -n "$sc_s" ] && ARGS="$ARGS --soundcard $sc_s"
 
+nodelay_toggle="/var/run/snapclient.nodelay"
+
+if [ -n "$sc_delay" -a ! -e "$nodelay_toggle" ]; then
+  touch "$nodelay_toggle"
+  sleep "$sc_delay"
+fi
+
 HOME="$ADDON_HOME" \
 nice -n "$sc_n" \
 /bin/sh -c "snapclient $ARGS > /dev/null"

--- a/packages/addons/service/snapclient/source/resources/language/resource.language.en_gb/strings.po
+++ b/packages/addons/service/snapclient/source/resources/language/resource.language.en_gb/strings.po
@@ -72,3 +72,11 @@ msgstr ""
 msgctxt "#30016"
 msgid "Server"
 msgstr ""
+
+msgctxt "#30017"
+msgid "Service delay"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Delay the snapclient service (default, 5 seconds) to prevent interference with Kodi audio output."
+msgstr ""

--- a/packages/addons/service/snapclient/source/resources/settings.xml
+++ b/packages/addons/service/snapclient/source/resources/settings.xml
@@ -76,6 +76,18 @@
           <default>false</default>
           <control type="toggle"/>
         </setting>
+        <setting id="sc_delay" type="integer" label="30017" help="30018">
+          <level>0</level>
+          <default>5</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>30</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+        </setting>
       </group>
     </category>
     <category id="rasperry pi" label="30009" help="">

--- a/packages/addons/service/snapclient/source/settings-default.xml
+++ b/packages/addons/service/snapclient/source/settings-default.xml
@@ -1,5 +1,6 @@
 <settings version="2">
     <setting id="sc_a" default="true">false</setting>
+    <setting id="sc_delay" default="true">5</setting>
     <setting id="sc_h" default="true"></setting>
     <setting id="sc_k" default="true">false</setting>
     <setting id="sc_l" default="true">0</setting>

--- a/packages/addons/service/snapclient/source/sleep.d/snapclient.power
+++ b/packages/addons/service/snapclient/source/sleep.d/snapclient.power
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+. /etc/profile
+
+SERVICE="service.snapclient"
+oe_setup_addon "$SERVICE"
+
+nodelay_toggle="/var/run/snapclient.nodelay"
+
+case "$1" in
+  pre)
+    if systemctl is-active "$SERVICE" &>/dev/null ; then
+      [ -e "$nodelay_toggle" ] && rm "$nodelay_toggle"
+      systemctl stop "$SERVICE"
+    fi
+    ;;
+  post)
+    if systemctl is-enabled "$SERVICE" &>/dev/null ; then
+      systemctl start "$SERVICE"
+    fi
+    ;;
+esac


### PR DESCRIPTION
This is my take to fix the issue #10752 with the open pull request #10753

I had the same problem / bug:
- HDMI audio output is missing in Kodi when the snapclient addon is installed
- Sound device resets to "no sound" after a resume when opening "system settings / audio" in Kodi

This pull request adds ~~two~~ a settings in the snapclient addon as a possible fix:

- Configurable delay for start on boot which defaults to 5 seconds
  - allows service restart without a delay when the "Stop when Kodi plays" setting is enabled and on reload
- ~~A switch to enable restart on resume (with the configured delay)~~
  - stop the service on suspend and start it again on resume