### PR TITLE
systemd: Add Gmyle/Hama remote to 70-local-keyboard.hwdb

### DIFF
--- a/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
+++ b/packages/sysutils/systemd/hwdb.d/70-local-keyboard.hwdb
@@ -15,6 +15,10 @@ evdev:input:b0005v0957p1001*
  KEYBOARD_KEY_70045=volumeup
  KEYBOARD_KEY_70069=volumedown
 
+# Gmyle / Hama Vista Remote Control
+evdev:input:b0003v05A4p9881*
+ KEYBOARD_KEY_90002=info # "i" and "right mouse" buttons, originally BTN_RIGHT
+
 # all osmc remotes
 evdev:input:b0003v2252p17*
  KEYBOARD_KEY_7000c=kpleftparen
@@ -74,3 +78,4 @@ evdev:input:b0005v5A44p5A44*
  KEYBOARD_KEY_c00e2=volume_mute
  KEYBOARD_KEY_c00e9=period #vol-up
  KEYBOARD_KEY_c00ea=comma #vol-down
+


### PR DESCRIPTION
Both the "i" and "right mouse" buttons on this remote generate BTN_RIGHT with the same 90002 scancode.

Map that to KEY_INFO like we previously did via eventlircd to match the old behaviour.

See https://forum.libreelec.tv/thread/30501-nightly-le13-remote-xml-not-loaded/?postID=206315#post206315

Tested on RPi5 with a Gmyle branded Vista Remote