### PR TITLE
scripts/get_archive: log primary/mirror URL before each download attempt

### DIFF
--- a/scripts/get_archive
+++ b/scripts/get_archive
@@ -34,6 +34,8 @@ NBGET=10
 NBCHKS=2
 while [ ${NBGET} -gt 0 ] && [ ${NBCHKS} -gt 0 ]; do
   for url in "${PKG_URL}" "${PACKAGE_MIRROR}"; do
+    [ "${url}" = "${PKG_URL}" ] && src="primary" || src="mirror"
+    build_msg "CLR_GET" "GET" "${1} [${src}] ${url}"
     rm -f "${PACKAGE}"
     if ${GET_CMD} "${url}"; then
       CALC_SHA256=$(sha256sum "${PACKAGE}" | cut -d" " -f1)
@@ -57,7 +59,7 @@ while [ ${NBGET} -gt 0 ] && [ ${NBCHKS} -gt 0 ]; do
 done
 
 if [ ${NBGET} -eq 0 ] || [ ${NBCHKS} -eq 0 ]; then
-  die "\nCannot get ${1} sources : ${PKG_URL}\nTry later!"
+  die "\nCannot get ${1} sources\n  primary: ${PKG_URL}\n   mirror: ${PACKAGE_MIRROR}\nTry later!"
 else
   build_msg "CLR_INFO" "INFO" "Calculated checksum: ${CALC_SHA256}"
   echo "${PKG_URL}" > "${STAMP_URL}"


### PR DESCRIPTION
Print which URL is being tried (with [primary] or [mirror] label) before each curl invocation, so download failures appear directly beneath the URL that caused them rather than without context.

Also include both URLs in the die message so it is clear both sources were exhausted.

e.g.

    GET      linux (archive)
        GET      linux [primary] https://www.kernel.org/pub/linux/kernel/v7.x/linux-7.1.2.tar.xz
      % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                     Dload  Upload  Total   Spent   Left   Speed
      0      0   0      0   0      0      0      0                              0
    curl: (22) The requested URL returned error: 404
        GET      linux [mirror] https://sources.libreelec.tv/mirror/linux/linux-7.1.2.tar.xz
      % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                     Dload  Upload  Total   Spent   Left   Speed
      0      0   0      0   0      0      0      0                              0
    curl: (22) The requested URL returned error: 404

    Cannot get linux sources
      primary: https://www.kernel.org/pub/linux/kernel/v7.x/linux-7.1.2.tar.xz
       mirror: https://sources.libreelec.tv/mirror/linux/linux-7.1.2.tar.xz