### PR TITLE
compose-data for libxkbcommon

### DIFF
--- a/packages/wayland/libxkbcommon/package.mk
+++ b/packages/wayland/libxkbcommon/package.mk
@@ -25,6 +25,12 @@ else
                            -Denable-wayland=false"
 fi
 
+# non-x11 images do not ship libX11, so pull in its Compose/locale data
+# separately for libxkbcommon dead-key and key-composing support
+if [ ! "${DISPLAYSERVER}" = "x11" ]; then
+  PKG_DEPENDS_TARGET+=" libx11-compose-data"
+fi
+
 pre_configure_target() {
   if [ "${DISPLAYSERVER}" = "x11" ]; then
     TARGET_LDFLAGS="${LDFLAGS} -lXau -lxcb"

--- a/packages/x11/lib/libx11-compose-data/package.mk
+++ b/packages/x11/lib/libx11-compose-data/package.mk
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libx11-compose-data"
+PKG_VERSION="1.8.13"
+PKG_LICENSE="MIT"
+PKG_SITE="https://www.x.org/"
+PKG_URL=""
+PKG_DEPENDS_UNPACK="libX11"
+PKG_DEPENDS_TARGET="toolchain util-macros xtrans libXau libxcb xorgproto"
+PKG_LONGDESC="X11 locale/Compose data (dead-key and key-composing tables) for libxkbcommon, without the rest of libX11."
+PKG_TOOLCHAIN="autotools"
+
+# libxkbcommon's Compose (dead keys, key composing) loads the X11 locale
+# Compose files from /usr/share/X11/locale. On non-x11 display servers libX11
+# is not in the image, so build libX11 here but install only its nls locale
+# data - the same split Debian ships as libx11-data and Gentoo as
+# compose-tables. Keep PKG_VERSION in sync with libX11.
+
+PKG_CONFIGURE_OPTS_TARGET="--disable-loadable-i18n \
+                           --disable-loadable-xcursor \
+                           --enable-xthreads \
+                           --disable-xcms \
+                           --enable-xlocale \
+                           --disable-xlocaledir \
+                           --enable-xkb \
+                           --with-keysymdefdir=${SYSROOT_PREFIX}/usr/include/X11 \
+                           --disable-xf86bigfont \
+                           --enable-malloc0returnsnull \
+                           --disable-specs \
+                           --without-xmlto \
+                           --without-fop \
+                           --enable-composecache \
+                           --disable-lint-library \
+                           --disable-ipv6 \
+                           --without-launchd \
+                           --without-lint"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/libX11/libX11-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+make_target() {
+  make -C nls
+}
+
+makeinstall_target() {
+  make -C nls install DESTDIR="${INSTALL}"
+}


### PR DESCRIPTION
DRAFT PR to address 
- closes #8273 

```
$ du install_pkg/libx11-compose-data-1.8.13/ -sk
1892   install_pkg/libx11-compose-data-1.8.13
``` 

@enen92 - it builds - not sure what needs to be tested/validated - or if it is appropriate to include. Will need to be tidied up, before merge - if it is to be merged.