### PR TITLE
kodi: add PR28529 to fix keyboard layout sorting

### DIFF
--- a/packages/mediacenter/kodi/patches/0003-pr28529-keyboard-layout-sorting.patch
+++ b/packages/mediacenter/kodi/patches/0003-pr28529-keyboard-layout-sorting.patch
@@ -1,0 +1,63 @@
+From a82a280838a6ccc68d0390eabd5b13260a7109a7 Mon Sep 17 00:00:00 2001
+From: Matthias Reichl <hias@horus.com>
+Date: Fri, 3 Jul 2026 21:27:00 +0200
+Subject: [PATCH] [keyboard] Fix keyboard layout sorting
+
+The keyboard layouts have to be sorted by label/description,
+not by value.
+
+While it does not make a difference in KeyboardLayoutManager,
+as label and value are set to the same string, it leads to
+rather weird sorting in libinput:
+
+value is set to the xkb layout, eg "gb" for English (UK)
+and "us" for English (US) which results in both entries
+being very far apart.
+
+The issue was introduces in commit 0028699753f97 "[settings] Add
+possibility to supply properties (name-value-pairs) with setting
+options." which switched the std::pair to StringSettingOption
+and introduced the LayoutSort helper function.
+
+When comparing two pairs the < operator compares the first elements
+(i.e. the label) first and only looks at the second elements if
+the first ones are equal.
+
+LayoutSort however compared the value which didn't match the
+old behaviour.
+
+Fix this both in KeyboardLayoutManager and LibInputSettings so
+that LayoutSort is identical in both files.
+
+Signed-off-by: Matthias Reichl <hias@horus.com>
+---
+ xbmc/input/keyboard/KeyboardLayoutManager.cpp  | 2 +-
+ xbmc/platform/linux/input/LibInputSettings.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/input/keyboard/KeyboardLayoutManager.cpp b/xbmc/input/keyboard/KeyboardLayoutManager.cpp
+index 998b059aa6774..d412d7795a6bc 100644
+--- a/xbmc/input/keyboard/KeyboardLayoutManager.cpp
++++ b/xbmc/input/keyboard/KeyboardLayoutManager.cpp
+@@ -133,7 +133,7 @@ namespace
+ {
+ inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
+ {
+-  return (i.value < j.value);
++  return (i.label < j.label);
+ }
+ } // namespace
+ 
+diff --git a/xbmc/platform/linux/input/LibInputSettings.cpp b/xbmc/platform/linux/input/LibInputSettings.cpp
+index c69264d10d4c4..be9935101d763 100644
+--- a/xbmc/platform/linux/input/LibInputSettings.cpp
++++ b/xbmc/platform/linux/input/LibInputSettings.cpp
+@@ -27,7 +27,7 @@ namespace
+ {
+   inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
+   {
+-    return (i.value < j.value);
++    return (i.label < j.label);
+   }
+ } // unnamed namespace
+ 


### PR DESCRIPTION
This fixes the long standing issue of the keyboard layouts in Settings->System->Input->Hardware keyboard layouts not being properly sorted.

See https://github.com/xbmc/xbmc/issues/28527 and https://github.com/xbmc/xbmc/pull/28529