### PR TITLE
[le12.2] audiodecoder.fluidsynth: update fluidsynth to 2.5.6 and addon (14)

### DIFF
--- a/packages/audio/fluidsynth/package.mk
+++ b/packages/audio/fluidsynth/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fluidsynth"
-PKG_VERSION="2.5.2"
-PKG_SHA256="1dcb13308b3aa383db658c60a7b63d73d0ff4601ccee589582ba7a816475410e"
+PKG_VERSION="2.5.6"
+PKG_SHA256="0825f024c9cf7a18073739b83612d46542ecbfb349ae9147a1e9f08e2d524407"
 PKG_LICENSE="GPL"
 PKG_SITE="http://fluidsynth.org/"
 PKG_URL="https://github.com/FluidSynth/fluidsynth/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.fluidsynth/package.mk
@@ -5,7 +5,7 @@
 PKG_NAME="audiodecoder.fluidsynth"
 PKG_VERSION="20.2.2-Nexus"
 PKG_SHA256="a716b48bbac476caf8500f74a07c5425c515abd9d1cf6e3404830d62cc053a13"
-PKG_REV="13"
+PKG_REV="14"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/xbmc/audiodecoder.fluidsynth"


### PR DESCRIPTION
- backport of #11560