### PR TITLE
spirv-tools: don't treat errors as warnings

### DIFF
--- a/packages/graphics/spirv-tools/package.mk
+++ b/packages/graphics/spirv-tools/package.mk
@@ -16,7 +16,7 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_DEPENDS_UNPACK="spirv-headers"
 PKG_LONGDESC="The SPIR-V Tools project provides an API and commands for processing SPIR-V modules."
 
-PKG_CMAKE_OPTS_HOST="-DSPIRV_SKIP_TESTS=ON"
+PKG_CMAKE_OPTS_HOST="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF"
 
 post_unpack() {
   mkdir -p ${PKG_BUILD}/external/spirv-headers


### PR DESCRIPTION
this fixes compilation on debian 13.