### PR TITLE
rust: update to 1.97.0

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="02a4d7bf424ea28d574fe5b5d29e7ae99b0bc11a5920d8f28fa7408aa6a37992"
+    PKG_SHA256="71f0457abe8fdf9fc048009f867acc27b21e25c8e06a1a3e9a12c637833b6aab"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="6f897eda50fec8836c4c0ccd1fc4073c1830682205b7712f48cd61f507b827e3"
+    PKG_SHA256="d6be52614c82959f9a9138e4369cc5105175090685c79ca2fb68a634dc6a0280"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="ecc53a3c49fab5ab8c9301b3bbc8fb1dff9be6c65287add3f57a0fe8fddfea9e"
+    PKG_SHA256="5c5bc94af02797b699bb7d4e85b356192eab9fb50376053a1e6edf509fcf7129"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="24bd362ff484421cae8be8c4d326fde143a086782e59e21fc7f353a5d04cd630"
+    PKG_SHA256="b6a90dab26527f17e7e395e24b2d79976e30432c41feb073fe920d3b26b709a0"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="37dc4e8f833b592470282d3524e49cad5c88df24e0f5652c46a32bc33ab5a4a7"
+    PKG_SHA256="45cb88efb2c437b99a0cd8d984f4c8b74fec71fded4085c707d2104120a2d6ef"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="1bf4fde5048cca33e6ea00c7471281ed96d792f6923141e3db45072743a1afae"
+    PKG_SHA256="0c43618128a7a6b96b0b04c04cf7b28dd52fb0991a74c9615fbd1a684ff88712"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.96.1"
-PKG_SHA256="d0a9b5198c41868538ae12af28064163551d06dcceab11ef0b1bc9aa6e98b7a7"
+PKG_VERSION="1.97.0"
+PKG_SHA256="1c0855d8982a0fb1d0321b6054b55b732d3b1d17c846841eb7fd0ab37bf276f8"
 PKG_LICENSE="MIT OR Apache-2.0"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -21,7 +21,7 @@ pre_configure_host() {
 configure_host() {
 
   cat >${PKG_BUILD}/config.toml  <<END
-change-id = 148671
+change-id = 154587
 
 [llvm]
 download-ci-llvm = false

--- a/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
+++ b/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
@@ -196,10 +196,10 @@ check with:
  create mode 100644 compiler/rustc_target/src/spec/targets/x86_64_libreelec_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 0601f9d7c2c..0b6a16ce77c 100644
+index d6a9e27c465..b6dc05b8986 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1443,6 +1443,10 @@ macro_rules! supported_targets {
+@@ -1455,6 +1455,10 @@ macro_rules! supported_targets {
  }
  
  supported_targets! {
@@ -273,7 +273,7 @@ index 00000000000..65c9c61f83f
 +}
 diff --git a/compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs b/compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs
 new file mode 100644
-index 00000000000..2a4af4d1c67
+index 00000000000..cbda6d57bde
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs
 @@ -0,0 +1,39 @@
@@ -318,7 +318,7 @@ index 00000000000..2a4af4d1c67
 +}
 diff --git a/compiler/rustc_target/src/spec/targets/armv7ve_libreelec_linux_gnueabihf.rs b/compiler/rustc_target/src/spec/targets/armv7ve_libreelec_linux_gnueabihf.rs
 new file mode 100644
-index 00000000000..2a4af4d1c67
+index 00000000000..cbda6d57bde
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/armv7ve_libreelec_linux_gnueabihf.rs
 @@ -0,0 +1,39 @@

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="4bc079af433c730af16aa90c96777985b86d40c4670670380160bd61626a577f"
+    PKG_SHA256="06a71688ee297515ebc6a815e42c779735c09423b0bed056e0896c80c7295399"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="604f11b6058e1d1a5c7aa709a5f11ba3ce1f9a1ab57b24ab78745d1c1ef39733"
+    PKG_SHA256="dba2c83ebc01bc0ec513ceca1e59b53df2efa35c61e2ff143c5b57a04fe929e8"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="3545a0efad2355ecb0a3b9ac02efee96e27f1f9d24b7ce2fc3f279b2efb0d923"
+    PKG_SHA256="0a8787303c88b018af61b5c53a0c7024d516d175e623eeab35a35eab11dbcad0"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
- rust-std-snapshot: update to 1.97.0
- rustc-snapshot: update to 1.97.0
- cargo-snapshot: update to 1.97.0
- rust: update to 1.97.0
- includes native openssl 4.x support 