### PR TITLE
addons updates

### DIFF
--- a/packages/addons/addon-depends/docker/containerd/package.mk
+++ b/packages/addons/addon-depends/docker/containerd/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="containerd"
-PKG_VERSION="2.3.2"
-PKG_SHA256="1a215ae4acb184192668b21f8b8375ceb6e86f8832a97fe6f7ab53ad79bb2cee"
+PKG_VERSION="2.3.3"
+PKG_SHA256="fcff2096ef20f1bc1d939bc55a8b831ea3eface574463fd7dc770b33ffe317b2"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://containerd.io"
 PKG_URL="https://github.com/containerd/containerd/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="A daemon to control runC, built for performance and density."
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching release https://github.com/containerd/containerd/releases
-export PKG_GIT_COMMIT="fff62f14765df376e5fc36f5a8f8e795b5670f61"
+export PKG_GIT_COMMIT="aad11006b869517fcd3009450b6f82da282e1a9b"
 
 pre_make_target() {
 

--- a/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/bottom/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bottom"
-PKG_VERSION="0.14.3"
-PKG_SHA256="dca5cd43313c7d5c48bd78e95c778943a45b3cc0f418c368f9d2fe5b44456fa9"
+PKG_VERSION="0.14.4"
+PKG_SHA256="c2b2a5bf438d014b2a32fbbd9edc2da634cbdff4b01a2810d5dcb571d3998051"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/ClementTsang/bottom"
 PKG_URL="https://github.com/ClementTsang/bottom/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/screen/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/screen/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="screen"
-PKG_VERSION="5.0.1"
-PKG_SHA256="2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d"
+PKG_VERSION="5.0.2"
+PKG_SHA256="ca9a2c7e240919bc7ac12124593ae4529bb4eb5f7349d8857829b7e3f0b3b332"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://www.gnu.org/software/screen/"
 PKG_URL="https://ftpmirror.gnu.org/screen/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/screen/patches/0001-rename-pty-h-to-screen-pty-h.patch
+++ b/packages/addons/addon-depends/system-tools-depends/screen/patches/0001-rename-pty-h-to-screen-pty-h.patch
@@ -4,6 +4,7 @@ Date: Thu, 29 Aug 2024 09:49:06 +0000
 Subject: [PATCH] rename pty.h to screen-pty.h
 
 diff --git a/display.c b/display.c
+index a3fc962..a52ad1e 100644
 --- a/display.c
 +++ b/display.c
 @@ -47,7 +47,7 @@
@@ -16,18 +17,19 @@ diff --git a/display.c b/display.c
  #include "termcap.h"
  #include "tty.h"
 diff --git a/Makefile.in b/Makefile.in
+index b64a288..5312d97 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -66,7 +66,7 @@
+@@ -67,7 +67,7 @@ screen: $(OFILES)
  	$(CC) $(LDFLAGS) -o $@ $(OFILES) $(LIBS)
  
  .c.o:
 -	$(CC) -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 +	$(CC) -c -I$(srcdir) $(CPPFLAGS) $(CFLAGS) $< -o $@
  
- check: $(TESTBIN)
- 	for f in $(TESTBIN); do \
-@@ -197,12 +197,12 @@
+ check: $(TESTBIN) $(TESTSTANDALONE)
+ 	for f in $(TESTBIN) $(TESTSTANDALONE); do \
+@@ -205,12 +205,12 @@ search.o: search.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
   logfile.h mark.h input.h
  tty.o: tty.c config.h screen.h os.h ansi.h sched.h acls.h comm.h layer.h \
   term.h image.h canvas.h display.h layout.h viewport.h window.h logfile.h \
@@ -42,7 +44,7 @@ diff --git a/Makefile.in b/Makefile.in
   utmp.h
  utmp.o: utmp.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
   layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
-@@ -229,7 +229,7 @@
+@@ -237,7 +237,7 @@ process.o: process.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
  display.o: display.c config.h screen.h os.h ansi.h sched.h acls.h comm.h \
   layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
   logfile.h winmsg.h winmsgbuf.h winmsgcond.h backtick.h encoding.h mark.h \
@@ -52,6 +54,7 @@ diff --git a/Makefile.in b/Makefile.in
   layer.h term.h image.h canvas.h display.h layout.h viewport.h window.h \
   logfile.h
 diff --git a/pty.c b/pty.c
+index 5139403..3ccb03d 100644
 --- a/pty.c
 +++ b/pty.c
 @@ -28,7 +28,7 @@
@@ -64,6 +67,7 @@ diff --git a/pty.c b/pty.c
  #include <sys/ioctl.h>
  
 diff --git a/pty.h b/pty.h
+index f72d6ea..0000000 100644
 --- a/pty.h
 +++ b/pty.h
 @@ -1,11 +0,0 @@
@@ -79,7 +83,9 @@ diff --git a/pty.h b/pty.h
 -
 -#endif /* SCREEN_PTY_H */
 diff --git a/screen-pty.h b/screen-pty.h
---- a/screen-pty.h
+new file mode 100644
+index 0000000..f72d6ea
+--- /dev/null
 +++ b/screen-pty.h
 @@ -0,0 +1,11 @@
 +#ifndef SCREEN_PTY_H
@@ -94,9 +100,10 @@ diff --git a/screen-pty.h b/screen-pty.h
 +
 +#endif /* SCREEN_PTY_H */
 diff --git a/tty.c b/tty.c
+index 3e0f922..ecebe84 100644
 --- a/tty.c
 +++ b/tty.c
-@@ -44,7 +44,7 @@
+@@ -49,7 +49,7 @@
  #include "screen.h"
  #include "fileio.h"
  #include "misc.h"
@@ -106,6 +113,7 @@ diff --git a/tty.c b/tty.c
  #include "tty.h"
  
 diff --git a/window.c b/window.c
+index 68fc006..e97b705 100644
 --- a/window.c
 +++ b/window.c
 @@ -48,7 +48,7 @@
@@ -117,3 +125,6 @@ diff --git a/window.c b/window.c
  #include "resize.h"
  #include "telnet.h"
  #include "termcap.h"
+-- 
+2.53.0
+

--- a/packages/addons/addon-depends/system-tools-depends/screen/patches/0002-Include-pty.h-when-openpty-is-available-so-glibc-bui.patch
+++ b/packages/addons/addon-depends/system-tools-depends/screen/patches/0002-Include-pty.h-when-openpty-is-available-so-glibc-bui.patch
@@ -17,7 +17,7 @@ Comment: Debian enables -Werror=implicit-function-declaration in
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/pty.c b/pty.c
-index 5139403..99d8f4c 100644
+index 3ccb03d..8bee510 100644
 --- a/pty.c
 +++ b/pty.c
 @@ -31,10 +31,11 @@

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/filebrowser/package.mk
+++ b/packages/addons/service/filebrowser/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="filebrowser"
-PKG_VERSION="2.63.17"
-PKG_REV="7"
+PKG_VERSION="2.63.18"
+PKG_REV="8"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://filebrowser.org"
 PKG_DEPENDS_TARGET="toolchain:host"
@@ -15,15 +15,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="c0df6b84944a8d90176e65913a2eacc5d6b50337ecc703ddba88fb72a0a7a060"
+    PKG_SHA256="29b3935c222d91522874e98dfa33195ee7d2acdac5dfbf37c1361a73704a28de"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-arm64-filebrowser.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="9ccf5b3c7fa6c0da28291617f7cbebf90d9715387300733a305b4059a6feb580"
+    PKG_SHA256="79edb6f9b582a0d4df2e126cf6f0a184d725967ada5a064e3d0effd345dbb8b5"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-armv7-filebrowser.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="d463799e80bebff70f2e6faddf8628184b11248722cd0298ca3fd340f98914e9"
+    PKG_SHA256="cd599c34afad0e8e61c577d1061c820bccb7feaa3c5a4477a12db586a1cd93ff"
     PKG_URL="https://github.com/filebrowser/filebrowser/releases/download/v${PKG_VERSION}/linux-amd64-filebrowser.tar.gz"
     ;;
 esac

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="2.0.87"
-PKG_SHA256="379588df24e4961ebef6752fed544c800115e04db78052139d5c36e0104d9189"
-PKG_REV="5"
+PKG_VERSION="2.0.88"
+PKG_SHA256="fbd256f8d1c6b03bcfe5eb0bf694c46c9216d646626acc783742457f2c70bb45"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/prometheus-node-exporter/package.mk
+++ b/packages/addons/service/prometheus-node-exporter/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="prometheus-node-exporter"
-PKG_VERSION="1.11.1"
-PKG_SHA256="d2b5a7740b7526543429b41a5d741bc530277f406f7b121fc64cb3ca583f7387"
-PKG_REV="0"
+PKG_VERSION="1.12.0"
+PKG_SHA256="2b759f480fbb9bb756d051e2c6c0bc5f1a6bfc3720db734b6b5be7f4e24f45d7"
+PKG_REV="1"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/prometheus/node_exporter"
 PKG_URL="https://github.com/prometheus/node_exporter/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="12"
+PKG_REV="13"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"


### PR DESCRIPTION
- docker: update addon (8)
  - containerd: update to 2.3.3
- system-tools: update addon (13)
  - screen: update to 5.0.2
  - bottom: update to 0.14.4
- prometheus-node-exporter: update to 1.12.0 and addon (1)
- minisatip: update to 2.0.88 and addon (6)
- filebrowser: update to 2.63.18 and addon (8)