### PR TITLE
bluez: fix compiler warnings in the QCA9377 hciattach vendor code

### DIFF
--- a/packages/network/bluez/patches/0008-hciattach-rome-fix-compiler-warnings.patch
+++ b/packages/network/bluez/patches/0008-hciattach-rome-fix-compiler-warnings.patch
@@ -1,0 +1,122 @@
+From 4a85f50c6f7f37cda711ffa3daeda655b5c5f57d Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi.heitbaum@gmail.com>
+Date: Sun, 5 Jul 2026 12:00:00 +1000
+Subject: [PATCH] hciattach: rome: fix compiler warnings
+
+Fix warnings emitted by gcc-16 in the QCA9377/Tuffello vendor code added
+by the previous patch:
+
+ - userial_vendor_ioctl(): parenthesise the tcsetattr() assignment so
+   the return value is stored in err, not the result of the comparison
+   (-Wparentheses).
+ - read_bd_address(): pass __func__ for the %s in the two persist-memory
+   failure messages (-Wformat).
+ - rome_get_tlv_file(): drop the unused nvm_tag_len and ibs_value, and
+   guard bdaddr with MODULE_HAS_MAC_ADDR like its only user.
+ - rome_set_baudrate_req(), rome_hci_reset_req(): drop the unused flags.
+ - qca_soc_init(): drop the set-but-unused size.
+---
+ tools/hciattach_rome.c | 19 ++++++++-----------
+ 1 file changed, 8 insertions(+), 11 deletions(-)
+
+diff --git a/tools/hciattach_rome.c b/tools/hciattach_rome.c
+index 1b7a27f..eeae2fa 100644
+--- a/tools/hciattach_rome.c
++++ b/tools/hciattach_rome.c
+@@ -190,7 +190,7 @@ int userial_vendor_ioctl(int fd, userial_vendor_ioctl_op_t op, int *p_data)
+ #endif  //  (BT_WAKE_VIA_USERIAL_IOCTL==TRUE)
+ 		case USERIAL_OP_FLOW_ON:
+ 			ti.c_cflag |= CRTSCTS;
+-			if (err = tcsetattr(fd, TCSANOW, &ti) < 0) {
++			if ((err = tcsetattr(fd, TCSANOW, &ti)) < 0) {
+ 				perror("Can't set port settings");
+ 				return -1;
+ 			}
+@@ -199,7 +199,7 @@ int userial_vendor_ioctl(int fd, userial_vendor_ioctl_op_t op, int *p_data)
+ 
+ 		case USERIAL_OP_FLOW_OFF:
+ 			ti.c_cflag &= ~CRTSCTS;
+-			if (err = tcsetattr(fd, TCSANOW, &ti) < 0) {
++			if ((err = tcsetattr(fd, TCSANOW, &ti)) < 0) {
+ 				fprintf(stderr, "Can't set port settings");
+ 				return -1;
+ 			}
+@@ -881,7 +881,7 @@ int read_bd_address(unsigned char *bdaddr)
+ 			data[NVITEM], data[RDWR_PROT], data[NVITEM_SIZE]);
+ 	else {
+ 		fprintf(stderr, "%s: Read from persist memory failed : Programming default"
+-			" BD ADDR\n");
++			" BD ADDR\n", __func__);
+ 		close(fd);
+ 		return -1;
+ 	}
+@@ -900,7 +900,7 @@ int read_bd_address(unsigned char *bdaddr)
+ 			data[1], data[2], data[3], data[4], data[5]);
+ 	else {
+ 		fprintf(stderr, "%s: Read from persist memory failed : Programming default"
+-			" BD ADDR\n");
++			" BD ADDR\n", __func__);
+ 		close(fd);
+ 		return -1;
+ 	}
+@@ -962,13 +962,14 @@ int rome_get_tlv_file(char *file_path, unsigned char baud_rate)
+ 	FILE * pFile;
+ 	long fileSize;
+ 	int readSize, nvm_length, nvm_index, i;
+-	unsigned short nvm_tag_len;
+ 	tlv_patch_info *ptlv_header;
+ 	tlv_nvm_hdr *nvm_ptr;
+ 	unsigned char data_buf[PRINT_BUF_SIZE]={0,};
+ 	unsigned char *nvm_byte_ptr;
++#ifndef MODULE_HAS_MAC_ADDR
+ 	unsigned char bdaddr[6];
+-	unsigned short pcm_value, ibs_value;
++#endif
++	unsigned short pcm_value;
+ 	unsigned short deep_sleep_value;
+ 
+ 	pFile = fopen ( file_path , "r" );
+@@ -1051,7 +1052,7 @@ int rome_get_tlv_file(char *file_path, unsigned char baud_rate)
+ 		for(nvm_byte_ptr=(unsigned char *)(nvm_ptr = &(ptlv_header->tlv.nvm)), nvm_index=0;
+ 		    nvm_index < nvm_length ; nvm_ptr = (tlv_nvm_hdr *) nvm_byte_ptr) {
+ 			PR_DBG("TAG ID\t\t\t : %d\n", nvm_ptr->tag_id);
+-			PR_DBG("TAG Length\t\t\t : %d\n", nvm_tag_len = nvm_ptr->tag_len);
++			PR_DBG("TAG Length\t\t\t : %d\n", nvm_ptr->tag_len);
+ 			PR_DBG("TAG Pointer\t\t\t : %d\n", nvm_ptr->tag_ptr);
+ 			PR_DBG("TAG Extended Flag\t\t : %d\n", nvm_ptr->tag_ex_flag);
+ 
+@@ -1642,7 +1643,6 @@ int rome_set_baudrate_req(int fd, unsigned char baud_rate)
+ 	unsigned char cmd[HCI_MAX_CMD_SIZE];
+ 	unsigned char rsp[HCI_MAX_EVENT_SIZE];
+ 	hci_command_hdr *cmd_hdr;
+-	int flags;
+ 
+ 	memset(cmd, 0x0, HCI_MAX_CMD_SIZE);
+ 
+@@ -1694,7 +1694,6 @@ int rome_hci_reset_req(int fd, char baud)
+ 	unsigned char cmd[HCI_MAX_CMD_SIZE];
+ 	unsigned char rsp[HCI_MAX_EVENT_SIZE];
+ 	hci_command_hdr *cmd_hdr;
+-	int flags;
+ 
+ 	memset(cmd, 0x0, HCI_MAX_CMD_SIZE);
+ 
+@@ -1738,7 +1737,6 @@ int qca_soc_init(int fd, int speed, char *bdaddr)
+ {
+ 	int err = -1;
+ 	int ret = 0;
+-	int size;
+ 	unsigned char baud_rate = 0;
+ 
+ 	vnd_userial.fd = fd;
+@@ -1773,7 +1771,6 @@ int qca_soc_init(int fd, int speed, char *bdaddr)
+ 		}
+ 
+ 		/* Send Reset */
+-		size = (HCI_CMD_IND + HCI_COMMAND_HDR_SIZE + EDL_PATCH_CMD_LEN);
+ 		err = rome_rampatch_reset(fd);
+ 		if (err < 0) {
+ 			fprintf(stderr, "Failed to RESET after RAMPATCH upgrade!\n");
+-- 
+2.47.1
+


### PR DESCRIPTION
The carried QCA9377/Tuffello hciattach patch adds tools/hciattach_rome.c from a dead CodeAurora tree that gcc-16 warns about. Add a follow-up patch fixing two real bugs (a tcsetattr assignment/comparison precedence error and a %s with no argument) and dropping six unused locals.