### PR TITLE
rtmpdump: cleanup package.mk

### DIFF
--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -23,7 +23,6 @@ make_target() {
        SHARED=no \
        CRYPTO="OPENSSL" \
        OPT="" \
-       XCFLAGS="${CFLAGS}" \
        XCFLAGS="${CFLAGS} -Wno-unused-but-set-variable -Wno-unused-const-variable" \
        XLDFLAGS="${LDFLAGS}" \
        XLIBS="-lm"
@@ -65,8 +64,4 @@ makeinstall_target() {
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/sbin
-
-  #  # to be removed: hack for "compatibility"
-  #  mkdir -p ${INSTALL}/usr/lib
-  #    ln -sf librtmp.so.1 ${INSTALL}/usr/lib/librtmp.so.0
 }


### PR DESCRIPTION
- drop dead XCFLAGS line overridden on next line

- remove dead commented-out compatibility symlink hack 
  - The librtmp.so.0 compatibility symlink block in post_makeinstall_target was commented out and explicitly marked "to be removed".