### PR TITLE
comskip: fix undefined -lmp3lame references

### DIFF
--- a/packages/addons/addon-depends/comskip/package.mk
+++ b/packages/addons/addon-depends/comskip/package.mk
@@ -7,13 +7,18 @@ PKG_SHA256="bd90d7922916e0b04ea9f3426ea7747d347f218f3f915fb4d251961d0730876e"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://www.kaashoek.com/comskip/"
 PKG_URL="https://github.com/erikkaashoek/Comskip/archive/V${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain argtable2 ffmpegx"
+PKG_DEPENDS_TARGET="toolchain argtable2 ffmpegx lame"
 PKG_DEPENDS_CONFIG="argtable2 ffmpegx"
 PKG_LONGDESC="Comskip detects commercial breaks from a video stream. It can be used for post-processing recordings."
 PKG_TOOLCHAIN="autotools"
 PKG_BUILD_FLAGS="-sysroot -cfg-libs"
 
 pre_configure_target() {
+  # lame is a -sysroot package, so ffmpegx's static libavcodec.a (which
+  # pulls in libmp3lame symbols) can't be resolved without lame's
+  # install path explicitly added here too.
+  LDFLAGS+=" -L$(get_install_dir lame)/usr/lib"
+
   # pass ffmpegx to build
   CFLAGS+=" -I$(get_install_dir ffmpegx)/usr/local/include"
   LDFLAGS+=" -L$(get_install_dir ffmpegx)/usr/local/lib -ldl"


### PR DESCRIPTION
libavcodec.pc pulls in -lmp3lame with no -L (lame is -sysroot), so comskip's link against libavcodec.a fails. Add lame's lib path to LDFLAGS and depend on lame for build ordering.
- fixes #11576 
- https://github.com/LibreELEC/actions/actions/runs/29185163661/job/86629838588