### PR TITLE
meson: never download wrap subprojects

### DIFF
--- a/packages/addons/service/mpd/package.mk
+++ b/packages/addons/service/mpd/package.mk
@@ -24,8 +24,7 @@ PKG_ADDON_ICON_NAME="MPD"
 PKG_ADDON_ICON_SIZE="270"
 PKG_ADDON_TYPE="xbmc.service"
 
-PKG_MESON_OPTS_TARGET="--wrap-mode=nodownload \
-                       -Dadplug=disabled \
+PKG_MESON_OPTS_TARGET="-Dadplug=disabled \
                        -Dalsa=enabled \
                        -Dao=disabled \
                        -Daudiofile=disabled \

--- a/packages/devel/shared-mime-info/package.mk
+++ b/packages/devel/shared-mime-info/package.mk
@@ -19,8 +19,12 @@ configure_package() {
   fi
 }
 
-PKG_MESON_OPTS_HOST="-Dupdate-mimedb=false -Dbuild-spec=false"
-PKG_MESON_OPTS_TARGET="-Dupdate-mimedb=false -Dbuild-spec=false"
+PKG_MESON_OPTS_COMMON="-Dupdate-mimedb=false \
+                       -Dbuild-spec=false \
+                       -Dbuild-tests=false"
+
+PKG_MESON_OPTS_HOST="${PKG_MESON_OPTS_COMMON}"
+PKG_MESON_OPTS_TARGET="${PKG_MESON_OPTS_COMMON}"
 
 post_makeinstall_target() {
   # Create /usr/share/mime/mime.cache

--- a/packages/graphics/gdk-pixbuf/package.mk
+++ b/packages/graphics/gdk-pixbuf/package.mk
@@ -19,8 +19,7 @@ configure_package() {
 }
 
 pre_configure_target() {
-  PKG_MESON_OPTS_TARGET="--wrap-mode=nodownload \
-                         -Ddocumentation=false \
+  PKG_MESON_OPTS_TARGET="-Ddocumentation=false \
                          -Dintrospection=disabled \
                          -Dman=false \
                          -Drelocatable=false \

--- a/packages/tools/flashrom/package.mk
+++ b/packages/tools/flashrom/package.mk
@@ -10,8 +10,7 @@ PKG_URL="https://download.flashrom.org/releases/${PKG_NAME}-v${PKG_VERSION}.tar.
 PKG_DEPENDS_TARGET="toolchain libusb-compat"
 PKG_LONGDESC="flashrom is a utility for identifying, reading, writing, verifying and erasing flash chips. It is designed to flash BIOS/EFI/coreboot/firmware/optionROM images on mainboards, network/graphics/storage controller cards, and various other programmer devices."
 
-PKG_MESON_OPTS_TARGET="--wrap-mode=nodownload \
-                       -Dprogrammer=dummy,serprog,buspirate_spi,pony_spi,linux_mtd,linux_spi"
+PKG_MESON_OPTS_TARGET="-Dprogrammer=dummy,serprog,buspirate_spi,pony_spi,linux_mtd,linux_spi"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/sbin

--- a/scripts/build
+++ b/scripts/build
@@ -174,7 +174,8 @@ TARGET_MESON_OPTS="--prefix=/usr \
                    --libdir=/usr/lib \
                    --libexecdir=/usr/lib \
                    --localstatedir=/var \
-                   --buildtype=${MESON_BUILD_TYPE}"
+                   --buildtype=${MESON_BUILD_TYPE} \
+                   --wrap-mode=nodownload"
 if [ "${BUILD_WITH_DEBUG}" != "yes" ] && flag_enabled "strip" "yes"; then
   TARGET_MESON_OPTS+=" -Dstrip=true"
 fi
@@ -204,7 +205,8 @@ HOST_MESON_OPTS="--prefix=${TOOLCHAIN} \
                  --libdir=${TOOLCHAIN}/lib \
                  --libexecdir=${TOOLCHAIN}/lib \
                  --localstatedir=${TOOLCHAIN}/var \
-                 --buildtype=plain"
+                 --buildtype=plain \
+                 --wrap-mode=nodownload"
 
 # configure INIT build defaults
 INIT_CONFIGURE_OPTS="${TARGET_CONFIGURE_OPTS}"


### PR DESCRIPTION
Set --wrap-mode=nodownload for all meson builds (target, init, host and
bootstrap) so a missing dependency fails loudly instead of silently
fetching a subproject from the network -- as mpd did, pulling lame from
wrapdb when it could not find the -sysroot lame.

Nothing in the tree ships a .wrap or subprojects/ directory, so no
package relies on a subproject fallback.

- shared-mime-info: disable build-tests to avoid xdgmime wrap download
- meson: never download wrap subprojects
  - flashrom: rely on meson buildsystem wrap-mode=nodownload
  - mpd: rely on meson buildsystem wrap-mode=nodownload
  - gdk-pixbuf: rely on meson buildsystem wrap-mode=nodownload

