### PR TITLE
libcec: update to githash bf0380f

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcec"
-PKG_VERSION="62d077c414f415f29a0ea2886ff7c2f79af90f33"
-PKG_SHA256="48c48c38c0aae194a98259bad608f05fb4d857603a95aab3d32da3650e1bcf28"
+PKG_VERSION="bf0380f663a31d8a21d53d9783715dd40cdbccdb"
+PKG_SHA256="c8b9bbe3d859619dc6c5db75ee767ba6630161a178893db96374aa07fa198e80"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://libcec.pulse-eight.com/"
 PKG_URL="https://github.com/Pulse-Eight/libcec/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Log:
- https://github.com/Pulse-Eight/libcec/compare/62d077c414f415f29a0ea2886ff7c2f79af90f33...bf0380f663a31d8a21d53d9783715dd40cdbccdb