### PR TITLE
amlogic: update kodi subs on lima patch

### DIFF
--- a/projects/Amlogic/patches/kodi/0001-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
+++ b/projects/Amlogic/patches/kodi/0001-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
@@ -1,43 +1,43 @@
-From 5a79eaf1ac03eab5f89ab6bb98e55dc4f057b81b Mon Sep 17 00:00:00 2001
+From 42bdab8f22515295f5ecfab9ca2e97fef7c65a12 Mon Sep 17 00:00:00 2001
 From: smf007 <froebe@gmail.com>
 Date: Tue, 21 Mar 2023 11:56:45 -0400
 Subject: [PATCH] Workaround for subtitles on Mali Utgard (lima) devices
 
-Multiply the depth value by 0.99, so that the outmost layers are pushed
+Multiply the depth value by 0.99 so that the outmost layers are pushed
 into the rendering area.
----
- xbmc/guilib/GUIFontTTFGL.cpp | 2 +-
- 1 file changed, 2 insertions(+), 2 deletions(-)
 
- 8 files changed, 9 insertions(+), 8 deletions(-)
+Signed-off-by: smf007 <froebe@gmail.com>
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp | 2 +-
+ xbmc/guilib/GUIFontTTFGLES.cpp                                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
-index 4f4b39b038..237afacc42 100644
+index 99e1bd3ff9..8075f89dab 100644
 --- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
 +++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
-@@ -387,8 +387,8 @@ void COverlayGlyphGLES::Render(SRenderState& state)
+@@ -397,7 +397,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
    glEnableVertexAttribArray(colLoc);
    glEnableVertexAttribArray(tex0Loc);
-
+ 
 -  glUniform1f(depthLoc, -1.0f);
 +  glUniform1f(depthLoc, -0.99f);
-
-   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
-
-   glDisableVertexAttribArray(posLoc);
+ 
+   glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
+   CRenderSystemBase::m_GUIElementCount++;
 diff --git a/xbmc/guilib/GUIFontTTFGLES.cpp b/xbmc/guilib/GUIFontTTFGLES.cpp
-index b8f30136ca..593581e372 100644
+index 6554740fc6..42897ee9df 100644
 --- a/xbmc/guilib/GUIFontTTFGLES.cpp
 +++ b/xbmc/guilib/GUIFontTTFGLES.cpp
-@@ -238,10 +238,10 @@ void CGUIFontTTFGLES::LastEnd()
-       // the gui matrix doesn't align to exact pixel coords atm. correct it here for now.
-       matrix.Translatef(fractX, fractY, 0.0f);
-
+@@ -253,7 +253,7 @@ void CGUIFontTTFGLES::LastEnd()
+ 
        // Apply the depth value of the layer
        float depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth();
 -      glUniform1f(depthLoc, depth);
 +      glUniform1f(depthLoc, depth*0.99f);
-
+ 
        glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
+ 
+-- 
+2.43.0
 
-       // Bind the buffer to the OpenGL context's GL_ARRAY_BUFFER binding point


### PR DESCRIPTION
Some upstream changes for WebOS support require the current temp patch to be regenerated.