### PR TITLE
libcec: revert back to 62d077c

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcec"
-PKG_VERSION="c389bc1cdcac8555a5d37ae9dfb6cc859a80dd69"
-PKG_SHA256="2a8097872c039fa292bdeab2a59dcd4f226017e0411179881e6a8b2947af0647"
+PKG_VERSION="bf0380f663a31d8a21d53d9783715dd40cdbccdb"
+PKG_SHA256="c8b9bbe3d859619dc6c5db75ee767ba6630161a178893db96374aa07fa198e80"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://libcec.pulse-eight.com/"
 PKG_URL="https://github.com/Pulse-Eight/libcec/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcec"
-PKG_VERSION="bf0380f663a31d8a21d53d9783715dd40cdbccdb"
-PKG_SHA256="c8b9bbe3d859619dc6c5db75ee767ba6630161a178893db96374aa07fa198e80"
+PKG_VERSION="62d077c414f415f29a0ea2886ff7c2f79af90f33"
+PKG_SHA256="48c48c38c0aae194a98259bad608f05fb4d857603a95aab3d32da3650e1bcf28"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="http://libcec.pulse-eight.com/"
 PKG_URL="https://github.com/Pulse-Eight/libcec/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
libcec is in the middle of version 8 development and is adding lots of (AI generated) commits almost on a daily basis.

One of the changes now exposes two cec interfaces on RPi4/5 which kodi can't cope with yet .

Revert back to the version before main ver8 development started so we have a stable basis for LE13.

Bumping libcec to version 8 is material for LE14 / Kodi 23 as it'll need kodi changes to handle multiple CEC interfaces