### PR TITLE
linux: remove ancient udev rule to disable USB wakeup

### DIFF
--- a/packages/linux/udev.d/30-disable-wakeup.rules
+++ b/packages/linux/udev.d/30-disable-wakeup.rules
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
-# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
-
-ACTION!="add|change", GOTO="end"
-
-DRIVER=="ehci-pci|xhci_hcd", RUN+="/usr/bin/sh -c 'echo disabled > /sys$devpath/power/wakeup'"
-
-LABEL="end"


### PR DESCRIPTION
The rule was added 12 years ago in OpenELEC 4.1 days as a workaround hoping that it "should fix some more standby issues".

As the ancient eventlircd udev rule that papered around that by enabling wakeup for USB is no longer in place this means wake from USB stayed disabled.

Just drop the udev rule so wakeup by USB keyboards/remotes works again.

Fixes: #11602 