### PR TITLE
https://github.com/LibreELEC/LibreELEC.tv/issues/11602 Remove the legacy udev rule that disables wakeup on the xHCI controller.

### DIFF
--- a/packages/linux/udev.d/30-disable-wakeup.rules
+++ b/packages/linux/udev.d/30-disable-wakeup.rules
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
-# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
-
-ACTION!="add|change", GOTO="end"
-
-DRIVER=="ehci-pci|xhci_hcd", RUN+="/usr/bin/sh -c 'echo disabled > /sys$devpath/power/wakeup'"
-
-LABEL="end"


### PR DESCRIPTION
**Summary**

Remove the legacy udev rule that disables wakeup on the xHCI controller.

**Background**

After the removal of eventlircd, wake-from-suspend stopped working for FLIRC USB receivers on my system.

Investigation showed that the FLIRC itself could be configured for wakeup using a udev rule, but wake still failed because the parent xHCI controller's power/wakeup attribute remained disabled.

The xHCI controller was being disabled by a legacy udev rule. Removing that rule allows the controller to remain wake-capable, restoring the previous behaviour.

**Testing**

Tested on a Beelink mini PC with a FLIRC USB receiver via overriding the rule with an empty file in the ~/.config/udev.rules.d diretory.

**Before this change:**

FLIRC functioned normally as a USB HID keyboard after boot.
Suspend worked.
Wake from the FLIRC did not work.
/sys/bus/pci/devices/0000:00:15.0/power/wakeup was disabled.

**After this change:**

The xHCI controller remains wake-capable.
The FLIRC successfully wakes the system from suspend.
Normal FLIRC operation after boot is unchanged.

This restores the wake-from-suspend behaviour that existed before the eventlircd removal.