### PR TITLE
Package updates

### DIFF
--- a/packages/addons/service/tailscale/package.mk
+++ b/packages/addons/service/tailscale/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tailscale"
-PKG_VERSION="1.98.4"
-PKG_REV="3"
+PKG_VERSION="1.98.9"
+PKG_REV="4"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://tailscale.com"
@@ -20,15 +20,15 @@ PKG_ADDON_TYPE="xbmc.service"
 
 case "${ARCH}" in
   "x86_64")
-    PKG_SHA256="e6c08a8ee7e63e69aaf1b62ecd12672b3883fbcd2a176bf6cfa42a15fdce0b6b"
+    PKG_SHA256="11be30ad301d48f84ff52fec34f8a2f78eb3e3dee1be4e9624d19fccc8df5540"
     TAILSCALE_ARCH="amd64"
     ;;
   "arm")
-    PKG_SHA256="18d4568fe5c72ac31fdac4a8af233770a0357673e6a32f315d04eb0453f495bd"
+    PKG_SHA256="2269fd75206e438d4e56e7d8ae1f48def6a3b1c00717664c861108bdd7fa1e33"
     TAILSCALE_ARCH="arm"
     ;;
   "aarch64")
-    PKG_SHA256="3cb068eb1368b6bb218d0ef0aa0a7a679a7156b7c979e2279cc2c2321b5f05c7"
+    PKG_SHA256="fa554ee808d7d07ee8e3ebbc0215ea087157e2a0abbf408e6e18ea7532554db6"
     TAILSCALE_ARCH="arm64"
     ;;
 esac

--- a/packages/audio/espeak-ng/package.mk
+++ b/packages/audio/espeak-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="espeak-ng"
-PKG_VERSION="fbe4b3764285c35b1f035cb8d09ad9fc19f71c30"
-PKG_SHA256="8a997899a38d55a5035b934539b497ff033a15976ce99377d708929a686ba4c3"
+PKG_VERSION="2152f9c42916612f8cf0fc721aec9905a3c73420"
+PKG_SHA256="798d8d6af592e03dad5da633a1c2b34fb31a05eb973d014c80721fcfa173e169"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/espeak-ng/espeak-ng"
 PKG_URL="https://github.com/espeak-ng/espeak-ng/archive/${PKG_VERSION}.tar.gz"

--- a/packages/devel/mimalloc/package.mk
+++ b/packages/devel/mimalloc/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mimalloc"
-PKG_VERSION="3.4.1"
-PKG_SHA256="37107a52c16baa80c5f74861dddda7b27bb9949e41a6637691867a94c88ca446"
+PKG_VERSION="3.4.3"
+PKG_SHA256="7b043c26b64dde66344d144fbcac3664858a4eb32197793ea2a18feb32741ca1"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/microsoft/mimalloc"
 PKG_URL="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/emulation/libretro-cannonball/package.mk
+++ b/packages/emulation/libretro-cannonball/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-cannonball"
-PKG_VERSION="98cb31638e00f7fb073ed12421dc7358755f47fb"
-PKG_SHA256="9f2f4f6b6be5ffece6fdfe644f9beff2fa030acdd00e29d8dbd3842b5edd8586"
+PKG_VERSION="65cb1f5f227db45abcd9d2006efe7687a0d9cb72"
+PKG_SHA256="40b82778641050d25841735f40f45f23643525dbf410fb1a581768f9cbe8ba14"
 PKG_LICENSE="LicenseRef-MAME"
 PKG_SITE="https://github.com/libretro/cannonball"
 PKG_URL="https://github.com/libretro/cannonball/archive/${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.cannonball/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.cannonball/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro.cannonball"
-PKG_VERSION="0.0.1.39-Omega"
-PKG_SHA256="af9b77bebdfcce96cf24aa7cef11101a0cf65ea53549706aa464f55b010c101b"
-PKG_REV="1"
+PKG_VERSION="0.0.1.40-Omega"
+PKG_SHA256="2a02b908783313856a2adbebcbf1825ec76be2b9cdd26135f6616fe270e75fde"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="LicenseRef-Non-commercial"
 PKG_SITE="https://github.com/kodi-game/game.libretro.cannonball"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libssh"
-PKG_VERSION="0.12.0"
-PKG_SHA256="1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121"
+PKG_VERSION="0.12.1"
+PKG_SHA256="d3941af0a2d78d5d82ed7a36988e9133994312f035b9659a6e43f8db3968784c"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="http://www.libssh.org/"
 PKG_URL="https://www.libssh.org/files/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- tailscale: update to 1.98.9 and addon (4)
- espeak-ng: update to githash 2152f9c
- game.libretro.cannonball: update to 0.0.1.40-Omega and addon (2)
  - libretro-cannonball: update to githash 65cb1f5
- libssh: update to 0.12.1
- mimalloc: update to 3.4.3