### PR TITLE
rockchip: Fix HEVC_EXT_SPS_{ST|LT}_RPS dims

### DIFF
--- a/packages/linux/patches/rockchip/rockchip-0032-FROMGIT-6.20-media-rkvdec-Add-HEVC-support-for-the-V.patch
+++ b/packages/linux/patches/rockchip/rockchip-0032-FROMGIT-6.20-media-rkvdec-Add-HEVC-support-for-the-V.patch
@@ -1196,12 +1196,12 @@ index c988fae85843..ba34a165374a 100644
 +	{
 +		.cfg.id = V4L2_CID_STATELESS_HEVC_EXT_SPS_ST_RPS,
 +		.cfg.ops = &rkvdec_ctrl_ops,
-+		.cfg.dims = { 65 },
++		.cfg.dims = { 64 },
 +	},
 +	{
 +		.cfg.id = V4L2_CID_STATELESS_HEVC_EXT_SPS_LT_RPS,
 +		.cfg.ops = &rkvdec_ctrl_ops,
-+		.cfg.dims = { 65 },
++		.cfg.dims = { 32 },
 +	},
 +};
 +

--- a/packages/linux/patches/rockchip/rockchip-0176-FROMLIST-v3-media-rkvdec-Add-support-for-the-VDPU346.patch
+++ b/packages/linux/patches/rockchip/rockchip-0176-FROMLIST-v3-media-rkvdec-Add-support-for-the-VDPU346.patch
@@ -65,12 +65,12 @@ index 967c452ab61f..ef85151b3593 100644
 +	{
 +		.cfg.id = V4L2_CID_STATELESS_HEVC_EXT_SPS_ST_RPS,
 +		.cfg.ops = &rkvdec_ctrl_ops,
-+		.cfg.dims = { 65 },
++		.cfg.dims = { 64 },
 +	},
 +	{
 +		.cfg.id = V4L2_CID_STATELESS_HEVC_EXT_SPS_LT_RPS,
 +		.cfg.ops = &rkvdec_ctrl_ops,
-+		.cfg.dims = { 65 },
++		.cfg.dims = { 32 },
 +	},
 +};
 +


### PR DESCRIPTION
The values for HEVC_EXT_SPS_ST_RPS and ..._SPS_LT_RPS were not allowed according to the specs, so make those values compliant with the spec. This has been accepted by the upstream maintainer and should therefore land in kernel 7.3.

Link: https://lore.kernel.org/linux-rockchip/20260527194737.1999409-2-michael.bommarito@gmail.com/
Link: https://git.linuxtv.org/media.git/commit?id=f0b9d7e5be061b4858279d451f5a6ad0ed20b1be