### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/docker/cli/package.mk
+++ b/packages/addons/addon-depends/docker/cli/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="cli"
 PKG_VERSION="$(get_pkg_version moby)"
-PKG_SHA256="dabee4ef9d2906e2f1e3c5879f9ee43b38a3449f1017aefd940931ccede0bec7"
+PKG_SHA256="09c72c14870f9c34029942f4c5cf3169b69dc48ea78e7380b5ebaa316356ba1d"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/docker/cli"
 PKG_URL="https://github.com/docker/cli/archive/v${PKG_VERSION}.tar.gz"
@@ -12,7 +12,7 @@ PKG_LONGDESC="The Docker CLI"
 PKG_TOOLCHAIN="manual"
 
 # Git commit of the matching tag https://github.com/docker/cli/tags
-export PKG_GIT_COMMIT="c1eba931e3d15d204bedeadeb55ad8880be14ad3"
+export PKG_GIT_COMMIT="e9452d6e785f6e365712b9d71bd7517591773c86"
 
 configure_target() {
   go_configure

--- a/packages/addons/addon-depends/docker/moby/package.mk
+++ b/packages/addons/addon-depends/docker/moby/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="moby"
-PKG_VERSION="29.7.0"
-PKG_SHA256="0970adb5445056dc763303fea6b38d8f86d06acbabbf6bb1d3bc55c12b57d38e"
+PKG_VERSION="29.7.1"
+PKG_SHA256="e852479cc37cbf151126be1c077bef5e7ceea6c854dd860d46e61004bdf70b76"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://mobyproject.org/"
 PKG_URL="https://github.com/moby/moby/archive/docker-v${PKG_VERSION}.tar.gz"
@@ -13,7 +13,7 @@ PKG_TOOLCHAIN="manual"
 PKG_NO_REFRESH_PATCHES="tools/moby/gen-patches.sh"
 
 # Git commit of the matching release https://github.com/moby/moby
-export PKG_GIT_COMMIT="4b5cb715735a1b7000093bb2ab54295dfedfebfe"
+export PKG_GIT_COMMIT="c5b8ce9274b5c00cb1f8287c8e258edc1f01176d"
 
 PKG_MOBY_BUILDTAGS="daemon \
                     autogen \

--- a/packages/addons/service/docker/package.mk
+++ b/packages/addons/service/docker/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker"
-PKG_REV="11"
+PKG_REV="12"
 PKG_ARCH="any"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="http://www.docker.com/"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="2.0.88"
-PKG_SHA256="fbd256f8d1c6b03bcfe5eb0bf694c46c9216d646626acc783742457f2c70bb45"
-PKG_REV="6"
+PKG_VERSION="2.0.90"
+PKG_SHA256="f84514dbb5b058b7dbace08cd35dc23f8b06f52748c1d71232df3522a14699c7"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="cmake"
-PKG_VERSION="4.4.1"
-PKG_SHA256="95d4721f3625fb0d9d6ca480dd59a46c84b4c157f7fadd2e9b179ef9c871174d"
+PKG_VERSION="4.4.2"
+PKG_SHA256="1db9e61e60b6e0874c86386340b910382f3c5e75b9fbfb44d122063129a2789d"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://cmake.org/"
 PKG_URL="https://cmake.org/files/v$(get_pkg_version_maj_min)/cmake-${PKG_VERSION}.tar.gz"

--- a/packages/graphics/harfbuzz/package.mk
+++ b/packages/graphics/harfbuzz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="harfbuzz"
-PKG_VERSION="14.2.1"
-PKG_SHA256="a54a5d8e9380a41fbb762ce367bcbf7704792dfca0d93f1bbca86c5a57902e0e"
+PKG_VERSION="14.3.0"
+PKG_SHA256="16070d77cfc4ba1f1e7327e83bf9b3f55898081cabdb94e56a33e04fc8874eae"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/HarfBuzz"
 PKG_URL="https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/spirv-llvm-translator/package.mk
+++ b/packages/graphics/spirv-llvm-translator/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="spirv-llvm-translator"
-PKG_VERSION="22.1.4"
-PKG_SHA256="77888f4e22e312d1ac05737407c45dffcc6d0c9c725f9d08bbeb04a6dbe1a5f2"
+PKG_VERSION="22.1.5"
+PKG_SHA256="3c6dffb4b8d67f5c544370e0c869ec7d22c013d4bb798f24655ec903f26cc5d5"
 PKG_LICENSE="NCSA"
 PKG_SITE="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
 PKG_URL="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nano"
-PKG_VERSION="9.1"
-PKG_SHA256="5f47764274cb7532349ce0aa20ec10f1e8e851a6e9fa3eb66812c43d196db042"
+PKG_VERSION="9.2"
+PKG_SHA256="05ecb99247b782e8a5b3a25ed4101dd034b0236902f7449bc9795b717642f7e9"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://www.nano-editor.org/"
 PKG_URL="https://www.nano-editor.org/dist/v${PKG_VERSION%%.*}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- cmake: update to 4.4.2
- harfbuzz: update to 14.3.0
- minisatip: update to 2.0.90 and addon (7)
- docker: update to 29.7.1 and addon (12)
  - cli: update to 29.7.1
  - moby: update to 29.7.1
- spirv-llvm-translator: update to 22.1.5
- nano: update to 9.2