### PR TITLE
externalhelper: bump PKG_REV

### DIFF
--- a/packages/addons/tools/externalhelper/package.mk
+++ b/packages/addons/tools/externalhelper/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="externalhelper"
 PKG_VERSION="0"
-PKG_REV="8"
+PKG_REV="9"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://libreelec.tv"
 PKG_URL=""


### PR DESCRIPTION
We need to roll out a rebuilt version since the libdisplay-info bump to 0.4.0 resulted in a soname change.

See https://forum.libreelec.tv/thread/30549-flatpak-and-retroarch