### PR TITLE
mesa: update to 26.2.0

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mesa"
-PKG_VERSION="26.1.6"
-PKG_SHA256="5296b88a0f1e012e2cb9ada150a2bbadf728ca81e5a4fb2ab43c83a4d2158606"
+PKG_VERSION="26.2.0"
+PKG_SHA256="efd4bb08cdb7c365a812cd4e6c9202ab55b2f22cdcd13c7d6c4f9647b799a4ef"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.mesa3d.org/"
 PKG_URL="https://mesa.freedesktop.org/archive/mesa-${PKG_VERSION}.tar.xz"

--- a/packages/graphics/mesa/patches/mesa-001-fix-addrlib-lgcc-link.patch
+++ b/packages/graphics/mesa/patches/mesa-001-fix-addrlib-lgcc-link.patch
@@ -1,0 +1,11 @@
+--- a/src/gallium/targets/dri/meson.build	2026-07-16 22:43:10.635701052 +0000
++++ b/src/gallium/targets/dri/meson.build	2026-07-16 22:43:19.569121376 +0000
+@@ -47,7 +47,7 @@
+     inc_gallium_winsys, include_directories('../../frontends/dri'),
+   ],
+   gnu_symbol_visibility : 'hidden',
+-  link_args : [ld_args_build_id, ld_args_gc_sections, gallium_dri_ld_args],
++  link_args : [ld_args_build_id, ld_args_gc_sections, gallium_dri_ld_args, '-lgcc'],
+   link_depends : gallium_dri_link_depends,
+   link_with : [
+     libmesa, libgalliumvl,


### PR DESCRIPTION
Release notes:
- https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/26.2.0.rst