### PR TITLE
game.libretro.freechaf: new package

### DIFF
--- a/packages/emulation/libretro-freechaf/package.mk
+++ b/packages/emulation/libretro-freechaf/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-freechaf"
+PKG_VERSION="cb499cd4c29d919e9da80442fa6178bf25c6bbb9"
+PKG_SHA256="138775df617d709139e24378bf9f9b6f2f4705354f6817ac8158d3201684c20d"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/FreeChaF"
+PKG_URL="https://github.com/kodi-game/FreeChaF/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="FreeChaF is a libretro emulation core for the Fairchild Channel F / Video Entertainment System."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="freechaf_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="FREECHAF_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.freechaf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.freechaf/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.freechaf"
+PKG_VERSION="1.0.0.35-Omega"
+PKG_SHA256="cd02af78414f1f7a550f9363d95409dcccb63b1953eb735d1469c21a37d27fa0"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.freechaf"
+PKG_URL="https://github.com/kodi-game/game.libretro.freechaf/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-freechaf"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.freechaf: FreeChaF for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Adds the Fairchild Channel F emulator to the add-on repository.

`game.libretro.freechaf` is present in `kodi-game/repo-binary-addons` on Piers, Omega and Nexus with `platforms: all`, but has never had a package here, so it is unavailable to LibreELEC users.

Two packages, following the shape of the existing `libretro-o2em` / `game.libretro.o2em` pair:

- `packages/emulation/libretro-freechaf` — the core. Version and repository taken from the add-on's `depends/common/freechaf/freechaf.txt`, which is the source `tools/mkpkg/update_retroplayer-addons` reads when bumping.
- `packages/mediacenter/kodi-binary-addons/game.libretro.freechaf` — the Kodi wrapper, at tag `1.0.0.35-Omega` (the newest tag; the add-on has no Piers tag yet, matching the other `game.libretro.*` packages here).

Both carry FreeChaF's licence, GPL-3.0-or-later.

## Testing

- Core builds clean from the pinned tarball with the default `platform=unix` and produces `freechaf_libretro.so`, matching `PKG_LIBNAME`.
- No GL or other optional dependencies, so no conditional `PKG_MAKE_OPTS_TARGET` is needed.
- `PKG_LIBVAR="FREECHAF_LIB"` matches the `find_library` call in the add-on's `CMakeLists.txt`.
- Checksums verified against the tarballs the URLs resolve to.
- Field order and package layout diffed against `libretro-o2em` and `game.libretro.o2em`.

I have not run a full image build for this. Happy to if you'd like it verified end to end before merge.
