### PR TITLE
game.libretro.freeintv, game.libretro.neocd: new packages

### DIFF
--- a/packages/emulation/libretro-freeintv/package.mk
+++ b/packages/emulation/libretro-freeintv/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-freeintv"
+PKG_VERSION="428915baf2bfc032fc03e645f4f8f9c6c3144979"
+PKG_SHA256="bc2826e362f78276c21f696c8bece86257d4a7be7484e96eaa79696016a3aac3"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/libretro/FreeIntv"
+PKG_URL="https://github.com/libretro/FreeIntv/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="FreeIntv is a libretro emulation core for the Mattel Intellivision."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="freeintv_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="FREEINTV_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/emulation/libretro-neocd/package.mk
+++ b/packages/emulation/libretro-neocd/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-neocd"
+PKG_VERSION="9e9ad181bed60f84f9cff02c03617b41e8a31cfe"
+PKG_SHA256="287e16da9c70f5d0797439b6da6583d191027f25dcf6c719d5890539966e6194"
+PKG_LICENSE="LGPL-3.0-only"
+PKG_SITE="https://github.com/libretro/neocd_libretro"
+PKG_URL="https://github.com/libretro/neocd_libretro/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="NeoCD is a libretro emulation core for the SNK Neo Geo CD."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="neocd_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="NEOCD_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.freeintv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.freeintv/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.freeintv"
+PKG_VERSION="1.2.0.37-Omega"
+PKG_SHA256="2e2303c6fc33996e3568b91808cb20537d0399e8100f1395f3652006f53e9196"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.freeintv"
+PKG_URL="https://github.com/kodi-game/game.libretro.freeintv/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-freeintv"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.freeintv: FreeIntv for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.neocd/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.neocd/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.neocd"
+PKG_VERSION="20.22.0.27-Omega"
+PKG_SHA256="58a79c8bf0a963954333039198b89bd45b52089970eb46b8f9d1f24fb556978e"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="LGPL-3.0-only"
+PKG_SITE="https://github.com/kodi-game/game.libretro.neocd"
+PKG_URL="https://github.com/kodi-game/game.libretro.neocd/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-neocd"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.neocd: NeoCD for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Adds Mattel Intellivision and SNK Neo Geo CD to the add-on repository. Neither system currently has any core packaged here.

Both are present in `kodi-game/repo-binary-addons` on Piers, Omega and Nexus with `platforms: all`.

Each follows the shape of the existing `libretro-o2em` / `game.libretro.o2em` pair — a core package under `packages/emulation` plus the Kodi wrapper under `packages/mediacenter/kodi-binary-addons`. Core versions and repositories are taken from each add-on's `depends/common/<name>/<name>.txt`, which is what `tools/mkpkg/update_retroplayer-addons` reads when bumping.

Add-ons are pinned at their newest tags, `1.2.0.37-Omega` and `20.22.0.27-Omega`, matching the `-Omega` suffix used by the other `game.libretro.*` packages here.

## Testing

- Both cores build clean from the pinned tarballs with the default `platform=unix`, producing `freeintv_libretro.so` and `neocd_libretro.so` to match `PKG_LIBNAME`.
- `PKG_LIBVAR` values match the `find_library` calls in each add-on's `CMakeLists.txt` (`FREEINTV_LIB`, `NEOCD_LIB`).
- Neither core has GL or other optional dependencies, so no conditional `PKG_MAKE_OPTS_TARGET` is needed.
- Checksums verified against the tarballs the URLs resolve to.
- Field order and layout diffed against `libretro-o2em` and `game.libretro.o2em`.

I have not run a full image build for these. Happy to if you'd like them verified end to end.

## One note on licences

FreeIntv's `LICENSE` says GPL "version 2 of the License, or (at your option) any later version", so I used `GPL-2.0-or-later` — note this contradicts the add-on's own `addon.xml`, which declares GPLv3. Tell me if you would rather match the add-on.

NeoCD ships the plain LGPL-3.0 text with no explicit "or later" election, so I took the conservative `LGPL-3.0-only`. Happy to change it.
