### PR TITLE
game.libretro.px68k: new package

### DIFF
--- a/packages/emulation/libretro-px68k/package.mk
+++ b/packages/emulation/libretro-px68k/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-px68k"
+PKG_VERSION="45dfd4005434d1199b01fb74a5371ec9bc513164"
+PKG_SHA256="294a496e5ec20173f0496c8d7477e5575dc734791258ef598a0beb86cec293c1"
+PKG_LICENSE="LicenseRef-Non-commercial"
+PKG_SITE="https://github.com/libretro/px68k-libretro"
+PKG_URL="https://github.com/libretro/px68k-libretro/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="PX68k is a libretro emulation core for the Sharp X68000."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="px68k_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="PX68K_LIB"
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.px68k/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.px68k/package.mk
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.px68k"
+PKG_VERSION="0.15.0.36-Omega"
+PKG_SHA256="37bbb2ed218b8117824d11ee95e00c15511a7379d36ac2105bc7cbd9657dfead"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="LicenseRef-Non-commercial"
+PKG_SITE="https://github.com/kodi-game/game.libretro.px68k"
+PKG_URL="https://github.com/kodi-game/game.libretro.px68k/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-px68k"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.px68k: PX68k for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Adds Sharp X68000 support to the add-on repository. No X68000 core is currently packaged here.

`game.libretro.px68k` is present in `kodi-game/repo-binary-addons` on Piers, Omega and Nexus with `platforms: all`.

Follows the shape of the existing `libretro-o2em` / `game.libretro.o2em` pair. The core version and repository come from the add-on's `depends/common/px68k/px68k.txt`, which is what `tools/mkpkg/update_retroplayer-addons` reads when bumping. The add-on is pinned at its newest tag, `0.15.0.36-Omega`, matching the `-Omega` suffix used by the other `game.libretro.*` packages here.

## Testing

- Core builds clean from the pinned tarball with the default `platform=unix`, producing `px68k_libretro.so` to match `PKG_LIBNAME`.
- `PKG_LIBVAR="PX68K_LIB"` matches the `find_library` call in the add-on's `CMakeLists.txt`.
- No GL or other optional dependencies, so no conditional `PKG_MAKE_OPTS_TARGET` is needed.
- Checksum verified against the tarball the URL resolves to.
- Field order and layout diffed against `libretro-o2em` and `game.libretro.o2em`.

I have not run a full image build for this.

## Licence

I used `LicenseRef-Non-commercial` to match the add-on's own `addon.xml`, which declares "Custom Non-Commercial" — consistent with how `libretro-fmsx`, `libretro-genplus` and `libretro-snes9x` are handled here.

Worth flagging that this contradicts the core's `COPYING`, which is the plain GPL-2 text, and I could find no non-commercial clause anywhere in the source. I went with the more restrictive of the two claims. Happy to switch to `GPL-2.0-only` if you read it the other way.
