### PR TITLE
kodi: add Mali-Utgard/lima subs workaround patch to Allwinner/Rockchip

### DIFF
--- a/projects/Allwinner/patches/kodi/0001-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
+++ b/projects/Allwinner/patches/kodi/0001-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
@@ -1,0 +1,43 @@
+From 42bdab8f22515295f5ecfab9ca2e97fef7c65a12 Mon Sep 17 00:00:00 2001
+From: smf007 <froebe@gmail.com>
+Date: Tue, 21 Mar 2023 11:56:45 -0400
+Subject: [PATCH] Workaround for subtitles on Mali Utgard (lima) devices
+
+Multiply the depth value by 0.99 so that the outmost layers are pushed
+into the rendering area.
+
+Signed-off-by: smf007 <froebe@gmail.com>
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp | 2 +-
+ xbmc/guilib/GUIFontTTFGLES.cpp                                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+index 99e1bd3ff9..8075f89dab 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+@@ -397,7 +397,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
+   glEnableVertexAttribArray(colLoc);
+   glEnableVertexAttribArray(tex0Loc);
+ 
+-  glUniform1f(depthLoc, -1.0f);
++  glUniform1f(depthLoc, -0.99f);
+ 
+   glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
+   CRenderSystemBase::m_GUIElementCount++;
+diff --git a/xbmc/guilib/GUIFontTTFGLES.cpp b/xbmc/guilib/GUIFontTTFGLES.cpp
+index 6554740fc6..42897ee9df 100644
+--- a/xbmc/guilib/GUIFontTTFGLES.cpp
++++ b/xbmc/guilib/GUIFontTTFGLES.cpp
+@@ -253,7 +253,7 @@ void CGUIFontTTFGLES::LastEnd()
+ 
+       // Apply the depth value of the layer
+       float depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth();
+-      glUniform1f(depthLoc, depth);
++      glUniform1f(depthLoc, depth*0.99f);
+ 
+       glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
+ 
+-- 
+2.43.0
+

--- a/projects/Rockchip/patches/kodi/0003-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
+++ b/projects/Rockchip/patches/kodi/0003-Workaround-for-subtitles-on-Mali-Utgard-lima-devices.patch
@@ -1,0 +1,43 @@
+From 42bdab8f22515295f5ecfab9ca2e97fef7c65a12 Mon Sep 17 00:00:00 2001
+From: smf007 <froebe@gmail.com>
+Date: Tue, 21 Mar 2023 11:56:45 -0400
+Subject: [PATCH] Workaround for subtitles on Mali Utgard (lima) devices
+
+Multiply the depth value by 0.99 so that the outmost layers are pushed
+into the rendering area.
+
+Signed-off-by: smf007 <froebe@gmail.com>
+---
+ xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp | 2 +-
+ xbmc/guilib/GUIFontTTFGLES.cpp                                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+index 99e1bd3ff9..8075f89dab 100644
+--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
++++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+@@ -397,7 +397,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
+   glEnableVertexAttribArray(colLoc);
+   glEnableVertexAttribArray(tex0Loc);
+ 
+-  glUniform1f(depthLoc, -1.0f);
++  glUniform1f(depthLoc, -0.99f);
+ 
+   glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
+   CRenderSystemBase::m_GUIElementCount++;
+diff --git a/xbmc/guilib/GUIFontTTFGLES.cpp b/xbmc/guilib/GUIFontTTFGLES.cpp
+index 6554740fc6..42897ee9df 100644
+--- a/xbmc/guilib/GUIFontTTFGLES.cpp
++++ b/xbmc/guilib/GUIFontTTFGLES.cpp
+@@ -253,7 +253,7 @@ void CGUIFontTTFGLES::LastEnd()
+ 
+       // Apply the depth value of the layer
+       float depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth();
+-      glUniform1f(depthLoc, depth);
++      glUniform1f(depthLoc, depth*0.99f);
+ 
+       glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
The patch is taken from https://github.com/xbmc/xbmc/issues/26889 and is currently included with Amlogic images. Add the same patch to the Allwinner and Rockchip projects as they also have Mali-Utgard using devices. NB: It is not the correct long-term fix, but it will do until Kodi figure out something better, or (less likely) the root cause in lima is resolved.

NB: Untested by me as I have no Allwinner and older Rockchip hardware, but should be good ™️ 

Fixes #11646 