### PR TITLE
Add melonDS and Yaba Sanshiro emulator packages

### DIFF
--- a/packages/emulation/libretro-melonds/package.mk
+++ b/packages/emulation/libretro-melonds/package.mk
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-melonds"
+PKG_VERSION="66b5d2634cd0a79030562811e6e05f5532f800ba"
+PKG_SHA256="8fa494f12a8fe7f20a4ab32ac89a1391f079d41a203d02822b8541e71637a22c"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/libretro/melonDS"
+PKG_URL="https://github.com/libretro/melonDS/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="melonDS is a Nintendo DS emulator, focused on accuracy and performance."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="melonds_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="MELONDS_LIB"
+
+# melonDS also ships a CMakeLists.txt, for its standalone build. Leaving that
+# where the build script looks sends the whole build out-of-tree, and the
+# libretro Makefile is not out there, so point the probe somewhere it finds none
+PKG_CMAKE_SCRIPT="${PKG_BUILD}/no-cmake"
+
+PKG_MAKE_OPTS_TARGET="platform=unix"
+
+if build_with_debug; then
+  PKG_MAKE_OPTS_TARGET+=" DEBUG=1"
+fi
+
+# melonDS' OpenGL renderer is desktop GL only -- its Makefile.common gates the
+# renderer on HAVE_OPENGL and links glsym_gl.c, and the HAVE_OPENGLES3 its
+# platform table sets is never read. So take OpenGL where the project provides
+# it, and the software renderer everywhere else (DS runs well on it)
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  # glvnd provides libOpenGL here, not libGL: there is no GLX on a GBM build
+  PKG_MAKE_OPTS_TARGET+=" GL_LIB=-lOpenGL"
+else
+  PKG_MAKE_OPTS_TARGET+=" DISABLE_OPENGL=1"
+fi
+
+pre_make_target() {
+  # The core's assembly sources carry no .note.GNU-stack, so the linker marks
+  # the whole library as needing an executable stack (GNU_STACK RWE), and Kodi
+  # cannot load it at all:
+  #
+  #   cannot enable executable stack as shared object requires: Invalid argument
+  #
+  # The JIT maps its own executable pages and never runs code from the stack,
+  # so asking for a non-executable one costs nothing.
+  export LDFLAGS="${LDFLAGS} -Wl,-z,noexecstack"
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/emulation/libretro-melonds/package.mk
+++ b/packages/emulation/libretro-melonds/package.mk
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-melonds"
+PKG_VERSION="66b5d2634cd0a79030562811e6e05f5532f800ba"
+PKG_SHA256="8fa494f12a8fe7f20a4ab32ac89a1391f079d41a203d02822b8541e71637a22c"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/libretro/melonDS"
+PKG_URL="https://github.com/libretro/melonDS/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="melonDS is a Nintendo DS emulator, focused on accuracy and performance."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="melonds_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="MELONDS_LIB"
+
+PKG_MAKE_OPTS_TARGET="platform=unix"
+
+
+if build_with_debug; then
+  PKG_MAKE_OPTS_TARGET+=" DEBUG=1"
+fi
+
+# melonDS' OpenGL renderer is desktop GL only -- its Makefile.common gates the
+# renderer on HAVE_OPENGL and links glsym_gl.c, and the HAVE_OPENGLES3 its
+# platform table sets is never read. So take OpenGL where the project provides
+# it, and the software renderer everywhere else (DS runs well on it)
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  # glvnd provides libOpenGL here, not libGL: there is no GLX on a GBM build
+  PKG_MAKE_OPTS_TARGET+=" GL_LIB=-lOpenGL"
+else
+  PKG_MAKE_OPTS_TARGET+=" DISABLE_OPENGL=1"
+fi
+
+post_unpack() {
+  # melonDS ships a CMakeLists.txt for its standalone build. Its presence makes
+  # the build run out of tree, where the libretro Makefile is not.
+  rm -f ${PKG_BUILD}/CMakeLists.txt
+}
+
+pre_make_target() {
+  # The core's assembly sources carry no .note.GNU-stack, so the linker marks
+  # the whole library as needing an executable stack (GNU_STACK RWE), and Kodi
+  # cannot load it at all:
+  #
+  #   cannot enable executable stack as shared object requires: Invalid argument
+  #
+  # The JIT maps its own executable pages and never runs code from the stack,
+  # so asking for a non-executable one costs nothing.
+  export LDFLAGS="${LDFLAGS} -Wl,-z,noexecstack"
+}
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/emulation/libretro-melonds/patches/libretro-melonds-001-allow-building-without-opengl.patch
+++ b/packages/emulation/libretro-melonds/patches/libretro-melonds-001-allow-building-without-opengl.patch
@@ -1,0 +1,23 @@
+melonDS hard-links -lGL on x86, so it cannot be built for a system that only
+provides OpenGL ES. Its OpenGL renderer is desktop-GL only -- Makefile.common
+gates it on HAVE_OPENGL and pulls glsym_gl.c -- so add DISABLE_OPENGL and build
+the software renderer alone.
+
+Submitted upstream: https://github.com/libretro/melonDS/pull/215
+
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -80,8 +80,10 @@ ifeq ($(platform), unix)
+    endif
+    HAVE_THREADS=1
+    ifneq ($(filter $(ARCH),x86 x86_64),)
+-     LIBS += -lGL
+-     HAVE_OPENGL=1
++     ifneq ($(DISABLE_OPENGL), 1)
++       LIBS += -lGL
++       HAVE_OPENGL=1
++     endif
+    endif
+    ifeq ($(ARCH),x86_64)
+       JIT_ARCH=x64

--- a/packages/emulation/libretro-melonds/patches/libretro-melonds-001-allow-building-without-opengl.patch
+++ b/packages/emulation/libretro-melonds/patches/libretro-melonds-001-allow-building-without-opengl.patch
@@ -1,0 +1,28 @@
+From a4e1826a9fe1c985a56d330dd308c91c7b03d3e1 Mon Sep 17 00:00:00 2001
+From: Chris <chris.dixon.78.burnbridge@gmail.com>
+Date: Thu, 07 Aug 2026 10:00:00 +0100
+Subject: [PATCH] allow building without OpenGL
+
+melonDS hard-links -lGL on x86, so it cannot be built for a system that only
+provides OpenGL ES. Its OpenGL renderer is desktop-GL only -- Makefile.common
+gates it on HAVE_OPENGL and pulls glsym_gl.c -- so add DISABLE_OPENGL and build
+the software renderer alone.
+
+Submitted upstream: https://github.com/libretro/melonDS/pull/215
+---
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -80,8 +80,10 @@ ifeq ($(platform), unix)
+    endif
+    HAVE_THREADS=1
+    ifneq ($(filter $(ARCH),x86 x86_64),)
+-     LIBS += -lGL
+-     HAVE_OPENGL=1
++     ifneq ($(DISABLE_OPENGL), 1)
++       LIBS += -lGL
++       HAVE_OPENGL=1
++     endif
+    endif
+    ifeq ($(ARCH),x86_64)
+       JIT_ARCH=x64

--- a/packages/emulation/libretro-yabasanshiro/package.mk
+++ b/packages/emulation/libretro-yabasanshiro/package.mk
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-yabasanshiro"
+PKG_VERSION="f448097b69a6037246a08e9dc09eabaa420d7893"
+PKG_SHA256="4b38c8d05a4a36333c81bf6dce18a7f4d1c38611ec23177211798bc8ee9af109"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/libretro/yabause"
+PKG_URL="https://github.com/libretro/yabause/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Yaba Sanshiro is a Sega Saturn emulator, a fork of Yabause with a hardware renderer."
+PKG_TOOLCHAIN="make"
+
+PKG_LIBNAME="yabasanshiro_libretro.so"
+PKG_LIBPATH="yabause/src/libretro/${PKG_LIBNAME}"
+PKG_LIBVAR="YABASANSHIRO_LIB"
+
+PKG_MAKE_OPTS_TARGET="-C yabause/src/libretro platform=unix GIT_VERSION="
+
+if build_with_debug; then
+  PKG_MAKE_OPTS_TARGET+=" DEBUG=1"
+fi
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  # glvnd provides libOpenGL here, not libGL: there is no GLX on a GBM build
+  PKG_MAKE_OPTS_TARGET+=" GL_LIB=-lOpenGL"
+fi
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  PKG_MAKE_OPTS_TARGET+=" FORCE_GLES=1"
+fi
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp ${PKG_LIBPATH} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.melonds"
+PKG_VERSION="0.9.3.48-Omega"
+PKG_SHA256="9ebbd88a842371171ed732546ef47216600a2c37a004c0adbc2e577c331d8d5b"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.melonds"
+PKG_URL="https://github.com/kodi-game/game.libretro.melonds/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-melonds"
+PKG_DEPENDS_UNPACK="libretro-melonds"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.melonds: melonDS for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.melonds/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.melonds"
+PKG_VERSION="0.9.3.47-Omega"
+PKG_SHA256="42b89621d81f0caacce62b8d5d73bf3c6f14fa91589dd01c0aa23f5716bed18c"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-3.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.melonds"
+PKG_URL="https://github.com/kodi-game/game.libretro.melonds/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-melonds"
+PKG_DEPENDS_UNPACK="libretro-melonds"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.melonds: melonDS for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabasanshiro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabasanshiro/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.yabasanshiro"
+PKG_VERSION="3.4.2.15-Omega"
+PKG_SHA256="b1ff8b4d99a0204219f2f38c82573ad0ab43be80ccdcc9380627a0192b7a9652"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.yabasanshiro"
+PKG_URL="https://github.com/kodi-game/game.libretro.yabasanshiro/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-yabasanshiro"
+PKG_DEPENDS_UNPACK="libretro-yabasanshiro"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.yabasanshiro: Yaba Sanshiro for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.yabasanshiro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.yabasanshiro/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.yabasanshiro"
+PKG_VERSION="3.4.2.12-Omega"
+PKG_SHA256="5c8ab17ec3bf0590a42176447b1a111bc9e8a8843e4353e3ecdbe0a427c401f5"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.yabasanshiro"
+PKG_URL="https://github.com/kodi-game/game.libretro.yabasanshiro/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-yabasanshiro"
+PKG_DEPENDS_UNPACK="libretro-yabasanshiro"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.yabasanshiro: Yaba Sanshiro for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"


### PR DESCRIPTION
Adds two emulator cores that are not currently packaged: **melonDS** (Nintendo
DS) and **Yaba Sanshiro** (Sega Saturn). Each is the usual pair — a
`libretro-<name>` core package and a `game.libretro.<name>` add-on package.

Core versions are pinned from each add-on's `depends/common/<name>/<name>.txt`,
so they match what the Kodi add-on expects rather than upstream HEAD.

### Yaba Sanshiro

Builds for both renderer flavours. It is one of the few hardware-renderer cores
with a genuine GLES path — with `FORCE_GLES=1` it compiles `glsym_es3.c` and
links `-lGLESv2` — so it works on the GLES projects as well as the OpenGL ones.

### melonDS

Takes OpenGL where the project provides it, and the software renderer
everywhere else. It carries one patch to make that possible.

melonDS links `-lGL` unconditionally on x86, so it cannot build against a
GLES-only sysroot at all (`cannot find -lGL`). There is no GLES fallback in the
core to switch to either: `Makefile.common` gates the renderer on `HAVE_OPENGL`
and compiles `glsym_gl.c`, and the `HAVE_OPENGLES3` its platform table sets for
the ARM boards is never read by the build or by any source — those targets link
`-lGLESv2` but run the software renderer regardless. The patch adds
`DISABLE_OPENGL` so the software renderer can be built cleanly, and is submitted
upstream as https://github.com/libretro/melonDS/pull/215. DS runs well on it.

### Testing

Built for `Generic` / `x86_64` (the default GLES device), all four packages:

| Package | Result |
|---|---|
| `libretro-melonds` | builds, 3.9 MB, no `-lGL` in the link |
| `game.libretro.melonds` | builds, add-on installs |
| `libretro-yabasanshiro` | builds, 2.0 MB, links `-lGLESv2` |
| `game.libretro.yabasanshiro` | builds, add-on installs with buttonmap and topology |

Not tested on ARM projects or on the `OpenGL` device variant.

- https://github.com/libretro/melonDS/pull/215
