### PR TITLE
dtc: don't build libfdt python bindings

### DIFF
--- a/packages/tools/dtc/package.mk
+++ b/packages/tools/dtc/package.mk
@@ -12,8 +12,10 @@ PKG_DEPENDS_HOST="make:host flex:host ninja:host"
 PKG_DEPENDS_TARGET="make:host gcc:host ninja:host"
 PKG_LONGDESC="The Device Tree Compiler"
 
-PKG_MESON_OPTS_TARGET="-Dtests=false"
-PKG_MESON_OPTS_HOST="-Dtests=false"
+PKG_MESON_OPTS_TARGET="-Dtests=false
+                       -Dpython=disabled"
+PKG_MESON_OPTS_HOST="-Dtests=false
+                     -Dpython=disabled"
 
 post_make_host() {
   safe_remove ${PKG_BUILD}/.${HOST_NAME}/libfdt/libfdt.so.*.p


### PR DESCRIPTION
Python bindings are not used in LE and would require swig as additional dependency.

Just disable them which also fixes the currently broken dtc:host builds.