### PR TITLE
glibc: fix the remaining parallel build races from the 2.44 branch

### DIFF
--- a/packages/devel/glibc/patches/0002-Fix-gen-as-const-headers-races-with-the-parallel-sub.patch
+++ b/packages/devel/glibc/patches/0002-Fix-gen-as-const-headers-races-with-the-parallel-sub.patch
@@ -1,0 +1,135 @@
+From 5d1e923ed79185668ac62d19fc37e7e23a3642b6 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 6 Aug 2026 14:07:55 -0300
+Subject: [PATCH] Fix gen-as-const-headers races with the parallel subdir
+ recursion (BZ 34438)
+
+The parallel subdirectory recursion (commit 7cac99621e96) only orders
+csu (and mach/hurd on Hurd) before the parallel fan-out plus the edges
+the Depend files request.  A header generated from gen-as-const-headers
+is only ordered before the compilations of the subdirectory that
+adds the .sym (through before-compile), so a header consumed by a
+different subdirectory may not exist yet when its consumer is
+compiled.
+
+That is the case for <sigaltstack-offsets.h>: it is generated when
+building misc, while its only consumer, ____longjmp_chk.S (x86_64 and
+sh), is built in debug.  The serial recursion always ran misc before
+debug in the sorted order, hiding the missing dependency.
+
+Move the generate the header to 'debug' instead.
+
+The same class of problem exists on Hurd: jmp_buf-ssp.h that is used
+by ____longjmp_chk.S in debug, and signal-defines.h that is sued
+by debug and setjmp.
+
+Deterministically reproduced with 'make debug/subdir_lib' from a clean
+build tree (which orders only csu before debug), and verified with
+builds for x86_64-linux-gnu, sh4-linux-gnu, i686-gnu, and x86_64-gnu.
+Reviewed-by: Sam James <sam@gentoo.org>
+
+(cherry picked from commit 60c9ed0e6b9cce07e85ee56fc39b9afe36919e45)
+---
+ Makerules                               | 12 +++++++++++-
+ sysdeps/mach/hurd/x86/Makefile          |  6 +-----
+ sysdeps/unix/sysv/linux/sh/Makefile     |  4 +++-
+ sysdeps/unix/sysv/linux/x86_64/Makefile |  4 +++-
+ sysdeps/x86/Makefile                    | 10 ++++++++--
+ 5 files changed, 26 insertions(+), 10 deletions(-)
+
+diff --git a/Makerules b/Makerules
+index 6bef57ec..cef30974 100644
+--- a/Makerules
++++ b/Makerules
+@@ -259,7 +259,17 @@ endif  # gen-py-const-headers
+ ifdef gen-as-const-headers
+ # Generating headers for assembly constants.
+ # We need this defined early to get into before-compile before
+-# it's used in sysd-rules, below.
++# it's used in sysd-rules, below.  The gen-as-const-headers is evaluated
++# per subdirectory, so the before-compile dependency below only orders
++# the generated header before the compiles of the subdirectory whose
++# Makefile adds the .sym directive.
++# The parallel subdirectory recursion does not order sibling subdirectories,
++# so a .sym must be added in the subdirectory that compiles its consumers,
++# or in csu (which runs before the parallel) when it has consumers in
++# several subdirectories.
++# It must not add the same .sym in several subdirectories though: their
++# concurrent sub-makes would race generating the header through the fixed
++# temporary files below.
+ # Define GEN_AS_CONST_HEADERS to avoid circular dependency [BZ #22792].
+ # NB: <tcb-offsets.h> is generated from tcb-offsets.sym to define
+ # offsets and sizes of types in <tls.h> and maybe <pthread.h> which
+diff --git a/sysdeps/mach/hurd/x86/Makefile b/sysdeps/mach/hurd/x86/Makefile
+index 97e3287c..1d94f3a1 100644
+--- a/sysdeps/mach/hurd/x86/Makefile
++++ b/sysdeps/mach/hurd/x86/Makefile
+@@ -3,11 +3,7 @@ sysdep_routines += ioperm
+ sysdep_headers += sys/io.h
+ endif
+ 
+-ifeq ($(subdir),debug)
+-gen-as-const-headers += signal-defines.sym
+-endif
+-
+-ifeq ($(subdir),setjmp)
++ifeq ($(subdir),csu)
+ gen-as-const-headers += signal-defines.sym
+ endif
+ 
+diff --git a/sysdeps/unix/sysv/linux/sh/Makefile b/sysdeps/unix/sysv/linux/sh/Makefile
+index dd3b382a..8c4cb738 100644
+--- a/sysdeps/unix/sysv/linux/sh/Makefile
++++ b/sysdeps/unix/sysv/linux/sh/Makefile
+@@ -6,7 +6,9 @@ ifeq ($(subdir),stdlib)
+ gen-as-const-headers += ucontext_i.sym
+ endif
+ 
+-ifeq ($(subdir),misc)
++# <sigaltstack-offsets.h> is only used by ____longjmp_chk.S, which is
++# built in the debug subdirectory.
++ifeq ($(subdir),debug)
+ gen-as-const-headers += sigaltstack-offsets.sym
+ endif
+ 
+diff --git a/sysdeps/unix/sysv/linux/x86_64/Makefile b/sysdeps/unix/sysv/linux/x86_64/Makefile
+index 69383828..528fd951 100644
+--- a/sysdeps/unix/sysv/linux/x86_64/Makefile
++++ b/sysdeps/unix/sysv/linux/x86_64/Makefile
+@@ -10,7 +10,9 @@ ifeq ($(subdir),csu)
+ gen-as-const-headers += ucontext_i.sym
+ endif
+ 
+-ifeq ($(subdir),misc)
++# <sigaltstack-offsets.h> is only used by ____longjmp_chk.S, which is
++# built in the debug subdirectory.
++ifeq ($(subdir),debug)
+ gen-as-const-headers += sigaltstack-offsets.sym
+ endif
+ 
+diff --git a/sysdeps/x86/Makefile b/sysdeps/x86/Makefile
+index 232e388d..b4434deb 100644
+--- a/sysdeps/x86/Makefile
++++ b/sysdeps/x86/Makefile
+@@ -1,5 +1,12 @@
+ ifeq ($(subdir),csu)
+-gen-as-const-headers += cpu-features-offsets.sym features-offsets.sym
++# <jmp_buf-ssp.h> is used by the setjmp/longjmp implementations in the
++# setjmp subdirectory and also by ____longjmp_chk.S in the debug
++# subdirectory.
++gen-as-const-headers += \
++  cpu-features-offsets.sym \
++  features-offsets.sym \
++  jmp_buf-ssp.sym \
++  # gen-as-const-headers
+ endif
+ 
+ ifeq ($(subdir),elf)
+@@ -171,7 +178,6 @@ tests += \
+ endif # $(subdir) == math
+ 
+ ifeq ($(subdir),setjmp)
+-gen-as-const-headers += jmp_buf-ssp.sym
+ sysdep_routines += __longjmp_cancel
+ endif
+ 

--- a/packages/devel/glibc/patches/0003-Makefile-Order-the-top-level-stamp-files-before-the-.patch
+++ b/packages/devel/glibc/patches/0003-Makefile-Order-the-top-level-stamp-files-before-the-.patch
@@ -1,0 +1,45 @@
+From f34027b27fefbc94aab04bff613ba5c24fb909b1 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 6 Aug 2026 14:07:59 -0300
+Subject: [PATCH] Makefile: Order the top-level stamp files before the
+ subdirectory fan-out
+
+The archive rules in Makerules list every stamp file as a prerequisite,
+including the top level's own, and the elf sub-make evaluates them to
+build libc_pic.a for the librtld.map link.  A sub-make can only create
+the stamp files of its own directory, so when the top-level ones do not
+exist yet it fails with:
+
+  make[2]: *** No rule to make target '.../stamp.os', needed by
+  '.../libc_pic.a'.  Stop.
+
+The serial recursion created them before the subdirectories through the
+prerequisite order of subdir_lib; the parallel recursion (commit
+7cac99621e96) does not.  Add them as prerequisites of the object-building
+per-subdirectory targets.
+Reviewed-by: Sam James <sam@gentoo.org>
+
+(cherry picked from commit 25c42d04c45fc5fdb1481a7f968782791b21fd3e)
+---
+ Makefile | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index b9fac6f47c..d559c42873 100644
+--- a/Makefile
++++ b/Makefile
+@@ -575,6 +575,14 @@ $(foreach t,$(+elf_last_subdir_targets),$(eval \
+   elf/$(t): $(addsuffix /$(t),$(filter-out elf,$(subdirs)))))
+ endif
+ 
++# The archive rules in Makerules list every stamp file as a
++# prerequisite of libc_pic.a, which the elf sub-make evaluates for the
++# librtld.map link, but a sub-make can only create its own directory's
++# stamps.  Create the top-level ones before the fan-out.
++$(foreach t,$(+elf_last_subdir_targets),$(eval \
++  $(addsuffix /$(t),$(subdirs)): \
++    $(foreach o,$(object-suffixes-for-libc),$(common-objpfx)stamp$(o))))
++
+ # Pass barriers: a subdirectory 'others' build links programs against
+ # the libraries, so the 'lib' pass (including the top-level libc.so
+ # link) must have completed.

--- a/packages/devel/glibc/patches/0004-Makerules-Make-the-.dt-to-.d-conversion-safe-against.patch
+++ b/packages/devel/glibc/patches/0004-Makerules-Make-the-.dt-to-.d-conversion-safe-against.patch
@@ -1,0 +1,64 @@
+From fc3641194619c7c327ef398c88c07b3069878ed3 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 6 Aug 2026 14:07:58 -0300
+Subject: [PATCH] Makerules: Make the .dt to .d conversion safe against
+ concurrent sub-makes
+
+The %.d: %.dt rule seds its input into a fixed temporary name, renames
+it into place and removes the input.  Two makes converting the same
+file trip over each other:
+
+  mv: cannot stat '.../test-double-libmvec-sincos-avx512f.o.T': No such file or directory
+  sed: can't read .../test-float-libmvec-acosf-avx512f.o.dt: No such file or directory
+
+That happens because the elf rtld-Rules recursion runs a sub-make over
+every $(rtld-subdirs) directory, which converts that directory's .dt
+files, and the parallel subdirectory recursion (commit 7cac99621e96)
+runs it concurrently with those subdirectories' own sub-makes.
+
+Add the PID of the shell to the temporary name and claim the input with
+a rename: only the run that wins converts and installs the target.
+Reviewed-by: Sam James <sam@gentoo.org>
+
+(cherry picked from commit ba8c8801be7674cc12406914184516a811ac22a8)
+---
+ Makerules | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/Makerules b/Makerules
+index 5f65f3ab9e..be51154bae 100644
+--- a/Makerules
++++ b/Makerules
+@@ -755,10 +755,20 @@ all-dt-files := $(foreach o,$(object-suffixes-for-libc),$(+depfiles:.d=$o.dt))
+ 	     $(wildcard $(all-dt-files:.dt=.d))
+ 
+ # This is a funny rule in that it removes its input file.
++#
++# More than one make can convert the .dt files of a single object
++# directory: the elf rtld-Rules recursion runs a sub-make over every
++# $(rtld-subdirs) directory, concurrently with that directory's own
++# sub-make under the parallel subdir recursion.  Add the PID of the
++# shell to the temporary name and claim the input with a rename: only
++# the run that wins converts and installs the target.
+ %.d: %.dt
+-	@sed $(sed-remove-objpfx) $< > $(@:.d=.T) && \
+-	 mv -f $(@:.d=.T) $@ && \
+-	 rm -f $<
++	@dt=$(@:.d=.T)$$$$; \
++	 if mv -f $< $$dt 2>/dev/null; then \
++	   sed $(sed-remove-objpfx) $$dt > $$dt.new && \
++	   mv -f $$dt.new $@ && \
++	   rm -f $$dt; \
++	 fi
+ 
+ # Avoid the .h.d files for any .sym files whose .h files don't exist yet.
+ # They will be generated when they're needed, and trying too early won't work.
+@@ -1423,7 +1433,7 @@ endef
+ # Also remove the dependencies and generated source files.
+ common-clean: common-mostlyclean
+ 	-rm -f $(addprefix $(objpfx),$(generated))
+-	-rm -f $(objpfx)*.d $(objpfx)*.dt
++	-rm -f $(objpfx)*.d $(objpfx)*.dt $(objpfx)*.T[0-9]*
+ 	-rm -fr $(addprefix $(objpfx),$(generated-dirs))
+ 	-rm -f $(addprefix $(common-objpfx),$(common-generated))
+ 	-rm -f $(gen-as-const-headers:%.sym=$(common-objpfx)%.h)

--- a/packages/devel/glibc/patches/0005-arm-Order-the-rtld-link-after-libgcc-stubs.a.patch
+++ b/packages/devel/glibc/patches/0005-arm-Order-the-rtld-link-after-libgcc-stubs.a.patch
@@ -1,0 +1,44 @@
+From 10e3ce8a57e134c13dd28772de68542b0e3d4e86 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 6 Aug 2026 14:08:00 -0300
+Subject: [PATCH] arm: Order the rtld link after libgcc-stubs.a
+
+The librtld.map and librtld.os link recipes use $(gnulib), which on arm
+contains libgcc-stubs.a through gnulib-arch.  But the archive is only a
+prerequisite of lib-noranlib so the rtld link can run before the archive
+exists:
+
+  ld.bfd: cannot find .../elf/libgcc-stubs.a: No such file or directory
+
+The race seems to predates the parallel subdirectory recursion, which
+only made it observable.
+
+Add the order-only dependency in sysdeps/arm/Makefile rather than in
+elf/Makefile.  Theprerequisite lists expand when the rule is parsed,
+and gnulib-arch is only defined once Makerules includes the sysdeps
+makefiles.
+
+Verified with a build for arm-linux-gnueabihf.
+Reviewed-by: Sam James <sam@gentoo.org>
+
+(cherry picked from commit a33ceb6e96dc8de8d36de1b1f3ec06ceb524d012)
+---
+ sysdeps/arm/Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sysdeps/arm/Makefile b/sysdeps/arm/Makefile
+index 0bb1b6e05b..9042315492 100644
+--- a/sysdeps/arm/Makefile
++++ b/sysdeps/arm/Makefile
+@@ -10,6 +10,11 @@ shared-only-routines += aeabi_unwind_cpp_pr1
+ $(objpfx)libgcc-stubs.a: $(objpfx)aeabi_unwind_cpp_pr1.os
+ 	$(build-extra-lib)
+ 
++# The rtld link recipes in elf/Makefile use $(gnulib), which here
++# includes libgcc-stubs.a, but they cannot name it as a prerequisite:
++# gnulib-arch is only defined once this file is included from Makerules.
++$(objpfx)librtld.map $(objpfx)librtld.os: | $(objpfx)libgcc-stubs.a
++
+ lib-noranlib: $(objpfx)libgcc-stubs.a
+ 
+ ifeq ($(build-shared),yes)


### PR DESCRIPTION
2.44 runs the subdirectory recursion in parallel, which exposed several missing dependencies. Back port the rest of the series from the 2.44 branch so the whole set is covered.
- should fixes build races with `glibc:target` in GHA CI