### PR TITLE
libretro-dolphin, game.libretro.dolphin: new packages

### DIFF
--- a/packages/emulation/libretro-dolphin/package.mk
+++ b/packages/emulation/libretro-dolphin/package.mk
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-dolphin"
+PKG_VERSION="0cd3bb89c29535db9b7552fc86871867ccf5b471"
+PKG_SHA256="4be468f93f13ceaedcfb7bb350d06a6eaab6cc18232fb223c9cc7dffef07a7ec"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/libretro/dolphin"
+# Built by tools/mkpkg/mkpkg_dolphin rather than taken from GitHub directly.
+# Dolphin keeps its dependencies as git submodules and a GitHub archive
+# contains none of them, so the build stops at the first add_subdirectory().
+# The mkpkg tarball is the same sources with the twelve submodules this
+# configuration cannot get any other way already in place.
+PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain systemd bzip2 curl glslang hidapi libusb lz4 pugixml zlib zstd lzo xz libiconv"
+PKG_LONGDESC="Dolphin is a GameCube and Wii emulator."
+PKG_TOOLCHAIN="cmake"
+
+PKG_LIBNAME="dolphin_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="DOLPHIN_LIB"
+
+PKG_CMAKE_OPTS_TARGET="-DLIBRETRO=ON \
+                       -DCMAKE_BUILD_TYPE=Release \
+                       -DENABLE_QT=OFF \
+                       -DENABLE_SDL=OFF \
+                       -DENABLE_TESTS=OFF \
+                       -DENABLE_TESTING=OFF \
+                       -DUSE_DISCORD_PRESENCE=OFF \
+                       -DENABLE_ANALYTICS=OFF \
+                       -DENABLE_AUTOUPDATE=OFF \
+                       -DENABLE_CLI_TOOL=OFF \
+                       -DENABLE_LTO=OFF"
+
+# AUTO rather than ON: Dolphin takes a system library wherever one is found and
+# falls back to the copy under Externals otherwise, which is what the twelve
+# bundled in the tarball are there for. ON makes any library it cannot find on
+# the system a hard error, including the four -- mbedtls, LZO, liblzma and
+# libiconv -- that Dolphin carries in its own tree rather than as submodules.
+PKG_CMAKE_OPTS_TARGET+=" -DUSE_SYSTEM_LIBS=AUTO"
+
+# The nine we do package are required rather than preferred. Under AUTO alone a
+# library that stopped being found would quietly fall back to Externals, where
+# the tarball deliberately has nothing, and the build would fail on a missing
+# source directory rather than say which dependency went away.
+PKG_CMAKE_OPTS_TARGET+=" -DUSE_SYSTEM_BZIP2=ON \
+                         -DUSE_SYSTEM_CURL=ON \
+                         -DUSE_SYSTEM_GLSLANG=ON \
+                         -DUSE_SYSTEM_HIDAPI=ON \
+                         -DUSE_SYSTEM_LIBUSB=ON \
+                         -DUSE_SYSTEM_LZ4=ON \
+                         -DUSE_SYSTEM_PUGIXML=ON \
+                         -DUSE_SYSTEM_ZLIB=ON \
+                         -DUSE_SYSTEM_ZSTD=ON"
+
+# Kodi only negotiates OpenGL and OpenGL ES contexts with a game client, so the
+# Vulkan backend can never be the one selected. Leaving it out also keeps two
+# header-only submodules, Vulkan-Headers and VulkanMemoryAllocator, out of the
+# tarball.
+PKG_CMAKE_OPTS_TARGET+=" -DENABLE_VULKAN=OFF"
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL} libglvnd"
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_EGL=ON"
+fi
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_EGL=ON"
+fi
+
+# No X11 on a GBM image, and the core probes for it rather than being told
+if [ "${DISPLAYSERVER}" = "x11" ]; then
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_X11=ON"
+else
+  PKG_CMAKE_OPTS_TARGET+=" -DENABLE_X11=OFF"
+fi
+
+makeinstall_target() {
+  mkdir -p ${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}
+  cp $(find ${PKG_BUILD}/.${TARGET_NAME} -name ${PKG_LIBNAME} | head -1) \
+     ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" >${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake
+}

--- a/packages/mediacenter/kodi-binary-addons/game.libretro.dolphin/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.dolphin/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="game.libretro.dolphin"
+PKG_VERSION="2606.0.0.34-Omega"
+PKG_SHA256="99d97c61666aa2e990628d26cf3f51c1130b577974d1b821dbaa3b6c16436c9e"
+PKG_REV="1"
+PKG_ARCH="x86_64"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/kodi-game/game.libretro.dolphin"
+PKG_URL="https://github.com/kodi-game/game.libretro.dolphin/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain tinyxml ${MEDIACENTER}:host libretro-dolphin"
+PKG_DEPENDS_UNPACK="libretro-dolphin"
+PKG_SECTION=""
+PKG_LONGDESC="game.libretro.dolphin: Dolphin for Kodi"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.gameclient"

--- a/tools/mkpkg/mkpkg_dolphin
+++ b/tools/mkpkg/mkpkg_dolphin
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+# Dolphin keeps its dependencies as git submodules under Externals/, and a
+# GitHub archive contains none of them. Most can be satisfied by system
+# libraries, but twelve cannot: some are pulled in with a bare
+# add_subdirectory() and have no find_package path at all, and the rest are
+# libraries LibreELEC does not ship. Either way CMake needs the directory to
+# exist before it runs.
+#
+# So this produces one tarball with those twelve already in place, which the
+# libretro-dolphin package consumes like any other versioned source.
+#
+# Usage: ./mkpkg_dolphin [commit]
+
+set -e
+
+GIT_URL="https://github.com/libretro/dolphin.git"
+GIT_DIR="dolphin.git"
+
+# Submodules a Linux libretro build reaches and cannot get any other way.
+#
+# The first six have no system-library option in Dolphin's CMake: cpp-ipc,
+# cpp-optparse, imgui, implot, tinygltf and watcher are added with a bare
+# add_subdirectory(), so USE_SYSTEM_LIBS cannot substitute for them.
+#
+# The last six are ordinary libraries with a find_package path, but LibreELEC
+# does not package them, so the bundled copy is what gets built.
+#
+# Everything else Dolphin needs -- bzip2, curl, glslang, hidapi, libusb, lz4,
+# pugixml, zlib, zstd -- comes from LibreELEC, and the remaining submodules are
+# gated out on this configuration: Qt, SDL and mGBA by ENABLE_QT/ENABLE_SDL,
+# rcheevos by USE_RETRO_ACHIEVEMENTS, miniupnpc by USE_UPNP, spirv_cross by
+# WIN32/APPLE, and wil, FFmpeg-bin, gtest and libadrenotools by platform.
+SUBMODULES="\
+  Externals/cpp-ipc/cpp-ipc \
+  Externals/cpp-optparse/cpp-optparse \
+  Externals/imgui/imgui \
+  Externals/implot/implot \
+  Externals/tinygltf/tinygltf \
+  Externals/watcher/watcher \
+  Externals/enet/enet \
+  Externals/fmt/fmt \
+  Externals/libspng/libspng \
+  Externals/minizip-ng/minizip-ng \
+  Externals/SFML/SFML \
+  Externals/xxhash/xxHash \
+"
+
+echo "getting sources..."
+if [ ! -d "${GIT_DIR}" ]; then
+  git clone "${GIT_URL}" "${GIT_DIR}"
+fi
+
+cd "${GIT_DIR}"
+git fetch
+if [ $# -eq 1 ]; then
+  git checkout "$1"
+else
+  git checkout origin/master
+fi
+GIT_REV=$(git log -n1 --format=%H)
+
+echo "getting submodules..."
+# Named rather than --recursive: the full set pulls Qt and a prebuilt FFmpeg,
+# which this configuration never compiles and which dwarf everything else.
+for module in ${SUBMODULES}; do
+  # A submodule that has been renamed or dropped upstream must stop the build
+  # here, rather than produce a tarball that fails at CMake time
+  if ! git ls-tree "${GIT_REV}" "${module}" | grep -q .; then
+    echo "error: ${module} is not a submodule of ${GIT_REV}" >&2
+    exit 1
+  fi
+  git submodule update --init --depth=1 "${module}"
+done
+cd ..
+
+# Named for the LibreELEC package rather than for Dolphin, so the tarball
+# unpacks straight into the directory the buildsystem expects
+PKG_DIR="libretro-dolphin-${GIT_REV}"
+
+echo "copying sources..."
+rm -rf "${PKG_DIR}"
+mkdir -p "${PKG_DIR}"
+# Excluding the git metadata keeps the tarball to the sources themselves, and
+# leaves nothing that could later be mistaken for a working checkout
+(cd "${GIT_DIR}" && tar cf - --exclude-vcs .) | (cd "${PKG_DIR}" && tar xf -)
+
+echo "packing sources..."
+tar cJf "${PKG_DIR}.tar.xz" "${PKG_DIR}"
+
+echo "remove temporary sourcedir..."
+rm -rf "${PKG_DIR}"
+
+echo
+echo "${PKG_DIR}.tar.xz"
+sha256sum "${PKG_DIR}.tar.xz"


### PR DESCRIPTION
Adds Dolphin, a GameCube and Wii emulator, and its Kodi game client.

Built and tested for Generic/OpenGL x86_64. GameCube runs: a game boots to a
picture and plays, with the core negotiating an OpenGL 3.3 core profile through
RetroPlayer's hardware rendering path.

Two things worth flagging for review:

- **git source, not an archive.** The Externals are submodules and GitHub
  tarballs never carry those, so an archive build stops at the first
  `add_subdirectory()`.
- **no `PKG_GIT_CLONE_DEPTH`.** A shallow clone only fetches the tip of master
  and the pinned commit is an earlier one. Submodules stay shallow, since the
  superproject pins those exactly.

`USE_SYSTEM_LIBS=OFF` so the core builds its bundled Externals rather than
picking up whatever the build host happens to have.
