### PR TITLE
flatpak.chrome: enable for aarch64 as well

### DIFF
--- a/packages/addons/flatpak/flatpak.chrome/package.mk
+++ b/packages/addons/flatpak/flatpak.chrome/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="flatpak.chrome"
 PKG_VERSION="0"
 PKG_REV="0"
-PKG_ARCH="x86_64"
+PKG_ARCH="aarch64 x86_64"
 PKG_LICENSE="LicenseRef-nonfree"
 PKG_SITE="https://www.google.com/chrome/"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
Google finally released Chrome for arm64 and it's available as flatpak, too.