### PR TITLE
Package and Addon updates

### DIFF
--- a/packages/addons/addon-depends/docker/docker-compose/package.mk
+++ b/packages/addons/addon-depends/docker/docker-compose/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="docker-compose"
-PKG_VERSION="5.4.0"
+PKG_VERSION="5.5.0"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://github.com/docker/compose"
 PKG_LONGDESC="Define and run multi-container applications with Docker."
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="fc5d1371f1ec7987e703da94ede49af3fbfb240b83f22991a98511de7bc4b93b"
+    PKG_SHA256="ff42489f5a9b879d5d117c5ffea6defc27390b3286da8ad52cbc9c6ab5df590e"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-aarch64"
     ;;
   "arm")
-    PKG_SHA256="f0c92550db24083a2622e4e980a3fdc13890125962ca09590a86c87ad0b3c536"
+    PKG_SHA256="50a7c5bc659f0d619f71f5600b1f15981b99f86df6167d600e0445ef179d5a06"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-armv7"
     ;;
   "x86_64")
-    PKG_SHA256="837fd1d35bf6a494f41b5b5988269a7be79de337cf1a1a6ff0e45ab51bb4e9be"
+    PKG_SHA256="c57ab918abd5b05ca7e7d0f275875dd1330a695074f309dc9eab1b49efafcd4b"
     PKG_URL="${PKG_SITE}/releases/download/v${PKG_VERSION}/docker-compose-linux-x86_64"
     ;;
 esac

--- a/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/squeezelite/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="squeezelite"
-PKG_VERSION="de709765072a1ef270f63956370c5b25a1ea1159"
-PKG_SHA256="ac1a359153c5020ce36271ccdd7627b0fc9016a90f63fbce223e6424de33e454"
+PKG_VERSION="c7c4248ddd70e47dbfeba0bf4a8a7ec08d8a995c"
+PKG_SHA256="734b8110c35a41b65c54eb033d1d636f65bafc2f7ff070d288b0656147041d01"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/ralph-irving/squeezelite"
 PKG_URL="https://github.com/ralph-irving/squeezelite/archive/${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
+++ b/packages/addons/addon-depends/rsyslog-depends/librelp/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="librelp"
-PKG_VERSION="1.12.0"
-PKG_SHA256="e2e53a9812d06f95d0a311bbfafba78704835de6d7f0ea0fd9c0d94e8eae496a"
+PKG_VERSION="1.13.0"
+PKG_SHA256="58e976e31795d7309cf2d9f37fdc93522daa4a322f5012d7879fed9ebfa40068"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://www.rsyslog.com/category/librelp/"
 PKG_URL="https://download.rsyslog.com/librelp/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/addon-depends/system-tools-depends/tmux/package.mk
+++ b/packages/addons/addon-depends/system-tools-depends/tmux/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2025-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="tmux"
-PKG_VERSION="3.7b"
-PKG_SHA256="87f2e99e3b685973f2ca002ffd6ed7e51a5744f7009daae5a15670b6d532db96"
+PKG_VERSION="3.7c"
+PKG_SHA256="7c60cae9a0e25288e2e24750aafc9e8800fc7fd4555e447e1b29ee4201cfb3bf"
 PKG_LICENSE="ISC"
 PKG_SITE="https://github.com/tmux/tmux/wiki"
 PKG_URL="https://github.com/tmux/tmux/releases/download/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/rsyslog/package.mk
+++ b/packages/addons/service/rsyslog/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rsyslog"
-PKG_VERSION="8.2606.0"
-PKG_SHA256="2574b3f3068e6955eb94ef5643e2b6a5b8585cc8eaa77209ff5cbc1e2e5f71e5"
-PKG_REV="2"
+PKG_VERSION="8.2608.0"
+PKG_SHA256="e3d60c83405268c422f95feec740455a1cc4b911d00bd8424d5d1272bc509b1a"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/rsyslog"

--- a/packages/addons/tools/multimedia-tools/package.mk
+++ b/packages/addons/tools/multimedia-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="multimedia-tools"
 PKG_VERSION="1.0"
-PKG_REV="6"
+PKG_REV="7"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"

--- a/packages/addons/tools/system-tools/package.mk
+++ b/packages/addons/tools/system-tools/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="system-tools"
 PKG_VERSION="1.0"
-PKG_REV="17"
+PKG_REV="18"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-only"
 PKG_SITE="https://libreelec.tv"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.126.1"
-PKG_SHA256="796b57330b08d0b3602d01931f491d4c01c52cd19745b16b129b5306d66d7455"
+PKG_VERSION="3.127"
+PKG_SHA256="0281d5905b17b59caf556d4b2981953efd2b9f92312a9e8879d4deb4220d36cb"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/sysutils/libevdev/package.mk
+++ b/packages/sysutils/libevdev/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libevdev"
-PKG_VERSION="1.13.6"
-PKG_SHA256="73f215eccbd8233f414737ac06bca2687e67c44b97d2d7576091aa9718551110"
+PKG_VERSION="1.13.7"
+PKG_SHA256="0caf824971108f15bb2ad356433bae198d7d3bf1e82d43f63626e069e060bfa6"
 PKG_LICENSE="MIT"
 PKG_SITE="http://www.freedesktop.org/wiki/Software/libevdev/"
 PKG_URL="http://www.freedesktop.org/software/libevdev/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- nss: update to 3.127
- docker-compose: update to 5.5.0
- libevdev: update to 1.13.7
- multimedia-tools: update addon (7)
  - squeezelite: update to githash c7c4248 (2.0.0.1595)
- rsyslog: update to 8.2608.0 and addon (3)
  - librelp: update to 1.13.0
- system-tools: update addon (18)
  - tmux: update to 3.7c