### PR TITLE
Update game libretro to v22.6.0

### DIFF
--- a/packages/emulation/libretro-common/package.mk
+++ b/packages/emulation/libretro-common/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libretro-common"
-PKG_VERSION="5b5a830baa6c72452c1f1d4ac3e2fdd04bfbd267"
-PKG_SHA256="007728cbf8940cb53f867190b77080bc654b285b77e2a79c1404f78ea5e9e8b4"
+PKG_VERSION="879c8d507b0b52e77e27d759239c2b5df1e26dfd"
+PKG_SHA256="b464f796ff9752f9fb53c4ced9a0346e428fdbf7786032abac79d106d7170fcd"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/libretro-common"
 PKG_URL="https://github.com/libretro/libretro-common/archive/${PKG_VERSION}.tar.gz"

--- a/packages/emulation/rcheevos/package.mk
+++ b/packages/emulation/rcheevos/package.mk
@@ -2,12 +2,12 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rcheevos"
-PKG_VERSION="9.2.0"
-PKG_SHA256="c8ed6ca74f905ea0c256250e46cced579922880001337e7c3d3d68179ad89d4e"
+PKG_VERSION="12.3.0"
+PKG_SHA256="bc7ab9985aee7b6a29e3d65492de9371c866236c5873a1c4493ec9cb6d2603d2"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/RetroAchievements/rcheevos"
 PKG_URL="https://github.com/RetroAchievements/rcheevos/archive/v${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain libretro-common"
 PKG_LONGDESC="Library to parse and evaluate achievements and leaderboards for RetroAchievements"
 PKG_BUILD_FLAGS="+pic"
 

--- a/packages/emulation/rcheevos/source/CMakeLists.txt
+++ b/packages/emulation/rcheevos/source/CMakeLists.txt
@@ -1,17 +1,47 @@
+cmake_minimum_required(VERSION 3.0...4.0)
 project(rcheevos)
 
-cmake_minimum_required(VERSION 3.10)
+find_path(LIBRETRO_COMMON_INCLUDE_DIR
+  NAMES libretro.h
+  PATH_SUFFIXES libretro-common
+)
+
+if(NOT LIBRETRO_COMMON_INCLUDE_DIR)
+  message(FATAL_ERROR "libretro-common headers not found")
+endif()
+
+# Compiling statically
+add_definitions(-DRC_STATIC)
 
 # Disable Lua for now
 add_definitions(-DRC_DISABLE_LUA)
 
+# RC_CLIENT_SUPPORTS_HASH gates rc_client_begin_identify_and_load_game(), which
+# the add-on uses to identify a game without knowing its console up front. It
+# has to be defined for the library too, not just for our own translation
+# units, or the function is compiled out and the reference goes unresolved.
+add_definitions(-DRC_CLIENT_SUPPORTS_HASH)
+
 include_directories(
   include
+  src
+  ${LIBRETRO_COMMON_INCLUDE_DIR}
 )
 
 add_library(${PROJECT_NAME}lib
+  src/rapi/rc_api_common.c
+  src/rapi/rc_api_editor.c
+  src/rapi/rc_api_info.c
+  src/rapi/rc_api_runtime.c
+  src/rapi/rc_api_user.c
+  src/rc_client_external.c
+  src/rc_client_raintegration.c
+  src/rc_client.c
+  src/rc_compat.c
+  src/rc_libretro.c
+  src/rc_util.c
+  src/rc_version.c
   src/rcheevos/alloc.c
-  src/rcheevos/compat.c
   src/rcheevos/condition.c
   src/rcheevos/condset.c
   src/rcheevos/consoleinfo.c
@@ -19,24 +49,21 @@ add_library(${PROJECT_NAME}lib
   src/rcheevos/lboard.c
   src/rcheevos/memref.c
   src/rcheevos/operand.c
+  src/rcheevos/rc_validate.c
   src/rcheevos/richpresence.c
-  src/rcheevos/runtime.c
   src/rcheevos/runtime_progress.c
+  src/rcheevos/runtime.c
   src/rcheevos/trigger.c
   src/rcheevos/value.c
+  src/rhash/aes.c
   src/rhash/cdreader.c
+  src/rhash/hash_disc.c
+  src/rhash/hash_encrypted.c
+  src/rhash/hash_rom.c
+  src/rhash/hash_zip.c
   src/rhash/hash.c
   src/rhash/md5.c
-  src/rurl/url.c
 )
-
-#add_dependencies(rcheevos
-#  lua # TODO
-#)
-
-#target_link_libraries(rcheevos
-#  lua
-#)
 
 install(TARGETS
   ${PROJECT_NAME}lib
@@ -48,17 +75,22 @@ install(TARGETS
 
 install(
   FILES
+    include/rc_api_editor.h
+    include/rc_api_info.h
+    include/rc_api_request.h
+    include/rc_api_runtime.h
+    include/rc_api_user.h
+    include/rc_client_raintegration.h
+    include/rc_client.h
+    include/rc_consoles.h
+    include/rc_error.h
+    include/rc_export.h
+    include/rc_hash.h
+    include/rc_runtime_types.h
+    include/rc_runtime.h
+    include/rc_util.h
     include/rcheevos.h
-    include/rconsoles.h
-    include/rhash.h
-    include/rurl.h
+    src/rc_libretro.h
   DESTINATION
     include/${PROJECT_NAME}
 )
-
-#install(
-#  DIRECTORY
-#    include
-#  DESTINATION
-#    include
-#)

--- a/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="game.libretro"
-PKG_VERSION="22.5.0-Piers"
-PKG_SHA256="b1f34377f6d98692355fc4215393942ae9cdf63badd85d55609201c9024d69b6"
+PKG_VERSION="22.6.0-Piers"
+PKG_SHA256="dc1d6d0c2467f55de910b86708ed209515aa168edd5d2d5215fb4b5fe012cbd6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"


### PR DESCRIPTION
## Description

This PR updates game.libretro, and its dependencies, for the latest Game API breaking changes in the Game API 7.2.0.

Changes since v22.5.0:

  * Updated to Game API v7.2.0
  * Updated rcheevos to v12.3.0
  * Updated libretro-common to latest git
  * Updated libretro settings API to core options v2
  * Fixed cores using previous core's system/save directories
  * Fixed silent gameplay for emulators with async audio
  * Fixed discarding audio frames at the start of a stream
  * Fixed changing FPS/samplerate not taking effect
  * Fixed possible crash when connecting/disconnecting controller
  * Fixed "stuck" analog triggers
  * Updated Czech language strings

Probably to be merged after Kodi is rebased on top of https://github.com/xbmc/xbmc/pull/29020.

## How has this been tested?

Building LE succeeds:

```
INSTALL      rcheevos (target)
INSTALL      game.libretro (target)
```

Included in latest round of test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22beta2-20260819