### PR TITLE
wsdd2: update to d7c9e1c and install our own unit

### DIFF
--- a/packages/network/wsdd2/package.mk
+++ b/packages/network/wsdd2/package.mk
@@ -2,15 +2,24 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wsdd2"
-PKG_VERSION="1.8.7"
-PKG_SHA256="b0b6b31522f4a5e39d075b31d59d57af9a567f543e0b39b2fbdfec324d30310a"
+PKG_VERSION="d7c9e1c5626010d406f36a05c7d51314deb7868c" # 1.8.7 + fixes
+PKG_SHA256="c96feddef2d95f9e7211a1aacf4e80ffc6aa660e827c5283cbf0c678d7e33e76"
 PKG_LICENSE="GPL-3.0-or-later"
-PKG_SITE="https://github.com/Netgear/wsdd2/"
-PKG_URL="https://github.com/Netgear/wsdd2/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/oldium/wsdd2"
+PKG_URL="https://github.com/oldium/wsdd2/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="make:host gcc:host"
 PKG_LONGDESC="WSD/LLMNR Discovery/Name Service Daemon"
 PKG_BUILD_FLAGS="+size"
 
+post_makeinstall_target() {
+  # our own unit is installed from system.d - upstream's has no ordering,
+  # no guard on the generated smb.conf and is wanted by multi-user.target
+  safe_remove ${INSTALL}/usr/lib/systemd/system/wsdd2.service
+}
+
 post_install() {
+  sed -e "/^ExecStart=/s|@MODEL@|${DEVICE:-${PROJECT}}|" \
+      -i ${INSTALL}/usr/lib/systemd/system/wsdd2.service
+
   enable_service wsdd2.service
 }

--- a/packages/network/wsdd2/patches/0001-set_getresp-parse-the-boot-info-values-correctly.patch
+++ b/packages/network/wsdd2/patches/0001-set_getresp-parse-the-boot-info-values-correctly.patch
@@ -1,0 +1,83 @@
+From 056631cfeff05f1cb4cc504f13c6d501c963ecae Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi.heitbaum@sparknel-dc.com.au>
+Date: Fri, 21 Aug 2026 18:49:28 +1000
+Subject: [PATCH 1/2] set_getresp: parse the boot info values correctly
+
+Two defects leave -b unusable for anything but a single key with a
+colon-free value, and the grammar it accepts was never written down,
+which is why neither was noticed.
+
+The value is copied with strndup(val, vallen + 1), one byte past its
+end. The byte taken is whatever ended the value, so every pair but the
+last - whose value ends at the terminating NUL - carries the separating
+comma into the value itself. "-b vendor:ACME,model:Widget" advertises
+the vendor as "ACME," in the ThisModel metadata, and reversing the two
+pairs moves the stray comma onto the model instead. Nothing reads out
+of bounds, the value is simply wrong.
+
+A value also ends at a colon as well as a comma, and a value followed
+by a colon is rejected outright, so no value may contain one. Three of
+the seven keys in the table are URLs, which makes those three
+impossible to set at all: "-b vendorurl:https://example.com" exits with
+"Bad key:val '://example.com'". Since the key has already been
+delimited by the first colon or blank, a colon after it is unambiguous,
+so let only a comma end a value.
+
+That does mean a pair whose comma is left out, as in
+"-b vendor:model:Widget", now sets the vendor to "model:Widget" rather
+than reporting an error. Weighed against three keys that cannot be
+expressed, the trade seems worth making.
+
+Document the grammar in wsdd2.8 so the accepted form is stated rather
+than implied.
+---
+ wsd.c   | 10 +++++-----
+ wsdd2.8 |  6 ++++++
+ 2 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/wsd.c b/wsd.c
+index 0337321..ef25c5d 100644
+--- a/wsd.c
++++ b/wsd.c
+@@ -213,11 +213,11 @@ int set_getresp(const char *str, const char **next)
+ 		goto exit;
+ 	val = p;
+ 
+-	/* Look for end of value. */
+-	while (*p && *p != ':' && *p != ',')
++	/* Look for end of value.  Only a comma ends a value: the key was
++	   already delimited by the first colon, so a colon here belongs to
++	   the value, as it does in every URL the table accepts. */
++	while (*p && *p != ',')
+ 		p++;
+-	if (*p && *p != ',')
+-		goto exit;
+ 
+ 	vallen = p - val;
+ 	if (next)
+@@ -232,7 +232,7 @@ int set_getresp(const char *str, const char **next)
+ 		return -1;
+ 
+ 	if (!bootinfo[i].value)
+-		bootinfo[i].value = strndup(val, vallen + 1);
++		bootinfo[i].value = strndup(val, vallen);
+ 
+ 	return 0;
+ 
+diff --git a/wsdd2.8 b/wsdd2.8
+index a5e5e57..d616525 100644
+--- a/wsdd2.8
++++ b/wsdd2.8
+@@ -173,6 +173,12 @@ Set WSDD query over HTTP response values in a comma-delimited list. The
+ valid/necessary keys are: \fBvendor, model, serial, sku, vendorurl,
+ modelurl, presentationurl\fR.
+ .br
++Each pair is delimited by a comma. Within a pair the key ends at the
++first colon or blank, and the value is everything up to the next comma,
++so a value may itself contain colons and blanks - a URL needs no
++quoting beyond keeping the whole list as one argument. A value may not
++contain a comma. An unknown key is an error.
++.br
+ This option overrides /proc/sys/dev/boot/info readouts.
+ .RE
+ 

--- a/packages/network/wsdd2/patches/0002-Report-the-serial-number-that-was-configured.patch
+++ b/packages/network/wsdd2/patches/0002-Report-the-serial-number-that-was-configured.patch
@@ -1,0 +1,78 @@
+From d4c70907359ce3bde63ab3abd7c04a06f7560ff9 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi.heitbaum@sparknel-dc.com.au>
+Date: Fri, 21 Aug 2026 18:51:43 +1000
+Subject: [PATCH 2/2] Report the serial number that was configured
+
+wsdd2.8 documents the serial as coming from /proc/sys/dev/boot/info or
+the -b option, defaulting to 0, and the table carries that default, but
+the ThisDevice metadata is built with the literal "20050718" instead.
+Both sources of the value are silently discarded, so -b serial:... has
+never had any effect. Pass the configured value through.
+
+This does change what an unconfigured daemon reports, from "20050718"
+to the documented default of 0. The serial number is informational and
+optional in the device metadata, so nothing keys off it.
+
+The SKU is the other way round: it is accepted from both sources, but
+there is no element in the device metadata to carry it and no code that
+tries, so the manual promises a value that cannot appear. Say so rather
+than removing a key that a boot info readout may still legitimately
+contain.
+
+Cite DPWS alongside WS-Discovery in STANDARDS, since it is DPWS that
+defines the metadata this section of the manual describes, and note
+that the namespaces on the wire are the earlier drafts - the manual
+otherwise implies wsdd2 speaks the 2009 standards. Also correct OASYS
+to OASIS in the sentence above.
+---
+ wsd.c   |  2 +-
+ wsdd2.8 | 13 +++++++++++--
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/wsd.c b/wsd.c
+index ef25c5d..0b276e5 100644
+--- a/wsd.c
++++ b/wsd.c
+@@ -857,7 +857,7 @@ static int wsd_send_get_response(int fd,
+ 	ssize_t len = asprintf(&body, body_templ,
+ 				"Microsoft Publication Service Device Host",
+ 				"1.0",
+-				"20050718",
++				get_getresp("serial:"),
+ 				get_getresp("vendor:"),
+ 				get_getresp("vendorurl:"),
+ 				get_getresp("model:"),
+diff --git a/wsdd2.8 b/wsdd2.8
+index d616525..474f416 100644
+--- a/wsdd2.8
++++ b/wsdd2.8
+@@ -208,7 +208,8 @@ Value retrieved from /proc/sys/dev/boot/info or set with the -b option or
+ .PP
+ SKU
+ .RS 4
+-Value retrieved from /proc/sys/dev/boot/info or set with the -b option.
++Accepted from /proc/sys/dev/boot/info and the -b option, but not
++reported: the device metadata has no element to carry it.
+ .RE
+ .PP
+ ModelURL
+@@ -265,10 +266,18 @@ messages.
+ .SH "STANDARDS"
+ .PP
+ The WSDD protocol is described in detail in "Web Services Dynamic Discovery
+-(WS-Discovery) Version 1.1" OASYS Standard, 1 July 2009
++(WS-Discovery) Version 1.1" OASIS Standard, 1 July 2009
+ .br
+ http://docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-spec-os.html
+ .PP
++The device metadata returned over HTTP is described in "Devices Profile for
++Web Services (DPWS) Version 1.1" OASIS Standard, 1 July 2009
++.br
++http://docs.oasis-open.org/ws-dd/dpws/1.1/os/wsdd-dpws-1.1-spec-os.html
++.PP
++Note that the XML namespaces on the wire are the earlier drafts those two
++standards grew out of, since that is what the Windows WSD client speaks.
++.PP
+ LLMNR complies with RFC4795.
+ 
+ .SH "AUTHOR"

--- a/packages/network/wsdd2/system.d/wsdd2.service
+++ b/packages/network/wsdd2/system.d/wsdd2.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=WSD/LLMNR Discovery/Name Service Daemon
+PartOf=smbd.service
+After=network-online.target smbd.service samba-config.service
+Wants=network-online.target
+ConditionPathExists=/run/samba/smb.conf
+
+[Service]
+ExecStart=/usr/sbin/wsdd2 -c /run/samba/smb.conf -b "vendor:LibreELEC,vendorurl:https://libreelec.tv,model:@MODEL@,modelurl:https://libreelec.tv"
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+DynamicUser=true
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=full
+ProtectHome=true
+
+[Install]
+WantedBy=smbd.service


### PR DESCRIPTION
- Fixes: #11592 

Update PKG_URL to github.com/oldium/wsdd2. Use our systemd unit, which uses `PartOf=` and `WantedBy=smbd.service`, ordered after the network and the config generator, conditional on the generated `smb.conf`. Keep upstream's `AmbientCapabilities`. Pass -c explicitly so the file the unit waits for is the file the daemon reads. The unit also passes -b, so the `ThisModel` metadata carries our vendor and the build target instead of "unknown" and a literal "(null)".

Verified a Get carrying the charset parameter is answered 200 where 1.8.7 answers 400, discovery is unchanged, the two testparm lines are gone, wsdd2 starts 4.5s after samba-config finishes rather than racing it, and stopping, starting and restarting smbd all carry wsdd2 with them.