### PR TITLE
kernel-firmware: rebuild when a firmware list changes

### DIFF
--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -8,6 +8,16 @@ PKG_LICENSE="LicenseRef-linux-firmware"
 PKG_SITE="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/"
 PKG_URL="https://cdn.kernel.org/pub/linux/kernel/firmware/linux-firmware-${PKG_VERSION}.tar.xz"
 PKG_NEED_UNPACK="${PROJECT_DIR}/${PROJECT}/packages/${PKG_NAME} ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/packages/${PKG_NAME}"
+# makeinstall_target() selects firmware from these lists, so a change to one
+# has to invalidate the stamp - they live outside the paths calculate_stamp()
+# already covers.
+PKG_NEED_UNPACK+=" ${PROJECT_DIR}/${PROJECT}/config/kernel-firmware.dat"
+PKG_NEED_UNPACK+=" ${PROJECT_DIR}/${PROJECT}/config/kernel-firmware-any.dat"
+PKG_NEED_UNPACK+=" ${PROJECT_DIR}/${PROJECT}/config/kernel-firmware-${TARGET_ARCH}.dat"
+if [ -n "${DEVICE}" ]; then
+  PKG_NEED_UNPACK+=" ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/config/kernel-firmware-any.dat"
+  PKG_NEED_UNPACK+=" ${PROJECT_DIR}/${PROJECT}/devices/${DEVICE}/config/kernel-firmware-${TARGET_ARCH}.dat"
+fi
 PKG_LONGDESC="kernel-firmware: kernel related firmware"
 PKG_TOOLCHAIN="manual"
 


### PR DESCRIPTION
makeinstall_target() picks firmware from config/kernel-firmware*.dat in the project and device directories, but calculate_stamp() only hashes PKG_DIR, the project/device patches and packages directories, and PKG_NEED_UNPACK. Editing or adding one of those lists therefore left the stamp unchanged, the package was treated as up to date and the selection never took effect.

Add the lists to PKG_NEED_UNPACK. Paths that do not exist are skipped by the find in calculate_stamp(), as already happens for the patches directories.