### PR TITLE
GitHub: tweaks to the bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,20 +8,16 @@ body:
       value: |
         Thanks for taking the time to file a report.
 
-        **Before you start — please read:** LibreELEC support happens on the
-        [forum](https://forum.libreelec.tv), not here. Triage your problem there
-        first. Reports opened without forum triage, without a debug log, on an
-        end-of-life release, or that are really support/configuration questions
-        will be closed with a pointer to the forum.
+        **Important:** Support happens on our [forum](https://forum.libreelec.tv) not here. Triage problems in the forum first. Bug reports opened without forum triage, without a debug log, on an End-of-Life release, and general support or config questions will be closed and redirected to the forum
 
   - type: checkboxes
     id: prerequisites
     attributes:
       label: Prerequisites
       options:
-        - label: I have searched the forum and the existing issues for my problem
+        - label: I have searched the [forum](https://forum.libreelec.tv) and existing [issues](https://github.com/LibreELEC/LibreELEC.tv/issues) for my problem
           required: true
-        - label: I am running a current LibreELEC release or nightly (not an end-of-life version)
+        - label: I am running a current LibreELEC release or nightly (not End-of-Life version)
           required: true
         - label: This is a reproducible bug, not a support or configuration question
           required: true
@@ -29,8 +25,8 @@ body:
   - type: input
     id: version
     attributes:
-      label: LibreELEC version
-      description: Exact version from Settings → System Information (e.g. `12.2.1`, or the nightly date / githash).
+      label: Version Info
+      description: Settings → System Information, e.g. `12.2.1` or nightly date-githash, e.g. `20260823-54eca63date`
       placeholder: "12.2.1"
     validations:
       required: true
@@ -38,46 +34,47 @@ body:
   - type: dropdown
     id: channel
     attributes:
-      label: Release channel
+      label: Release Channel
       options:
-        - Stable release
-        - Nightly / test build
+        - Stable
+        - Nightly
+        - Development
     validations:
       required: true
 
   - type: dropdown
     id: platform
     attributes:
-      label: Hardware platform
+      label: Hardware Platform
       options:
-        - Generic (x86_64 PC)
-        - Generic-Legacy (X11)
-        - Raspberry Pi 5
-        - Raspberry Pi 4 / 400
-        - Raspberry Pi 2 / 3
         - Allwinner
         - Amlogic
-        - Rockchip
-        - NXP (i.MX)
+        - Generic x86_64 (GBM)
+        - Generic-Legacy (X11)
+        - NXP (iMX)
         - Qualcomm (Dragonboard)
+        - Raspberry Pi 2 / 3
+        - Raspberry Pi 4 / 400
+        - Raspberry Pi 5 / 500
+        - Rockchip
         - Samsung (Exynos)
-        - Other (describe in Additional context)
+        - Other (describe in Additional Context)
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Describe the bug
-      description: A clear description of what the bug is and what you expected to happen instead.
+      label: Bug Description
+      description: Provide a clear description of what the bug is and what you expected to happen instead
     validations:
       required: true
 
   - type: textarea
     id: reproduce
     attributes:
-      label: How to reproduce
-      description: Steps to reproduce the behaviour.
+      label: Reproduction Instructions
+      description: Provide a sequence of steps to reproduce the behaviour
       placeholder: |
         1. Go to '...'
         2. Play '...'
@@ -88,11 +85,9 @@ body:
   - type: input
     id: log
     attributes:
-      label: Debug log URL
+      label: Log URL
       description: >-
-        Capture a debug log (https://libreelec.wiki/how_to/provide_logfile),
-        upload it to https://paste.libreelec.tv and paste the link here.
-        Do NOT paste the log inline.
+        [Capture a debug log](https://libreelec.wiki/how_to/provide_logfile) and paste the https://paste.libreelec.tv URL here. Do not paste logs inline!
       placeholder: "https://paste.libreelec.tv/..."
     validations:
       required: true
@@ -100,8 +95,8 @@ body:
   - type: input
     id: forum
     attributes:
-      label: Forum thread URL
-      description: Link to the forum thread where you triaged this first.
+      label: Forum URL
+      description: Provide a link to the forum thread where your issue was triaged first
       placeholder: "https://forum.libreelec.tv/thread/..."
     validations:
       required: true
@@ -109,7 +104,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Additional context
+      label: Additional Context
       description: Anything else relevant — exact hardware, attached peripherals, when it started, etc.
     validations:
       required: false


### PR DESCRIPTION
- Address some line-wrapping issues (GH handles this automatically)
- Alpha-sort the platforms list
- Add 'development' to release types
- Add an example of nightly release info
- Add extra forum/issue links in several places
- Remove trailing . periods from descriptions to avoid visual litter
- Limit label entries to two words and use Title Case (except for Add a title.. which is asserted by GH)
- Misc wording tweaks
