### PR TITLE
kodi: hide monitor selection on GBM

### DIFF
--- a/packages/mediacenter/kodi/config/appliance-gbm-generic.xml
+++ b/packages/mediacenter/kodi/config/appliance-gbm-generic.xml
@@ -22,4 +22,13 @@
       </group>
     </category>
   </section>
+  <section id="system">
+    <category id="display">
+      <group id="1">
+        <setting id="videoscreen.monitor">
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/packages/mediacenter/kodi/config/appliance-gbm.xml
+++ b/packages/mediacenter/kodi/config/appliance-gbm.xml
@@ -22,4 +22,13 @@
       </group>
     </category>
   </section>
+  <section id="system">
+    <category id="display">
+      <group id="1">
+        <setting id="videoscreen.monitor">
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>


### PR DESCRIPTION
The recently merged monitor selection for GBM https://github.com/xbmc/xbmc/pull/28633 is incomplete and potentially harmful.

Hide it from settings until it's properly implemented in kodi (likely not before Kodi 23/LE14).

See also the discussion in https://github.com/xbmc/xbmc/pull/29073

Runtime tested on RPi5 and Generic, monitor selection is not shown in display settings