### PR TITLE
rust: add armv6zk-libreelec-linux-gnueabihf target

### DIFF
--- a/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
+++ b/packages/rust/rust/patches/9999-target-add-LibreELEC-target-specifications-for-aarch.patch
@@ -1,18 +1,19 @@
-From 28fa72ca43bb05ce7e9af91f632af6c7cb624b90 Mon Sep 17 00:00:00 2001
+From 33675cfcc54ae4f5db6213370cd8a993fe3113c7 Mon Sep 17 00:00:00 2001
 From: Rudi Heitbaum <rudi@heitbaum.com>
-Date: Fri, 24 Apr 2026 09:41:06 +0000
+Date: Sun, 30 Aug 2026 23:24:16 +1000
 Subject: [PATCH] target: add LibreELEC target specifications for aarch64,
- armv7a, armv7ve, and x86_64
+ armv6zk, armv7a, armv7ve, and x86_64
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Add four new Rust target specifications for LibreELEC. These targets
+Add five new Rust target specifications for LibreELEC. These targets
 replace the previous JSON-based custom target definitions in the LibreELEC
 build system.
 
 Targets added:
   - aarch64-libreelec-linux-gnu
+  - armv6zk-libreelec-linux-gnueabihf
   - armv7a-libreelec-linux-gnueabihf
   - armv7ve-libreelec-linux-gnueabihf
   - x86_64-libreelec-linux-gnu
@@ -28,6 +29,7 @@ aarch64-libreelec-linux-gnu:
     valuable memory safety tooling on AArch64 hardware.
   - supports_xray: false (upstream: true)
 
+armv6zk-libreelec-linux-gnueabihf:
 armv7a-libreelec-linux-gnueabihf:
 armv7ve-libreelec-linux-gnueabihf:
   - features: +strict-align,+v6,+vfp2,-d32
@@ -37,6 +39,12 @@ armv7ve-libreelec-linux-gnueabihf:
     whose VFP units provide only 16 double-precision registers.
   - No sanitizer overrides; upstream arm-unknown-linux-gnueabihf defines
     none and the LibreELEC JSON spec lists none.
+  - arm32 ships a single target build across the whole ARMv6-and-up range,
+    so all three specs carry the same conservative ARMv6 tuning. armv6zk
+    is not built by LibreELEC itself; it exists so downstream projects
+    that still support first-generation Raspberry Pi hardware can name
+    --target armv6zk-libreelec-linux-gnueabihf directly rather than
+    borrowing the armv7a spec.
 
 x86_64-libreelec-linux-gnu:
   - stack_probes: Call (upstream: Inline)
@@ -48,7 +56,7 @@ x86_64-libreelec-linux-gnu:
     support not present in LibreELEC builds.
   - supports_xray: false (upstream: true)
 
-All four targets are registered in supported_targets! in
+All five targets are registered in supported_targets! in
 compiler/rustc_target/src/spec/mod.rs.
 
 Metadata:
@@ -60,7 +68,8 @@ diff between rust-1.95.0 and the libreelec target, these should be checked on ru
 check with:
     diff ./compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs ./compiler/rustc_target/src/spec/targets/aarch64_libreelec_linux_gnu.rs -Nu
     diff ./compiler/rustc_target/src/spec/targets/arm_unknown_linux_gnueabihf.rs ./compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs -Nu
-      - armv7ve_libreelec_linux_gnueabihf.rs is a copy of armv7a_libreelec_linux_gnueabihf.rs
+      - armv6zk_libreelec_linux_gnueabihf.rs and armv7ve_libreelec_linux_gnueabihf.rs
+        are byte-identical copies of armv7a_libreelec_linux_gnueabihf.rs
     diff ./compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs ./compiler/rustc_target/src/spec/targets/x86_64_libreelec_linux_gnu.rs -Nu
 
 *   --- ./compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs	2026-04-24 01:07:35.956658721 +0000
@@ -184,27 +193,30 @@ check with:
 *            },
 *            pointer_width: 64,
 ---
- compiler/rustc_target/src/spec/mod.rs         |  4 ++
+ compiler/rustc_target/src/spec/mod.rs         |  5 ++
  .../targets/aarch64_libreelec_linux_gnu.rs    | 55 +++++++++++++++++++
+ .../armv6zk_libreelec_linux_gnueabihf.rs      | 39 +++++++++++++
  .../armv7a_libreelec_linux_gnueabihf.rs       | 39 +++++++++++++
  .../armv7ve_libreelec_linux_gnueabihf.rs      | 39 +++++++++++++
  .../targets/x86_64_libreelec_linux_gnu.rs     | 52 ++++++++++++++++++
- 5 files changed, 189 insertions(+)
+ 6 files changed, 229 insertions(+)
  create mode 100644 compiler/rustc_target/src/spec/targets/aarch64_libreelec_linux_gnu.rs
+ create mode 100644 compiler/rustc_target/src/spec/targets/armv6zk_libreelec_linux_gnueabihf.rs
  create mode 100644 compiler/rustc_target/src/spec/targets/armv7a_libreelec_linux_gnueabihf.rs
  create mode 100644 compiler/rustc_target/src/spec/targets/armv7ve_libreelec_linux_gnueabihf.rs
  create mode 100644 compiler/rustc_target/src/spec/targets/x86_64_libreelec_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index d6a9e27c465..b6dc05b8986 100644
+index 5c19b35e160..c35c9522cd5 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1455,6 +1455,10 @@ macro_rules! supported_targets {
+@@ -1438,6 +1438,11 @@ macro_rules! supported_targets {
  }
  
  supported_targets! {
 +    ("x86_64-libreelec-linux-gnu", x86_64_libreelec_linux_gnu),
 +    ("aarch64-libreelec-linux-gnu", aarch64_libreelec_linux_gnu),
++    ("armv6zk-libreelec-linux-gnueabihf", armv6zk_libreelec_linux_gnueabihf),
 +    ("armv7a-libreelec-linux-gnueabihf", armv7a_libreelec_linux_gnueabihf),
 +    ("armv7ve-libreelec-linux-gnueabihf", armv7ve_libreelec_linux_gnueabihf),
      ("x86_64-unknown-linux-gnu", x86_64_unknown_linux_gnu),
@@ -266,6 +278,51 @@ index 00000000000..65c9c61f83f
 +                | SanitizerSet::THREAD
 +                | SanitizerSet::HWADDRESS,
 +            supports_xray: false,
++
++            ..base::linux_gnu::opts()
++        },
++    }
++}
+diff --git a/compiler/rustc_target/src/spec/targets/armv6zk_libreelec_linux_gnueabihf.rs b/compiler/rustc_target/src/spec/targets/armv6zk_libreelec_linux_gnueabihf.rs
+new file mode 100644
+index 00000000000..cbda6d57bde
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/targets/armv6zk_libreelec_linux_gnueabihf.rs
+@@ -0,0 +1,39 @@
++use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions, base};
++
++pub(crate) fn target() -> Target {
++    Target {
++        llvm_target: "arm-unknown-linux-gnueabihf".into(),
++        metadata: TargetMetadata {
++            description: Some("Armv6 Linux hardfloat for LibreELEC (kernel 3.2, glibc 2.17)".into()),
++            tier: Some(3),
++            host_tools: Some(false),
++            std: Some(true),
++        },
++        pointer_width: 32,
++        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
++        arch: Arch::Arm,
++        options: TargetOptions {
++            // ── Upstream arm-unknown-linux-gnueabihf defaults ─────────────
++            cfg_abi: CfgAbi::EabiHf,
++            llvm_floatabi: Some(FloatAbi::Hard),
++            // features: "+strict-align,+v6,+vfp2".into(),
++            max_atomic_width: Some(64),
++            mcount: "\u{1}__gnu_mcount_nc".into(),
++            llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),
++            // The default on linux is to have `default_uwtable=true`, but on
++            // this target we get an "`__aeabi_unwind_cpp_pr0` not defined"
++            // linker error, so set it to `true` here.
++            // FIXME(#146996): Remove this override once #146996 has been fixed.
++            default_uwtable: false,
++
++            // ── LibreELEC overrides ───────────────────────────────────────
++
++            // LibreELEC targets older ARM SoCs (e.g. Raspberry Pi, Amlogic)
++            // that need the -d32 flag to disable 32 double-precision VFP
++            // registers, keeping only 16
++            features: "+strict-align,+v6,+vfp2,-d32".into(),
 +
 +            ..base::linux_gnu::opts()
 +        },
@@ -420,5 +477,5 @@ index 00000000000..2d32c689ad6
 +    }
 +}
 -- 
-2.53.0
+2.47.1.windows.2
 


### PR DESCRIPTION
## Background

Lakka still supports the first-gen Raspberry Pi (`armv6zk`), which is
outside LibreELEC's current build range. While investigating a rustc
build failure there (`could not find specification for target
armv6zk-libreelec-linux-gnueabihf`), I found that
`armv7a_libreelec_linux_gnueabihf.rs` actually contains ARMv6-tuned
settings rather than armv7a ones:

```rust
description: Some("Armv6 Linux hardfloat for LibreELEC (kernel 3.2, glibc 2.17)".into()),
...
features: "+strict-align,+v6,+vfp2,-d32".into(),
```

I raised this on Slack, and as discussed there, that's intentional -
arm32 only ships one target build across the whole ARMv6-and-up
range, so keeping the conservative flags on `armv7a` avoids breaking
older boards. `chewitt` suggested it'd still be worth having a
correctly-named `armv6zk` target for consistency, hence this PR.

## What this does

- Copies `armv7a_libreelec_linux_gnueabihf.rs` to a correctly named
  `armv6zk_libreelec_linux_gnueabihf.rs`
- Registers it in `mod.rs`, so `--target
  armv6zk-libreelec-linux-gnueabihf` resolves directly instead of
  relying on the `armv7a` name
- `armv7a_libreelec_linux_gnueabihf.rs` itself is untouched

## Testing

Confirmed `rust:host` and downstream Rust-dependent core builds
succeed on Lakka's `RPi` (armv6zk) and `RPiZero-GPiCase` (armv6zk)
devices with this patch applied.

---
(This PR description was drafted with the help of Claude.)

Thanks,
ASAI, Shigeaki