### PR TITLE
kodi: support version 3 addon settings

### DIFF
--- a/packages/mediacenter/kodi/profile.d/00-addons.conf
+++ b/packages/mediacenter/kodi/profile.d/00-addons.conf
@@ -30,11 +30,14 @@ oe_setup_addon() {
     for xml_file in "$DEF" "$CUR"; do
       if [ -f "$xml_file" ]; then
         XML_SETTINGS_VER="$(xmlstarlet sel -t -m settings -v @version $xml_file)"
-        if [ "$XML_SETTINGS_VER" = "2" ]; then
-          eval $(xmlstarlet sel -t -m settings/setting -v @id -o "=" -v . -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
-        else
-          eval $(xmlstarlet sel -t -m settings -m setting -v @id -o "=" -v @value -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
-        fi
+        case "$XML_SETTINGS_VER" in
+          2|3)
+            eval $(xmlstarlet sel -t -m settings/setting -v @id -o "=" -v . -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
+            ;;
+          *)
+            eval $(xmlstarlet sel -t -m settings -m setting -v @id -o "=" -v @value -n "$xml_file" | sed -e "s/'/'\\\\''/g; s/=/='/; s/$/'/")
+            ;;
+        esac
       fi
     done
   fi


### PR DESCRIPTION
## Description

Kodi 22 can persist add-on settings using the version 3 XML format, which stores setting values as element text like version 2. The oe_setup_addon helper currently only handles version 2 this way, so version 3 files fall through to the legacy attribute parser and all loaded values become empty.

Handle versions 2 and 3 with the text-value parser while retaining the legacy fallback for older formats.

This was reproduced on LibreELEC 13 nightly build da49141f4f85e021ed91afe02e1bfd3b7b14c180 with service.tailscale: settings.xml contained ts_connect=true, but oe_setup_addon produced an empty ts_connect and left Tailscale stopped at boot.

## Testing

- Confirmed version 3 settings parse ts_connect=true on the affected RPi4 installation
- sh -n packages/mediacenter/kodi/profile.d/00-addons.conf
- git diff --check
- ShellCheck reports no warnings beyond those already present on master