### PR TITLE
tailscale: preserve custom control server

### DIFF
--- a/packages/addons/service/tailscale/package.mk
+++ b/packages/addons/service/tailscale/package.mk
@@ -3,7 +3,7 @@
 
 PKG_NAME="tailscale"
 PKG_VERSION="1.102.3"
-PKG_REV="7"
+PKG_REV="8"
 PKG_ARCH="any"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://tailscale.com"

--- a/packages/addons/service/tailscale/source/bin/tailscale.start
+++ b/packages/addons/service/tailscale/source/bin/tailscale.start
@@ -49,6 +49,14 @@ fi
 # Use --netfilter-mode=off to preserve LAN access (SSH, Kodi, etc.)
 TS_ARGS="--reset --netfilter-mode=off"
 
+# Preserve a custom control server, such as Headscale. Without an explicit
+# --login-server value, --reset restores Tailscale's default control server.
+CONTROL_URL="$($TAILSCALE --socket="$SOCKET" debug prefs 2>/dev/null |
+  sed -n 's/^[[:space:]]*"ControlURL": "\(.*\)",$/\1/p')"
+if [ -n "$CONTROL_URL" ]; then
+  TS_ARGS="$TS_ARGS --login-server=$CONTROL_URL"
+fi
+
 # Set node hostname
 if [ "$ts_auto_hostname" != "true" ] && [ -n "$ts_hostname" ]; then
   TS_ARGS="$TS_ARGS --hostname=$ts_hostname"


### PR DESCRIPTION
## Description

The Tailscale service add-on runs tailscale up with --reset whenever it starts. If --login-server is omitted, --reset restores Tailscale's public control server, silently replacing an existing custom Headscale ControlURL and leaving the node logged out.

Read the active ControlURL from the daemon preferences and include it in the generated tailscale up arguments. This preserves both the standard Tailscale control plane and custom Headscale servers across service restarts and reboots.

Bump the add-on revision so the corrected startup script is published as an update.

## Testing

Tested end-to-end on an RPi4 running LibreELEC 13 nightly build da49141f4f85e021ed91afe02e1bfd3b7b14c180 with Headscale:

- Deployed the exact startup script from this branch
- Confirmed the existing control URL was detected
- Restarted `service.tailscale` successfully
- Confirmed `ControlURL` remained unchanged
- Confirmed `WantRunning=true` and peer connectivity
- Rebooted LibreELEC
- Confirmed Tailscale started automatically after boot
- Confirmed the custom control URL and peer connectivity survived the reboot
- Confirmed no logout or public-control-plane errors appeared in the boot journal
- `sh -n packages/addons/service/tailscale/source/bin/tailscale.start`
- `bash -n packages/addons/service/tailscale/package.mk`
- `git diff --check`
- ShellCheck reports no warnings beyond those already present on `master`