### PR TITLE
kodi-binary-addons: update to latest versions

### DIFF
--- a/packages/graphics/lunasvg/package.mk
+++ b/packages/graphics/lunasvg/package.mk
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="lunasvg"
+PKG_VERSION="3.5.0"
+PKG_SHA256="1abf1472ee6c4d19797916e8cc3c2e4b628e0d81178ffac60bdb0d457e32c690"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/sammycage/lunasvg"
+PKG_URL="https://github.com/sammycage/lunasvg/archive/refs/tags/v${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="A standalone SVG rendering and manipulation library."
+PKG_BUILD_FLAGS="+pic -sysroot"
+PKG_TOOLCHAIN="cmake"
+
+# plutovg is bundled in-tree and built via add_subdirectory()
+PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=OFF \
+                       -DUSE_SYSTEM_PLUTOVG=OFF \
+                       -DLUNASVG_BUILD_EXAMPLES=OFF \
+                       -DLUNASVG_DISABLE_EXTERNAL_RESOURCES=ON"

--- a/packages/graphics/lunasvg/patches/0001-Reject-canvas-geometry-plutovg-cannot-represent.patch
+++ b/packages/graphics/lunasvg/patches/0001-Reject-canvas-geometry-plutovg-cannot-represent.patch
@@ -1,0 +1,45 @@
+From 365b2dd49b8d4edccf3cdd8c8d1f47baee52317c Mon Sep 17 00:00:00 2001
+From: cinemaONE <35371193+cinema-ONE@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 09:43:37 +0200
+Subject: [PATCH 1/2] Reject canvas geometry plutovg cannot represent
+
+Canvas::create() validates the float extents while plutovg_surface_create()
+validates the ints it is finally given, and nothing checks the conversion
+between them. NaN passes both arms of the guard, static_cast<int> of it is
+undefined and yields INT_MIN, plutovg_surface_create() returns null for that,
+and plutovg_canvas_create() dereferences it.
+
+Rounding reaches the same place from valid input: x=0.5, width=32767 gives
+r - l == kMaxSize, which plutovg also rejects.
+
+(cherry picked from commit 458214c5a506d92a11cee089c8946f6515bd3fe3)
+---
+ source/graphics.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/source/graphics.cpp b/source/graphics.cpp
+index 248c087..1158711 100644
+--- a/source/graphics.cpp
++++ b/source/graphics.cpp
+@@ -496,12 +496,20 @@ std::shared_ptr<Canvas> Canvas::create(const Bitmap& bitmap)
+ std::shared_ptr<Canvas> Canvas::create(float x, float y, float width, float height)
+ {
+     constexpr int kMaxSize = 1 << 15;
+-    if(width <= 0 || height <= 0 || width >= kMaxSize || height >= kMaxSize)
++    constexpr float kMaxCoord = 1 << 24;
++    // NaN compares false against everything, so this also rejects non-finite
++    // geometry, whose conversion to int below would be undefined.
++    if(!(width > 0 && height > 0 && width < kMaxCoord && height < kMaxCoord
++        && std::abs(x) < kMaxCoord && std::abs(y) < kMaxCoord))
+         return std::shared_ptr<Canvas>(new Canvas(0, 0, 1, 1));
+     auto l = static_cast<int>(std::floor(x));
+     auto t = static_cast<int>(std::floor(y));
+     auto r = static_cast<int>(std::ceil(x + width));
+     auto b = static_cast<int>(std::ceil(y + height));
++    // Rounding can push the extent past what plutovg_surface_create() accepts;
++    // it returns null there and plutovg_canvas_create() dereferences it.
++    if(r - l <= 0 || b - t <= 0 || r - l >= kMaxSize || b - t >= kMaxSize)
++        return std::shared_ptr<Canvas>(new Canvas(0, 0, 1, 1));
+     return std::shared_ptr<Canvas>(new Canvas(l, t, r - l, b - t));
+ }
+ 

--- a/packages/graphics/lunasvg/patches/0002-add-lunasvg-disable-external-resources.patch
+++ b/packages/graphics/lunasvg/patches/0002-add-lunasvg-disable-external-resources.patch
@@ -1,0 +1,82 @@
+From e2213a60fe6dd7b190c9e1b72b2f272015ae409c Mon Sep 17 00:00:00 2001
+From: cinemaONE <35371193+cinema-ONE@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 16:07:01 +0200
+Subject: [PATCH 2/2] Add LUNASVG_DISABLE_EXTERNAL_RESOURCES
+
+An SVG can reference any local path through `<image href>`, and the file is
+opened during parse. Embedders that render untrusted documents have no way to
+turn that off.
+
+Add an option mirroring LUNASVG_DISABLE_LOAD_SYSTEM_FONTS: when set, a
+non-`data:` href yields an empty Bitmap, so a blocked reference degrades like a
+broken one. Off by default.
+
+(cherry picked from commit 92b9cea376948512693f83b1cd6ff09bf90a20d6)
+---
+ CMakeLists.txt        | 5 +++++
+ meson.build           | 4 ++++
+ meson_options.txt     | 6 ++++++
+ source/svgelement.cpp | 4 ++++
+ 4 files changed, 19 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c526159..4354b58 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,6 +77,11 @@ if(LUNASVG_DISABLE_LOAD_SYSTEM_FONTS)
+     target_compile_definitions(lunasvg PRIVATE LUNASVG_DISABLE_LOAD_SYSTEM_FONTS)
+ endif()
+ 
++option(LUNASVG_DISABLE_EXTERNAL_RESOURCES "Disable loading of resources referenced by file path, leaving only data: URIs" OFF)
++if(LUNASVG_DISABLE_EXTERNAL_RESOURCES)
++    target_compile_definitions(lunasvg PRIVATE LUNASVG_DISABLE_EXTERNAL_RESOURCES)
++endif()
++
+ include(GNUInstallDirs)
+ include(CMakePackageConfigHelpers)
+ 
+diff --git a/meson.build b/meson.build
+index 6e92d66..6b72427 100644
+--- a/meson.build
++++ b/meson.build
+@@ -36,6 +36,10 @@ if get_option('load-system-fonts').disabled()
+     lunasvg_cpp_args += ['-DLUNASVG_DISABLE_LOAD_SYSTEM_FONTS']
+ endif
+ 
++if get_option('external-resources').disabled()
++    lunasvg_cpp_args += ['-DLUNASVG_DISABLE_EXTERNAL_RESOURCES']
++endif
++
+ lunasvg_lib = library('lunasvg', lunasvg_sources,
+     include_directories: include_directories('include', 'source'),
+     dependencies: plutovg_dep,
+diff --git a/meson_options.txt b/meson_options.txt
+index 3bde3dd..017436b 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -6,3 +6,9 @@ option('load-system-fonts',
+     value : 'auto',
+     description : 'Enable automatic loading of fonts from system directories'
+ )
++
++option('external-resources',
++    type : 'feature',
++    value : 'auto',
++    description : 'Enable loading of resources referenced by file path'
++)
+diff --git a/source/svgelement.cpp b/source/svgelement.cpp
+index 942ce97..796f9ab 100644
+--- a/source/svgelement.cpp
++++ b/source/svgelement.cpp
+@@ -908,7 +908,11 @@ static Bitmap loadImageResource(const std::string& href)
+         return plutovg_surface_load_from_image_base64(input.data(), input.length());
+     }
+ 
++#ifdef LUNASVG_DISABLE_EXTERNAL_RESOURCES
++    return Bitmap();
++#else
+     return plutovg_surface_load_from_image_file(href.data());
++#endif
+ }
+ 
+ void SVGImageElement::parseAttribute(PropertyID id, const std::string& value)

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.heif"
-PKG_VERSION="22.0.2-Piers"
-PKG_SHA256="09a5e35fd2eee28cdf530f439e29e7cf1f4d0eee72f501e3e4f059c66cec7acc"
-PKG_REV="8"
+PKG_VERSION="22.1.0-Piers"
+PKG_SHA256="ca62ee5b550af7cf24869ad28dc923ef72c515641f18d10f244b0e2205c27e5b"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.mpo/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.mpo"
-PKG_VERSION="22.0.3-Piers"
-PKG_SHA256="593726eee5ddec58bafa5510f2e0e05c1f532aa03e28dcd3cfa715058a83ebee"
-PKG_REV="3"
+PKG_VERSION="22.1.0-Piers"
+PKG_SHA256="e518db490f1573fb1ded92ba82ac88a9663ce0b409bf869c534ec1b7e1c721ea"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.mpo"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.raw/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="imagedecoder.raw"
-PKG_VERSION="22.0.4-Piers"
-PKG_SHA256="5e016e61f32d85d690550b433f3353c9c6246757c6d4405c76c5704b207eccbc"
-PKG_REV="4"
+PKG_VERSION="22.1.0-Piers"
+PKG_SHA256="de5df7b0bf955676e5694f9ecee3cc8394c44fea607c284dcf46cfbcec944568"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.raw"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.svg/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.svg/package.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="imagedecoder.svg"
+PKG_VERSION="22.0.1-Piers"
+PKG_SHA256="69c20cd52f55da95f0465b2ab6cc8a99b57f2f35796c77dc8bf953e4df2dd06c"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL-2.0-or-later"
+PKG_SITE="https://github.com/xbmc/imagedecoder.svg"
+PKG_URL="https://github.com/xbmc/imagedecoder.svg/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain lunasvg ${MEDIACENTER}:host"
+PKG_SECTION=""
+PKG_SHORTDESC="imagedecoder.svg"
+PKG_LONGDESC="imagedecoder.svg"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.imagedecoder"
+
+PKG_CMAKE_OPTS_TARGET="-Dlunasvg_DIR=$(get_install_dir lunasvg)/usr/lib/cmake/lunasvg \
+                       -Dplutovg_DIR=$(get_install_dir lunasvg)/usr/lib/cmake/plutovg"

--- a/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/inputstream.adaptive/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="inputstream.adaptive"
-PKG_VERSION="22.3.20-Piers"
-PKG_SHA256="a144f800e4ae4d35fea5cb8006140ad480f4fbb2f6d01bb49094e12209c27849"
+PKG_VERSION="22.3.21-Piers"
+PKG_SHA256="6f249bcd7557c75d2814869527745e739d2a44b5730d6a13c514495dd96d2b32"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"

--- a/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/peripheral.joystick/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="peripheral.joystick"
-PKG_VERSION="22.0.10-Piers"
-PKG_SHA256="02604971691a1a814b24ab32dc06cb76a60ceac846b26c60a8327d71b3c4eb8a"
+PKG_VERSION="22.0.11-Piers"
+PKG_SHA256="d4b2d2ed3276053d2da5f198fca248243a55d7b50730ca9e274d84636765e048"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"


### PR DESCRIPTION
- imagedecoder.heif: update 22.0.2-Piers to 22.1.0-Piers
- imagedecoder.mpo: update 22.0.3-Piers to 22.1.0-Piers
- imagedecoder.raw: update 22.0.4-Piers to 22.1.0-Piers
- imagedecoder.svg: initial package
  - lunasvg: new package (3.5.0)
- inputstream.adaptive: update 22.3.20-Piers to 22.3.21-Piers
- peripheral.joystick: update 22.0.10-Piers to 22.0.11-Piers
- needs #11725