### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/podman/gpgme/package.mk
+++ b/packages/addons/addon-depends/podman/gpgme/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gpgme"
-PKG_VERSION="2.1.2"
-PKG_SHA256="0687a95b299871c4141f507c0f740de6b429c9ac067d0fa4e062e3264df5fb77"
+PKG_VERSION="2.2.0"
+PKG_SHA256="7160e80e84dafd00d956c84891c533bb7ab16a6a54fbe1574b2f3acf0496977b"
 PKG_LICENSE="LGPL-2.1-or-later AND MIT"
 PKG_SITE="https://gnupg.org/software/gpgme/index.html"
 PKG_URL="https://gnupg.org/ftp/gcrypt/gpgme/gpgme-${PKG_VERSION}.tar.bz2"

--- a/packages/addons/tools/gnupg/package.mk
+++ b/packages/addons/tools/gnupg/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2026-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="gnupg"
-PKG_REV="3"
-PKG_VERSION="2.5.21"
-PKG_SHA256="e3af2c8caa46a66a9329fa7c6880af260451914d819595beabc2c26597b31352"
+PKG_REV="4"
+PKG_VERSION="2.5.22"
+PKG_SHA256="96e27b020ad26510388e06f5f07f3f70a4ed8916ee995f1b72b7a024e6d9d87e"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://www.gnupg.org"
 PKG_URL="https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-${PKG_VERSION}.tar.bz2"

--- a/packages/devel/pcre2/package.mk
+++ b/packages/devel/pcre2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pcre2"
-PKG_VERSION="10.47"
-PKG_SHA256="47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7"
+PKG_VERSION="10.48"
+PKG_SHA256="b6c68fdf6f3ac31388b50aa89ff0fc49c00c987c16e7b5146491d12003f2c8ed"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="http://www.pcre.org/"
 PKG_URL="https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PKG_VERSION}/pcre2-${PKG_VERSION}.tar.bz2"

--- a/packages/graphics/exiv2/package.mk
+++ b/packages/graphics/exiv2/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="exiv2"
-PKG_VERSION="0.28.8"
-PKG_SHA256="ea51b0609f58a9afa063b60daa1539948b62247721e154f4fff0ad3aec9f9756"
+PKG_VERSION="0.28.9"
+PKG_SHA256="700b76b97695b2fab4ef8c79619c68ae57d09e0c130724791cafbd39e0eb4aef"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://exiv2.org"
 PKG_URL="https://github.com/Exiv2/exiv2/archive/refs/tags/v${PKG_VERSION}.tar.gz"

--- a/packages/multimedia/media-driver/package.mk
+++ b/packages/multimedia/media-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="media-driver"
-PKG_VERSION="26.3.2"
-PKG_SHA256="3ac33632f22b8fee53e1ccad5650e5bd2a90fcb021a058642a0cf1f4358b8c54"
+PKG_VERSION="26.3.3"
+PKG_SHA256="bbe4deb0d2f72e5c58adaf17f87b7a11bf639446d99bf4193a116d0588647a97"
 PKG_ARCH="x86_64"
 PKG_LICENSE="MIT"
 PKG_SITE="https://01.org/linuxmedia"

--- a/packages/multimedia/nvidia-vaapi-driver/package.mk
+++ b/packages/multimedia/nvidia-vaapi-driver/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nvidia-vaapi-driver"
-PKG_VERSION="0.0.17"
-PKG_SHA256="4e4bed9acef9881de8705c8e0286901f13f6b43c2df1b0c8b6a2f8ba2a186ac9"
+PKG_VERSION="0.0.18"
+PKG_SHA256="7459205cd1719a5865ab9c8969723c27e9863add5e7229e8e56c5f8816017b2a"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/elFarto/nvidia-vaapi-driver"
 PKG_URL="https://github.com/elFarto/nvidia-vaapi-driver/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/network/libnftnl/package.mk
+++ b/packages/network/libnftnl/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libnftnl"
-PKG_VERSION="1.3.1"
-PKG_SHA256="607da28dba66fbdeccf8ef1395dded9077e8d19f2995f9a4d45a9c2f0bcffba8"
+PKG_VERSION="1.3.2"
+PKG_SHA256="c97abc3409f8fa396b4462b2bb7f147a3a47a4ddc97cfa0b2f18890c9cfde8b0"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://netfilter.org/projects/libnftnl"
 PKG_URL="https://netfilter.org/projects/libnftnl/files/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/textproc/expat/package.mk
+++ b/packages/textproc/expat/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="expat"
-PKG_VERSION="2.8.3"
-PKG_SHA256="f6256df90c906773d344da084402b7d3e4f22ed41b1a59c989098a83d3ea0c85"
+PKG_VERSION="2.8.4"
+PKG_SHA256="656ae1cc8da3b4ea513bb4e254f33e6243938084c0ec6239da873376b09985a7"
 PKG_LICENSE="MIT"
 PKG_SITE="https://libexpat.github.io"
 PKG_URL="https://github.com/libexpat/libexpat/releases/download/R_${PKG_VERSION//./_}/${PKG_NAME}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
- pcre2: update to 10.48
- media-driver: update to 26.3.3
- libnftnl: update to 1.3.2
- gpgme: update to 2.2.0
- expat: update to 2.8.4
- gnupg: update to 2.5.22 and addon (4)
- exiv2: update to 0.28.9
- nvidia-vaapi-driver: update to 0.0.18