### PR TITLE
mesa: work around out of range VFP literal pools on 32-bit arm

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -18,6 +18,15 @@ if [ "${DEVICE}" = "Dragonboard" ]; then
   PKG_DEPENDS_TARGET+=" libarchive libxml2 lua54"
 fi
 
+# workaround: on 32-bit arm gcc emits a VFP literal pool load that is more than
+# the 1020 byte vldr range away from its pool in the panfrost midgard compiler:
+# {standard input}: Error: co-processor offset out of range
+# dropping SLP vectorisation removes the 64-bit vector constants that overflow
+# the pool. seen with gcc 16.2.0 and mesa 26.2.2 on RK3288.
+if [ "${ARCH}" = "arm" ]; then
+  TARGET_CFLAGS+=" -fno-tree-slp-vectorize"
+fi
+
 PKG_MESON_OPTS_HOST="-Dglvnd=disabled \
                      -Dgallium-drivers= \
                      -Dplatforms= \


### PR DESCRIPTION
Building mesa 26.2.2 for RK3288 (armv7ve, hard float) fails assembling midgard_compile.c:

  {standard input}:6965: Error: co-processor offset out of range

gcc 16.2.0 places a VFP constant pool more than the 1020 byte vldr range away from the instruction that reads it, in emit_intrinsic():

  vldr    d16, .L902+32

midgard_compile.c is unchanged between 26.2.1 and 26.2.2 - the nir opcode and intrinsic table changes in 26.2.2 shift the code layout just past the limit, so this is latent rather than new.

Disabling SLP vectorisation removes the 64-bit vector constants that make the pools overflow, taking the worst pool distance from over 1020 bytes down to 624. -fno-tree-loop-vectorize also happens to build, but only reaches 996 bytes, which is luck rather than headroom.

Only applies to 32-bit arm; RK3288 is the sole panfrost midgard target there.

- https://github.com/LibreELEC/actions/actions/runs/33786829144/job/101027574419
- https://github.com/LibreELEC/actions/actions/runs/33786829144/job/100753570612
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=127227