### PR TITLE
compress: build xz, lz4, lzo and libarchive as shared libraries

### DIFF
--- a/packages/compress/libarchive/package.mk
+++ b/packages/compress/libarchive/package.mk
@@ -12,7 +12,7 @@ PKG_DEPENDS_TARGET="cmake:host gcc:host bzip2 lz4 lzo openssl pcre2 xz zlib zstd
 PKG_LONGDESC="A multi-format archive and compression library."
 
 PKG_CMAKE_OPTS_TARGET="-DCMAKE_POSITION_INDEPENDENT_CODE=1 \
-                       -DBUILD_SHARED_LIBS=OFF \
+                       -DBUILD_SHARED_LIBS=ON \
                        -DENABLE_ACL=ON \
                        -DENABLE_BZip2=ON \
                        -DENABLE_CAT=OFF \
@@ -29,8 +29,6 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_POSITION_INDEPENDENT_CODE=1 \
                        -DENABLE_LIBXML2=OFF \
                        -DENABLE_LZ4=ON \
                        -DENABLE_LZMA=ON \
-                       -DLIBLZMA_INCLUDE_DIR=$(get_install_dir xz)/usr/include \
-                       -DLIBLZMA_LIBRARY=$(get_install_dir xz)/usr/lib/liblzma.a \
                        -DENABLE_LZO=ON \
                        -DENABLE_MBEDTLS=OFF \
                        -DENABLE_NETTLE=OFF \

--- a/packages/compress/lz4/package.mk
+++ b/packages/compress/lz4/package.mk
@@ -14,7 +14,6 @@ PKG_LONGDESC="lz4 data compressor/decompressor"
 configure_package() {
   PKG_CMAKE_SCRIPT="${PKG_BUILD}/build/cmake/CMakeLists.txt"
 
-  PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=0 \
-                         -DLZ4_BUILD_CLI=OFF \
-                         -DCMAKE_POSITION_INDEPENDENT_CODE=0"
+  PKG_CMAKE_OPTS_TARGET="-DBUILD_SHARED_LIBS=1 \
+                         -DLZ4_BUILD_CLI=OFF"
 }

--- a/packages/compress/lzo/package.mk
+++ b/packages/compress/lzo/package.mk
@@ -14,7 +14,7 @@ PKG_LONGDESC="A data compression library which is suitable for data de-/compress
 PKG_BUILD_FLAGS="+pic"
 
 PKG_CMAKE_OPTS_HOST="-DENABLE_SHARED=OFF -DENABLE_STATIC=ON"
-PKG_CMAKE_OPTS_TARGET="-DENABLE_SHARED=OFF -DENABLE_STATIC=ON"
+PKG_CMAKE_OPTS_TARGET="-DENABLE_SHARED=ON -DENABLE_STATIC=OFF"
 
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/libexec

--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -10,12 +10,9 @@ PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://github.com/tukaani-project/xz/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="autotools:host gcc:host"
 PKG_LONGDESC="A free general-purpose data compression software with high compression ratio."
-PKG_BUILD_FLAGS="+pic -sysroot"
 PKG_TOOLCHAIN="configure"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static \
-                           --disable-shared \
-                           --disable-doc \
+PKG_CONFIGURE_OPTS_TARGET="--disable-doc \
                            --disable-lzmadec \
                            --disable-lzmainfo \
                            --disable-lzma-links \

--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -117,7 +117,6 @@ pre_configure_target() {
   export PYTHON_MODULES_INCLUDE="${TARGET_INCDIR}"
   export PYTHON_MODULES_LIB="${TARGET_LIBDIR}"
   export DISABLED_EXTENSIONS="${PKG_PY_DISABLED_MODULES}"
-  export PKG_CONFIG_PATH="$(get_install_dir xz)/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
 }
 
 post_makeinstall_target() {

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -17,6 +17,3 @@ PKG_LONGDESC="pvr.iptvsimple"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="xbmc.pvrclient"
-
-PKG_CMAKE_OPTS_TARGET="-DLZMA_INCLUDE_DIRS=$(get_install_dir xz)/usr/include \
-                       -DLZMA_LIBRARIES=$(get_install_dir xz)/usr/lib/liblzma.a"

--- a/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/vfs.libarchive/package.mk
@@ -16,6 +16,3 @@ PKG_LONGDESC="vfs.libarchive"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.vfs"
-
-PKG_CMAKE_OPTS_TARGET="-DLIBLZMA_INCLUDE_DIR=$(get_install_dir xz)/usr/include \
-                       -DLIBLZMA_LIBRARY=$(get_install_dir xz)/usr/lib/liblzma.a"


### PR DESCRIPTION
libarchive ships in the image, so build it and the compression libraries it
uses as shared rather than static.

xz was also marked -sysroot, which hid it from find_package(LibLZMA), so
libarchive was silently built without lzma support. Fixed, and the workarounds
for it are removed.
