### PR TITLE
Package updates

### DIFF
--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet8-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet8-runtime"
-PKG_VERSION="8.0.30"
+PKG_VERSION="8.0.31"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="827785571f027dd8bbc64603b93826a7274941fb24180ad6af6e5760cf3f67dc"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.30/aspnetcore-runtime-8.0.30-linux-arm64.tar.gz"
+    PKG_SHA256="e103ff30bb547983034d094410fbf7821ab307ac67633e8327d7e5812e565c96"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.31/aspnetcore-runtime-8.0.31-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="f1270b01b719b52e2274862ab1c7945886e14b7750eadb332cd27798636dc9ea"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.30/aspnetcore-runtime-8.0.30-linux-arm.tar.gz"
+    PKG_SHA256="629a3b1ec6c98685b002833162e57aa3f94bcecc5dfc75ea3f6fa642f83623ad"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.31/aspnetcore-runtime-8.0.31-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="3591ce9a61e635cee8c93630a5e0f338398cb19c5bd618a2f38f8f00e4a3c45e"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.30/aspnetcore-runtime-8.0.30-linux-x64.tar.gz"
+    PKG_SHA256="e69404ee842cdb128558e7975234f48f0abee32cc3adc3b2867d0ba38cf594b6"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.31/aspnetcore-runtime-8.0.31-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/dotnet-runtime-depends/aspnet9-runtime/package.mk
+++ b/packages/addons/addon-depends/dotnet-runtime-depends/aspnet9-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="aspnet9-runtime"
-PKG_VERSION="9.0.19"
+PKG_VERSION="9.0.20"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"
 PKG_DEPENDS_TARGET="toolchain"
@@ -11,16 +11,16 @@ PKG_TOOLCHAIN="manual"
 
 case "${ARCH}" in
   "aarch64")
-    PKG_SHA256="6d09f9462268e110bbaf4577eec61fa3df2b449c5d6f2d3b4eec7d669367a483"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.19/aspnetcore-runtime-9.0.19-linux-arm64.tar.gz"
+    PKG_SHA256="948f49d0f0ac3d67638f24a0c6d6ed1008eced27bfaf055b17a8dd5569f5b0d7"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.20/aspnetcore-runtime-9.0.20-linux-arm64.tar.gz"
     ;;
   "arm")
-    PKG_SHA256="3cf459678cf922a1fa018b9f5145f1451ff78dcc376c462dbdc76dbcdfc90825"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.19/aspnetcore-runtime-9.0.19-linux-arm.tar.gz"
+    PKG_SHA256="68ba01b0d41c065440bdc9a9f4793aefc459ab1022bf91d5af5cba9386241f8a"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.20/aspnetcore-runtime-9.0.20-linux-arm.tar.gz"
     ;;
   "x86_64")
-    PKG_SHA256="d949d01244ffd3bc0ab23602a4c186d5e961cae75961f0ed0e25b9e57e164b4f"
-    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.19/aspnetcore-runtime-9.0.19-linux-x64.tar.gz"
+    PKG_SHA256="2e7a60cb847b57fda9c4027fdf68afbc98dc318a8965661b06dd67a2e6a69c9d"
+    PKG_URL="https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.20/aspnetcore-runtime-9.0.20-linux-x64.tar.gz"
     ;;
 esac
 PKG_SOURCE_NAME="aspnetcore-runtime_${PKG_VERSION}_${ARCH}.tar.gz"

--- a/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
+++ b/packages/addons/addon-depends/jre-depends/apache-ant/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2020-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="apache-ant"
-PKG_VERSION="1.10.17"
-PKG_SHA256="9553018e2cd5368261c32b2163c802e00de0a1c9707c3cfdd4cf7d6821674b08"
+PKG_VERSION="1.10.18"
+PKG_SHA256="e03e4f4047b51ea0164dfdfa7827dce267b6e033bac1387241731ca037bda7b9"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://ant.apache.org/"
 PKG_URL="https://archive.apache.org/dist/ant/binaries/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz"

--- a/packages/addons/addon-depends/rsyslog-depends/liblognorm/package.mk
+++ b/packages/addons/addon-depends/rsyslog-depends/liblognorm/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="liblognorm"
-PKG_VERSION="2.1.0"
-PKG_SHA256="1f6c63d218a0a182b7758ce177033b604c2df30bbff80ea42b9bc032975e9ca9"
+PKG_VERSION="2.1.1"
+PKG_SHA256="295035a53e9420d0413d9e4025344140d577d12bb64a306f6b3714370501c4e8"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://www.liblognorm.com"
 PKG_URL="https://github.com/rsyslog/liblognorm/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/addons/service/minisatip/package.mk
+++ b/packages/addons/service/minisatip/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="minisatip"
-PKG_VERSION="2.0.100"
-PKG_SHA256="7bcecbd62499749b83b55e7cc3ca476594c03731580ab1ad4136bff0a12b8e72"
-PKG_REV="13"
+PKG_VERSION="2.0.102"
+PKG_SHA256="a23d69215eba4f9b3ec5e65b22f2a364d5fc2ab071af32e90a413b595f91a1bf"
+PKG_REV="14"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/catalinii/minisatip"

--- a/packages/addons/service/syncthing/package.mk
+++ b/packages/addons/service/syncthing/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="syncthing"
-PKG_VERSION="2.1.3"
-PKG_SHA256="f34bc1b3219e02ac1eca0b1446f582af8fe13f789da5f8c679ba9cac0396bf81"
-PKG_REV="4"
+PKG_VERSION="2.1.5"
+PKG_SHA256="11f129cff64fb4ba7cda33f9dae3a39eab8738a60bbbe8813cadecfdc94bd13d"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="https://syncthing.net/"

--- a/packages/addons/tools/dotnet-runtime/package.mk
+++ b/packages/addons/tools/dotnet-runtime/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="dotnet-runtime"
-PKG_REV="4"
+PKG_REV="5"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://dotnet.microsoft.com/"

--- a/packages/compress/xz/package.mk
+++ b/packages/compress/xz/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="xz"
-PKG_VERSION="5.8.3"
-PKG_SHA256="fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
+PKG_VERSION="5.8.4"
+PKG_SHA256="4ce24038fd4221e0d13bc1a2de7a4db56e90b92b3bf75321f6c14be73f65de4b"
 PKG_LICENSE="0BSD"
 PKG_SITE="https://tukaani.org/xz/"
 PKG_URL="https://github.com/tukaani-project/xz/releases/download/v${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="glib"
-PKG_VERSION="2.89.4"
-PKG_SHA256="1cdbb799f558832e6f14b8337b5fd599c6918ab144977b55e05e00a5e2e84a2c"
+PKG_VERSION="2.90.0"
+PKG_SHA256="17d15cac2af80a33271127408e0abc2748eb297c595c2a26409e81e14e7d1b8f"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://www.gtk.org/"
 PKG_URL="https://download.gnome.org/sources/glib/$(get_pkg_version_maj_min)/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/libcap-ng/package.mk
+++ b/packages/devel/libcap-ng/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2023-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libcap-ng"
-PKG_VERSION="0.9.5"
-PKG_SHA256="a2b4211f59b231d607c61ea2a13e9ecb38f446fe769b44e12da939d5af6d978a"
+PKG_VERSION="0.9.6"
+PKG_SHA256="399040138e0ca62fa2bcabd63da9af4431a246ef7a654561a0ca3cb00010a539"
 PKG_LICENSE="LGPL-2.1-or-later"
 PKG_SITE="https://github.com/stevegrubb/libcap-ng"
 PKG_URL="https://github.com/stevegrubb/libcap-ng/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/graphics/libheif/package.mk
+++ b/packages/graphics/libheif/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libheif"
-PKG_VERSION="1.23.3"
-PKG_SHA256="11c1179e0e4bec33624b87f22ec42c1e993a40d946d44d26f9c431cf1456a863"
+PKG_VERSION="1.23.4"
+PKG_SHA256="d0c02b4b0e978f34a1974b6f3eea7975a537bf7a9195ffeea38e7242ff316fdd"
 PKG_LICENSE="LGPL-3.0-or-later"
 PKG_SITE="https://www.libde265.org"
 PKG_URL="https://github.com/strukturag/libheif/releases/download/v${PKG_VERSION}/libheif-${PKG_VERSION}.tar.gz"

--- a/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/imagedecoder.heif/package.mk
@@ -4,7 +4,7 @@
 PKG_NAME="imagedecoder.heif"
 PKG_VERSION="22.1.0-Piers"
 PKG_SHA256="ca62ee5b550af7cf24869ad28dc923ef72c515641f18d10f244b0e2205c27e5b"
-PKG_REV="2"
+PKG_REV="3"
 PKG_ARCH="any"
 PKG_LICENSE="GPL-2.0-or-later"
 PKG_SITE="https://github.com/xbmc/imagedecoder.heif"

--- a/packages/rust/bindgen-cli/package.mk
+++ b/packages/rust/bindgen-cli/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bindgen-cli"
-PKG_VERSION="0.73.1"
-PKG_SHA256="11d72970909c7b333eb6685054e7bbd36fd8892eab40ce3a93da06f066ed983d"
+PKG_VERSION="0.73.2"
+PKG_SHA256="5fc3277dd334e4bbbd7bdb8cad5d4fb87a667b2e95a2bae350a8d5424c280629"
 PKG_LICENSE="BSD-3-Clause"
 PKG_SITE="https://rust-lang.github.io/rust-bindgen/"
 PKG_URL="https://github.com/rust-lang/rust-bindgen/archive/v${PKG_VERSION}.tar.gz"

--- a/packages/security/nss/package.mk
+++ b/packages/security/nss/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="nss"
-PKG_VERSION="3.128"
-PKG_SHA256="bfd84218ee9b0b24775723eb62bdf4590bf21a3818e8210d37de0b2c2db79750"
+PKG_VERSION="3.129"
+PKG_SHA256="d389064d5e5ef09d597f8ae8dadc066f71e97b982bd7418b835686425fc3a189"
 PKG_LICENSE="MPL-2.0"
 PKG_SITE="http://ftp.mozilla.org/"
 PKG_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_${PKG_VERSION//./_}_RTM/src/nss-${PKG_VERSION}-with-nspr-$(get_pkg_version nspr).tar.gz"

--- a/packages/sysutils/fuse3/package.mk
+++ b/packages/sysutils/fuse3/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="fuse3"
-PKG_VERSION="3.18.2"
-PKG_SHA256="f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298"
+PKG_VERSION="3.18.3"
+PKG_SHA256="bcd19582c5e30f7fe45dd86a5540e998590aa01903afc7ebcbeea6c8ac5421ee"
 PKG_LICENSE="LGPL-2.1-only"
 PKG_SITE="https://github.com/libfuse/libfuse/"
 PKG_URL="https://github.com/libfuse/libfuse/releases/download/fuse-${PKG_VERSION}/fuse-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
- minisatip: update to 2.0.102 and addon (14)
- syncthing: update to 2.1.5 and addon (5)
- xz: update to 5.8.4
- nss: update to 3.129
- liblognorm: update to 2.1.1
- libcap-ng: update to 0.9.6
- glib: update to 2.90.0
- fuse3: update to 3.18.3
- bindgen-cli: update to 0.73.2
- dotnet-runtime: update to 8.0.31 and 9.0.20 and addon (5)
  - aspnet9-runtime: update to 9.0.20
  - aspnet8-runtime: update to 8.0.31
- apache-ant: update to 1.10.18
- imagedecoder.heif: update libheif to 1.23.4 and addon (3)
  - libheif: update to 1.23.4